### PR TITLE
Remove dependency on NUnit in the analyzer project

### DIFF
--- a/src/nunit.analyzers.tests/Constants/NunitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NunitFrameworkConstantsTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Analyzers.Constants;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Analyzers.Tests.Constants
+{
+    /// <summary>
+    /// Tests to ensure that the string constants in the analyzer project correspond
+    /// to the NUnit concepts that they represent.
+    /// </summary>
+    [TestFixture]
+    public sealed class NunitFrameworkConstantsTests
+    {
+        [TestCase(NunitFrameworkConstants.NameOfEqualConstraintWithin, nameof(EqualConstraint.Within))]
+        [TestCase(NunitFrameworkConstants.NameOfIs, nameof(Is))]
+        [TestCase(NunitFrameworkConstants.NameOfIsFalse, nameof(Is.False))]
+        [TestCase(NunitFrameworkConstants.NameOfIsTrue, nameof(Is.True))]
+        [TestCase(NunitFrameworkConstants.NameOfIsEqualTo, nameof(Is.EqualTo))]
+        [TestCase(NunitFrameworkConstants.NameOfIsNot, nameof(Is.Not))]
+        [TestCase(NunitFrameworkConstants.NameOfIsNotEqualTo, nameof(Is.Not.EqualTo))]
+        [TestCase(NunitFrameworkConstants.NameOfAssert, nameof(Assert))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertIsTrue, nameof(Assert.IsTrue))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertTrue, nameof(Assert.True))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertIsFalse, nameof(Assert.IsFalse))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertFalse, nameof(Assert.False))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertAreEqual, nameof(Assert.AreEqual))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertAreNotEqual, nameof(Assert.AreNotEqual))]
+        [TestCase(NunitFrameworkConstants.NameOfAssertThat, nameof(Assert.That))]
+        [TestCase(NunitFrameworkConstants.NameOfTestCaseAttribute, nameof(TestCaseAttribute))]
+        [TestCase(NunitFrameworkConstants.NameOfTestCaseAttributeExpectedResult, nameof(TestCaseAttribute.ExpectedResult))]
+        public void TestConstant(string constant, string nameOfArgument)
+        {
+            Assert.That(constant, Is.EqualTo(nameOfArgument));
+        }
+
+        [Test]
+        public void FullNameOfTypeTestCaseAttributeTest()
+        {
+            Assert.That(
+                NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute,
+                Is.EqualTo(typeof(TestCaseAttribute).FullName));
+        }
+
+        [Test]
+        public void AssemblyQualifiedNameOfTypeAssertTest()
+        {
+            Assert.That(
+                NunitFrameworkConstants.AssemblyQualifiedNameOfTypeAssert,
+                Is.EqualTo(typeof(Assert).AssemblyQualifiedName));
+        }
+    }
+}

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
@@ -3,8 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Framework;
-using NUnit.Framework.Constraints;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -25,8 +23,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 			var equalToInvocationNode = SyntaxFactory.InvocationExpression(
 				SyntaxFactory.MemberAccessExpression(
 					SyntaxKind.SimpleMemberAccessExpression,
-					SyntaxFactory.IdentifierName(nameof(Is)),
-					SyntaxFactory.IdentifierName(nameof(Is.EqualTo))))
+					SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIs),
+					SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIsEqualTo)))
 				.WithArgumentList(SyntaxFactory.ArgumentList(
 					SyntaxFactory.SingletonSeparatedList(arguments[0])));
 
@@ -38,7 +36,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 					SyntaxFactory.MemberAccessExpression(
 						SyntaxKind.SimpleMemberAccessExpression,
 						equalToInvocationNode,
-						SyntaxFactory.IdentifierName(nameof(EqualConstraint.Within))))
+						SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfEqualConstraintWithin)))
 					.WithArgumentList(SyntaxFactory.ArgumentList(
 						SyntaxFactory.SingletonSeparatedList(arguments[2])));
 			}

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFix.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -25,9 +24,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 						SyntaxKind.SimpleMemberAccessExpression,
 						SyntaxFactory.MemberAccessExpression(
 							SyntaxKind.SimpleMemberAccessExpression,
-							SyntaxFactory.IdentifierName(nameof(Is)),
-							SyntaxFactory.IdentifierName(nameof(Is.Not))),
-						SyntaxFactory.IdentifierName(nameof(Is.Not.EqualTo))))
+							SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIs),
+							SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIsNot)),
+						SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIsNotEqualTo)))
 					.WithArgumentList(SyntaxFactory.ArgumentList(
 						SyntaxFactory.SingletonSeparatedList(arguments[0])))));
 

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -3,11 +3,11 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using static NUnit.Analyzers.Extensions.ITypeSymbolExtensions;
+using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
 
 namespace NUnit.Analyzers.ClassicModelAssertUsage
 {
@@ -18,12 +18,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 		private static readonly ImmutableDictionary<string, DiagnosticDescriptor> Names =
 			new Dictionary<string, DiagnosticDescriptor>
 			{
-				{ nameof(Assert.IsTrue), ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.IsTrueUsage) },
-				{ nameof(Assert.True), ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.TrueUsage) },
-				{ nameof(Assert.IsFalse), ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.IsFalseUsage) },
-				{ nameof(Assert.False), ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.FalseUsage) },
-				{ nameof(Assert.AreEqual), ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.AreEqualUsage) },
-				{ nameof(Assert.AreNotEqual), ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.AreNotEqualUsage) }
+				{ NameOfAssertIsTrue, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.IsTrueUsage) },
+				{ NameOfAssertTrue, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.TrueUsage) },
+				{ NameOfAssertIsFalse, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.IsFalseUsage) },
+				{ NameOfAssertFalse, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.FalseUsage) },
+				{ NameOfAssertAreEqual, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.AreEqualUsage) },
+				{ NameOfAssertAreNotEqual, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.AreNotEqualUsage) }
 			}.ToImmutableDictionary();
 
 		private static DiagnosticDescriptor CreateDescriptor(string identifier) =>
@@ -68,7 +68,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 				{
 					{ AnalyzerPropertyKeys.ModelName, invocationSymbol.Name },
 					{ AnalyzerPropertyKeys.HasToleranceValue,
-						(invocationSymbol.Name == nameof(Assert.AreEqual) &&
+						(invocationSymbol.Name == NameOfAssertAreEqual &&
 							invocationSymbol.Parameters.Length >= 3 &&
 							invocationSymbol.Parameters[2].Type.SpecialType == SpecialType.System_Double).ToString() }
 				}.ToImmutableDictionary();

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -36,7 +35,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 				invocationNode.DescendantNodes(_ => true).Where(_ => 
 					_.IsKind(SyntaxKind.IdentifierName) && 
 					(_ as IdentifierNameSyntax).Identifier.Text == invocationIdentifier).Single(),
-				SyntaxFactory.IdentifierName(nameof(Assert.That)));
+				SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfAssertThat));
 
 			// Now, replace the arguments.
 			var arguments = invocationNode.ArgumentList.Arguments.ToList();

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -24,8 +23,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 			arguments.Insert(1, SyntaxFactory.Argument(
 				SyntaxFactory.MemberAccessExpression(
 					SyntaxKind.SimpleMemberAccessExpression,
-					SyntaxFactory.IdentifierName(nameof(Is)),
-					SyntaxFactory.IdentifierName(nameof(Is.False)))));
+					SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIs),
+					SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIsFalse))));
 		}
 	}
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -24,8 +23,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 			arguments.Insert(1, SyntaxFactory.Argument(
 				SyntaxFactory.MemberAccessExpression(
 					SyntaxKind.SimpleMemberAccessExpression,
-					SyntaxFactory.IdentifierName(nameof(Is)),
-					SyntaxFactory.IdentifierName(nameof(Is.True)))));
+					SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIs),
+					SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIsTrue))));
 		}
 	}
 }

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -1,0 +1,35 @@
+namespace NUnit.Analyzers.Constants
+{
+    /// <summary>
+    /// String constants for relevant NUnit concepts (classes, fields, properties etc.)
+    /// so that we do not need have a dependency on NUnit from the analyzer project.
+    /// </summary>
+    public static class NunitFrameworkConstants
+    {
+        public const string NameOfEqualConstraintWithin = "Within";
+
+        public const string NameOfIs = "Is";
+        public const string NameOfIsFalse = "False";
+        public const string NameOfIsTrue = "True";
+        public const string NameOfIsEqualTo = "EqualTo";
+        public const string NameOfIsNot = "Not";
+        public const string NameOfIsNotEqualTo = "EqualTo";
+
+        public const string NameOfAssert = "Assert";
+        public const string NameOfAssertIsTrue = "IsTrue";
+        public const string NameOfAssertTrue = "True";
+        public const string NameOfAssertIsFalse = "IsFalse";
+        public const string NameOfAssertFalse = "False";
+        public const string NameOfAssertAreEqual = "AreEqual";
+        public const string NameOfAssertAreNotEqual = "AreNotEqual";
+        public const string NameOfAssertThat = "That";
+
+        public const string FullNameOfTypeTestCaseAttribute = "NUnit.Framework.TestCaseAttribute";
+
+        public const string NameOfTestCaseAttribute = "TestCaseAttribute";
+        public const string NameOfTestCaseAttributeExpectedResult = "ExpectedResult";
+
+        public const string AssemblyQualifiedNameOfTypeAssert =
+            "NUnit.Framework.Assert, nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb";
+    }
+}

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using NUnit.Framework;
+using Microsoft.CodeAnalysis;
 using System.Linq;
+using NUnit.Analyzers.Constants;
 
 namespace NUnit.Analyzers.Extensions
 {
@@ -18,8 +18,8 @@ namespace NUnit.Analyzers.Extensions
         internal static bool IsAssert(this ITypeSymbol @this)
 		{
 			return @this != null &&
-				typeof(Assert).AssemblyQualifiedName.Contains(@this.ContainingAssembly.Name) &&
-				@this.Name == nameof(Assert);
+				NunitFrameworkConstants.AssemblyQualifiedNameOfTypeAssert.Contains(@this.ContainingAssembly.Name) &&
+				@this.Name == NunitFrameworkConstants.NameOfAssert;
 		}
 	}
 }

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
-using NUnit.Framework;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -48,10 +47,10 @@ namespace NUnit.Analyzers.TestCaseUsage
 				{
 					var attributeNode = (AttributeSyntax)context.Node;
 					var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
-					var testCaseType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(TestCaseAttribute).FullName);
+					var testCaseType = context.SemanticModel.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
 
 					if (testCaseType.ContainingAssembly.Identity == attributeSymbol?.ContainingAssembly.Identity && 
-						nameof(TestCaseAttribute) == attributeSymbol?.ContainingType.Name)
+						NunitFrameworkConstants.NameOfTestCaseAttribute == attributeSymbol?.ContainingType.Name)
 					{
 						context.CancellationToken.ThrowIfCancellationRequested();
 
@@ -100,7 +99,7 @@ namespace NUnit.Analyzers.TestCaseUsage
 			var model = context.SemanticModel;
 
 			var expectedResultNamedArgument = attributeNamedArguments.SingleOrDefault(
-				_ => _.DescendantTokens().Any(__ => __.Text == nameof(TestCaseAttribute.ExpectedResult)));
+				_ => _.DescendantTokens().Any(__ => __.Text == NunitFrameworkConstants.NameOfTestCaseAttributeExpectedResult));
 
 			if (expectedResultNamedArgument != null)
 			{

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.1" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
   </ItemGroup>
 
   <Target Name="AfterBuild">


### PR DESCRIPTION
The correspondence between string constants in the analyzer
project and concepts in NUnit is kept well defined by tests.

The constant `AssemblyQualifiedNameOfTypeAssert` is a bit
ugly, so the code that makes use of this will be refactored
in a later commit.

Fixes #21