### PR TITLE
[WIP] Refactor tests tryout

### DIFF
--- a/src/nunit.analyzers.tests/Extensions/AttributeArgumentSyntaxExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/AttributeArgumentSyntaxExtensionsTests.cs
@@ -233,8 +233,8 @@ namespace NUnit.Analyzers.Tests.Extensions
         public async Task CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable()
         {
             // option 2
-            var values = await GetAttributeSyntaxAsync<CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable>();
-            Assert.That(values.Syntax.CanAssignTo(values.Symbol, values.Model), Is.False);
+            var (syntax, symbol, model) = await GetAttributeSyntaxAsync<CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable>();
+            Assert.That(syntax.CanAssignTo(symbol, model), Is.False);
         }
 
         private static string GetTestFileName<T>()

--- a/src/nunit.analyzers.tests/Targets/Extensions/AttributeArgumentSyntaxExtensionsTests/CanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable.cs
+++ b/src/nunit.analyzers.tests/Targets/Extensions/AttributeArgumentSyntaxExtensionsTests/CanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable.cs
@@ -3,10 +3,10 @@ using System;
 
 namespace NUnit.Analyzers.Tests.Targets.Extensions
 {
-    public sealed class AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable
+    public sealed class CanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable
     {
         [Arguments(new[] { "a", "b", "c" })]
-        public void Foo(int[] inputs) { }
+        public void Foo(string[] inputs) { }
 
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
         public sealed class ArgumentsAttribute

--- a/src/nunit.analyzers.tests/Targets/Extensions/AttributeArgumentSyntaxExtensionsTests/CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable.cs
+++ b/src/nunit.analyzers.tests/Targets/Extensions/AttributeArgumentSyntaxExtensionsTests/CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable.cs
@@ -3,10 +3,10 @@ using System;
 
 namespace NUnit.Analyzers.Tests.Targets.Extensions
 {
-    public sealed class AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable
+    public sealed class CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable
     {
         [Arguments(new[] { "a", "b", "c" })]
-        public void Foo(string[] inputs) { }
+        public void Foo(int[] inputs) { }
 
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
         public sealed class ArgumentsAttribute

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -34,8 +34,6 @@
     <Compile Remove="Targets\ClassicModelAssertUsage\IsTrueAndTrueClassicModelAssertUsageCodeFixTestsVerifyGetFixes.cs" />
     <Compile Remove="Targets\ClassicModelAssertUsage\IsTrueAndTrueClassicModelAssertUsageCodeFixTestsVerifyGetFixesWithMessage.cs" />
     <Compile Remove="Targets\ClassicModelAssertUsage\IsTrueAndTrueClassicModelAssertUsageCodeFixTestsVerifyGetFixesWithMessageAndParams.cs" />
-    <Compile Remove="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable.cs" />
-    <Compile Remove="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable.cs" />
     <Compile Remove="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsNotAssignable.cs" />
     <Compile Remove="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsNotNullableAndAssignable.cs" />
     <Compile Remove="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsNullableAndAssignable.cs" />
@@ -57,6 +55,8 @@
     <Compile Remove="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenParameterIsTimeSpanAndArgumentIsValidString.cs" />
     <Compile Remove="Targets\Extensions\AttributeSyntaxExtensionsTestsGetArguments.cs" />
     <Compile Remove="Targets\Extensions\AttributeSyntaxExtensionsTestsGetArgumentsWhenNoneExist.cs" />
+    <Compile Remove="Targets\Extensions\CanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable.cs" />
+    <Compile Remove="Targets\Extensions\CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable.cs" />
     <Compile Remove="Targets\Extensions\IMethodSymbolExtensionsTestsGetParameterCounts.cs" />
     <Compile Remove="Targets\Extensions\ITypeSymbolExtensionsTestsIsAssertWhenSymbolIsAssertType.cs" />
     <Compile Remove="Targets\Extensions\ITypeSymbolExtensionsTestsIsAssertWhenSymbolIsInNUnitAssemblyAndNotAssertType.cs" />
@@ -175,10 +175,10 @@
     <None Include="Targets\ClassicModelAssertUsage\IsTrueAndTrueClassicModelAssertUsageCodeFixTestsVerifyGetFixesWithMessageAndParams.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable.cs">
+    <None Include="Targets\Extensions\AttributeArgumentSyntaxExtensionsTests\CanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable.cs">
+    <None Include="Targets\Extensions\AttributeArgumentSyntaxExtensionsTests\CanAssignToWhenArgumentIsImplicitlyTypedArrayAndNotAssignable.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Targets\Extensions\AttributeArgumentSyntaxExtensionsTestsCanAssignToWhenArgumentIsNotAssignable.cs">


### PR DESCRIPTION
This is a tryout to continue the discussion in #70, with some more concrete examples.

These are 2 directions we could go now, to improve the readability of the tests.

What I have done:

- moved the testcase to a folder and made the name shorter
- created a helper to get the filename from a generic (so it's easy to move from test to testcase and visa versa)
- created 2 options we could go to (or a mix of course)
   1. option 1 is a small change compared to the current testcode
   2. option 2 refactors also the helpers and so less duplicate testcode is needed. Also using C#7 tuples makes stuff easier to read

note: this assumes that the class name and the filename are the same. I think that's even best practice.