### PR TITLE
Remove unnecessary extraction of attribute argument value

### DIFF
--- a/src/nunit.analyzers.tests/Targets/TestCaseUsage/TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsACast.cs
+++ b/src/nunit.analyzers.tests/Targets/TestCaseUsage/TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsACast.cs
@@ -1,0 +1,10 @@
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Targets.TestCaseUsage
+{
+    class TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsACast
+    {
+        [TestCase((byte)2)]
+        public void Test(byte a) { }
+    }
+}

--- a/src/nunit.analyzers.tests/Targets/TestCaseUsage/TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAPrefixedValue.cs
+++ b/src/nunit.analyzers.tests/Targets/TestCaseUsage/TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAPrefixedValue.cs
@@ -1,0 +1,10 @@
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Targets.TestCaseUsage
+{
+    class TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAPrefixedValue
+    {
+        [TestCase(-2)]
+        public void Test(int a) { }
+    }
+}

--- a/src/nunit.analyzers.tests/Targets/TestCaseUsage/TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAReferenceToConstant.cs
+++ b/src/nunit.analyzers.tests/Targets/TestCaseUsage/TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAReferenceToConstant.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Targets.TestCaseUsage
+{
+    class TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAReferenceToConstant
+    {
+        const int value = 42;
+
+        [TestCase(value)]
+        public void Test(int a) { }
+    }
+}

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -83,6 +83,30 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         }
 
         [Test]
+        public async Task AnalyzeWhenArgumentIsACast()
+        {
+            await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
+                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsACast))}.cs",
+                Array.Empty<string>());
+        }
+
+        [Test]
+        public async Task AnalyzeWhenArgumentIsAPrefixedValue()
+        {
+            await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
+                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsAPrefixedValue))}.cs",
+                Array.Empty<string>());
+        }
+
+        [Test]
+        public async Task AnalyzeWhenArgumentIsAReferenceToConstant()
+        {
+            await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
+                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsAReferenceToConstant))}.cs",
+                Array.Empty<string>());
+        }
+
+        [Test]
         public async Task AnalyzeWhenArgumentTypeIsIncorrect()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -66,6 +66,9 @@
     <Compile Remove="Targets\Extensions\ITypeSymbolExtensionsTestsIsAssignableFromWhenOtherIsNull.cs" />
     <Compile Remove="Targets\Extensions\ITypeSymbolExtensionsTestsIsAssignableFromWhenOtherIsSameTypeAsThis.cs" />
     <Compile Remove="Targets\Extensions\ITypeSymbolExtensionsTestsIsAssignableFromWhenThisIsNull.cs" />
+    <Compile Remove="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsACast.cs" />
+    <Compile Remove="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAPrefixedValue.cs" />
+    <Compile Remove="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAReferenceToConstant.cs" />
     <Compile Remove="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsCorrect.cs" />
     <Compile Remove="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentPassesNullToNullableType.cs" />
     <Compile Remove="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentPassesNullToValueType.cs" />
@@ -262,6 +265,15 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Targets\Extensions\ITypeSymbolExtensionsTestsIsAssignableFromWhenThisIsNull.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsACast.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAPrefixedValue.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsAReferenceToConstant.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Targets\TestCaseUsage\TestCaseUsageAnalyzerTestsAnalyzeWhenArgumentIsCorrect.cs">

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -158,12 +158,11 @@ namespace NUnit.Analyzers.TestCaseUsage
             for (var i = 0; i < attributePositionalArguments.Length; i++)
             {
                 var attributeArgument = attributePositionalArguments[i];
-                var attributeValue = (attributeArgument.Expression as LiteralExpressionSyntax).Token.Value;
                 var methodParametersSymbol = TestCaseUsageAnalyzer.GetParameterType(methodParameters, i);
                 var methodParameterType = methodParametersSymbol.Item1;
                 var methodParameterName = methodParametersSymbol.Item2;
 
-                if (!attributeArgument.CanAssignTo(methodParameterType, context.SemanticModel))
+                if (!attributeArgument.CanAssignTo(methodParameterType, model))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                       TestCaseUsageAnalyzer.CreateDescriptor(


### PR DESCRIPTION
The value was not used and only worked for literal expressions.

Fixes #11