### PR TITLE
Add .editorconfig fix #22.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,21 +16,31 @@ charset = utf-8
 [*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml}]
 indent_size = 2
 
-
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
 
 [*]
 # https://github.com/nunit/docs/wiki/Coding-Standards#namespace-class-structure-interface-enumeration-and-method-definitions
-csharp_indent_braces = false
-csharp_new_line_before_catch = true
+csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_within_query_expression_clauses = true
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#spaces
 csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_after_comma = true
+csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
 csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
 csharp_space_before_open_square_brackets = false
 csharp_space_before_semicolon_in_for_statement = false
 csharp_space_between_empty_square_brackets = false
@@ -40,17 +50,40 @@ csharp_space_between_method_call_parameter_list_parentheses = false
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = none
+csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#indentation
 csharp_indent_block_contents = true
+csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Always use "this." and "Me." when applicable; let StyleCop Analyzers provide the warning and fix
+dotnet_style_qualification_for_field = true:suggestion
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = true:suggestion
+dotnet_style_qualification_for_event = true:suggestion
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#naming
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Prefer "var" only where type is obvious; disable diagnostics since no firm policy is in place yet
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:none
+dotnet_style_collection_initializer = true:none
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#file-organization
+dotnet_sort_system_directives_first = true
 
 # The first matching rule wins, more specific rules at the top
 
@@ -58,28 +91,20 @@ dotnet_style_predefined_type_for_member_access = true:suggestion
 # dotnet_naming_symbols.*.applicable_kinds does not yet support namespace, type_parameter or local https://github.com/dotnet/roslyn/issues/18121
 
 dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
 
 dotnet_naming_symbols.namespaces_types_and_non_field_members.applicable_kinds = namespace, class, struct, enum, interface, delegate, type_parameter, method, property, event
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+
 dotnet_naming_rule.namespaces_types_and_non_field_members.severity = suggestion
 dotnet_naming_rule.namespaces_types_and_non_field_members.symbols = namespaces_types_and_non_field_members
 dotnet_naming_rule.namespaces_types_and_non_field_members.style = pascal_case
-
-dotnet_naming_symbols.public_fields.applicable_kinds = field
-dotnet_naming_symbols.public_fields.applicable_accessibilities = public
 dotnet_naming_rule.public_fields.severity = suggestion
 dotnet_naming_rule.public_fields.symbols = public_fields
 dotnet_naming_rule.public_fields.style = pascal_case
-
-dotnet_naming_style.camel_case.capitalization = camel_case
-
-dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
 dotnet_naming_rule.parameters_and_locals.severity = suggestion
 dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
 dotnet_naming_rule.parameters_and_locals.style = camel_case
 
-# https://github.com/nunit/docs/wiki/Coding-Standards#file-organization
-dotnet_sort_system_directives_first = true
-
-# https://github.com/nunit/docs/wiki/Coding-Standards#use-of-the-var-keyword
-# Would be true:warning, except that that so much existing code is not consistent with the coding standard.
-csharp_style_var_when_type_is_apparent = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,85 @@
+# EditorConfig helps developers define and
+# maintain consistent coding styles between
+# different editors and IDEs
+
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+charset = utf-8
+
+[*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml}]
+indent_size = 2
+
+
+
+[*]
+# https://github.com/nunit/docs/wiki/Coding-Standards#namespace-class-structure-interface-enumeration-and-method-definitions
+csharp_indent_braces = false
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#spaces
+csharp_space_after_cast = false
+csharp_space_after_comma = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = none
+csharp_space_between_square_brackets = false
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#indentation
+csharp_indent_block_contents = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#naming
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# The first matching rule wins, more specific rules at the top
+
+# dotnet_naming_rule.*.symbols does not yet support a comma-separated list https://github.com/dotnet/roslyn/issues/20891
+# dotnet_naming_symbols.*.applicable_kinds does not yet support namespace, type_parameter or local https://github.com/dotnet/roslyn/issues/18121
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_symbols.namespaces_types_and_non_field_members.applicable_kinds = namespace, class, struct, enum, interface, delegate, type_parameter, method, property, event
+dotnet_naming_rule.namespaces_types_and_non_field_members.severity = suggestion
+dotnet_naming_rule.namespaces_types_and_non_field_members.symbols = namespaces_types_and_non_field_members
+dotnet_naming_rule.namespaces_types_and_non_field_members.style = pascal_case
+
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public
+dotnet_naming_rule.public_fields.severity = suggestion
+dotnet_naming_rule.public_fields.symbols = public_fields
+dotnet_naming_rule.public_fields.style = pascal_case
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+dotnet_naming_rule.parameters_and_locals.severity = suggestion
+dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
+dotnet_naming_rule.parameters_and_locals.style = camel_case
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#file-organization
+dotnet_sort_system_directives_first = true
+
+# https://github.com/nunit/docs/wiki/Coding-Standards#use-of-the-var-keyword
+# Would be true:warning, except that that so much existing code is not consistent with the coding standard.
+csharp_style_var_when_type_is_apparent = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,9 +16,6 @@ charset = utf-8
 [*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml}]
 indent_size = 2
 
-# Sort using and Import directives with System.* appearing first
-dotnet_sort_system_directives_first = true
-
 [*]
 # https://github.com/nunit/docs/wiki/Coding-Standards#namespace-class-structure-interface-enumeration-and-method-definitions
 csharp_new_line_before_open_brace = all
@@ -27,7 +24,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_within_query_expression_clauses = true
+csharp_new_line_between_query_expression_clauses = true
 
 # https://github.com/nunit/docs/wiki/Coding-Standards#spaces
 csharp_space_after_cast = false


### PR DESCRIPTION
A couple of defaults, indent_style = tab makes Visual Studio pick up that this sln uses tabs.

Personally I prefer:
indent_style = space
indent_size = 4

But convention >> preference.
Reason I prefer spaces is that it renders nicer when reading code on github in the browser.