### PR TITLE
Give all analyzers unique identifiers

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -1,9 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.TestCaseUsage;
 using NUnit.Framework;
@@ -13,7 +13,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     [TestFixture]
     public sealed class TestCaseUsageAnalyzerTests
     {
-        private static readonly string BasePath =
+        private static readonly string basePath =
             $@"{TestContext.CurrentContext.TestDirectory}\Targets\TestCaseUsage\{nameof(TestCaseUsageAnalyzerTests)}";
 
         [Test]
@@ -22,12 +22,16 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
             var analyzer = new TestCaseUsageAnalyzer();
             var diagnostics = analyzer.SupportedDiagnostics;
 
-            Assert.That(diagnostics.Length, Is.EqualTo(3), nameof(DiagnosticAnalyzer.SupportedDiagnostics));
+            var expectedIdentifiers = new List<string>
+            {
+                AnalyzerIdentifiers.TestCaseNotEnoughArgumentsUsage,
+                AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
+                AnalyzerIdentifiers.TestCaseTooManyArgumentsUsage
+            };
+            CollectionAssert.AreEquivalent(expectedIdentifiers, diagnostics.Select(d => d.Id));
 
             foreach (var diagnostic in diagnostics)
             {
-                Assert.That(diagnostic.Id, Is.EqualTo(AnalyzerIdentifiers.TestCaseUsage),
-                    $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Id)}");
                 Assert.That(diagnostic.Title.ToString(), Is.EqualTo(TestCaseUsageAnalyzerConstants.Title),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
                 Assert.That(diagnostic.Category, Is.EqualTo(Categories.Usage),
@@ -50,7 +54,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenAttributeIsNotInNUnit()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenAttributeIsNotInNUnit))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenAttributeIsNotInNUnit))}.cs",
                 Array.Empty<string>());
         }
 
@@ -58,7 +62,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenAttributeIsTestAttribute()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenAttributeIsTestAttribute))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenAttributeIsTestAttribute))}.cs",
                 Array.Empty<string>());
         }
 
@@ -66,7 +70,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenAttributeHasNoArguments()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenAttributeHasNoArguments))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenAttributeHasNoArguments))}.cs",
                 Array.Empty<string>());
         }
 
@@ -74,7 +78,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentIsCorrect()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsCorrect))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentIsCorrect))}.cs",
                 Array.Empty<string>());
         }
 
@@ -82,7 +86,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentIsACast()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsACast))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentIsACast))}.cs",
                 Array.Empty<string>());
         }
 
@@ -90,7 +94,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentIsAPrefixedValue()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsAPrefixedValue))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentIsAPrefixedValue))}.cs",
                 Array.Empty<string>());
         }
 
@@ -98,7 +102,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentIsAReferenceToConstant()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentIsAReferenceToConstant))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentIsAReferenceToConstant))}.cs",
                 Array.Empty<string>());
         }
 
@@ -106,8 +110,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentTypeIsIncorrect()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentTypeIsIncorrect))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentTypeIsIncorrect))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -121,8 +125,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentPassesNullToValueType()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentPassesNullToValueType))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentPassesNullToValueType))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -136,7 +140,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentPassesNullToNullableType()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentPassesNullToNullableType))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentPassesNullToNullableType))}.cs",
                 Array.Empty<string>());
         }
 
@@ -144,7 +148,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenArgumentPassesValueToNullableType()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenArgumentPassesValueToNullableType))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenArgumentPassesValueToNullableType))}.cs",
                 Array.Empty<string>());
         }
 
@@ -152,8 +156,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenNotEnoughRequiredArgumentsAreProvided()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenNotEnoughRequiredArgumentsAreProvided))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenNotEnoughRequiredArgumentsAreProvided))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseNotEnoughArgumentsUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -166,8 +170,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenTooManyRequiredArgumentsAreProvided()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenTooManyRequiredArgumentsAreProvided))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenTooManyRequiredArgumentsAreProvided))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseTooManyArgumentsUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -180,8 +184,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenTooManyRequiredAndOptionalArgumentsAreProvided()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenTooManyRequiredAndOptionalArgumentsAreProvided))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenTooManyRequiredAndOptionalArgumentsAreProvided))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseTooManyArgumentsUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -194,7 +198,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenMethodHasRequiredAndParamsAndMoreArgumentsThanParametersAreProvided()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenMethodHasRequiredAndParamsAndMoreArgumentsThanParametersAreProvided))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenMethodHasRequiredAndParamsAndMoreArgumentsThanParametersAreProvided))}.cs",
                 Array.Empty<string>());
         }
 
@@ -202,7 +206,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenMethodHasOnlyParamsAndNoArgumentsAreProvided()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndNoArgumentsAreProvided))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndNoArgumentsAreProvided))}.cs",
                 Array.Empty<string>());
         }
 
@@ -210,7 +214,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsCorrect()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsCorrect))}.cs",
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsCorrect))}.cs",
                 Array.Empty<string>());
         }
 
@@ -218,8 +222,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsIncorrect()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsIncorrect))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsIncorrect))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -233,8 +237,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenMethodHasOnlyParamsAndArgumentPassesNullToValueType()
         {
             await TestHelpers.RunAnalysisAsync<TestCaseUsageAnalyzer>(
-                $"{TestCaseUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndArgumentPassesNullToValueType))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestCaseUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenMethodHasOnlyParamsAndArgumentPassesNullToValueType))}.cs",
+                new[] { AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -1,9 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.TestCaseUsage;
 using NUnit.Framework;
@@ -13,7 +13,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     [TestFixture]
     public sealed class TestMethodUsageAnalyzerTests
     {
-        private static readonly string BasePath =
+        private static readonly string basePath =
             $@"{TestContext.CurrentContext.TestDirectory}\Targets\TestMethodUsage\{nameof(TestMethodUsageAnalyzerTests)}";
 
         [Test]
@@ -22,12 +22,15 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
             var analyzer = new TestMethodUsageAnalyzer();
             var diagnostics = analyzer.SupportedDiagnostics;
 
-            Assert.That(diagnostics.Length, Is.EqualTo(2), nameof(DiagnosticAnalyzer.SupportedDiagnostics));
+            var expectedIdentifiers = new List<string>
+            {
+                AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
+                AnalyzerIdentifiers.TestMethodSpecifiedExpectedResultForVoidUsage
+            };
+            CollectionAssert.AreEquivalent(expectedIdentifiers, diagnostics.Select(d => d.Id));
 
             foreach (var diagnostic in diagnostics)
             {
-                Assert.That(diagnostic.Id, Is.EqualTo(AnalyzerIdentifiers.TestCaseUsage),
-                    $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Id)}");
                 Assert.That(diagnostic.Title.ToString(), Is.EqualTo(TestMethodUsageAnalyzerConstants.Title),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
                 Assert.That(diagnostic.Category, Is.EqualTo(Categories.Usage),
@@ -48,7 +51,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenExpectedResultIsProvidedCorrectly()
         {
             await TestHelpers.RunAnalysisAsync<TestMethodUsageAnalyzer>(
-                $"{TestMethodUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedCorrectly))}.cs",
+                $"{TestMethodUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedCorrectly))}.cs",
                 Array.Empty<string>());
         }
 
@@ -56,8 +59,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenExpectedResultIsProvidedAndReturnTypeIsVoid()
         {
             await TestHelpers.RunAnalysisAsync<TestMethodUsageAnalyzer>(
-                $"{TestMethodUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndReturnTypeIsVoid))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestMethodUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndReturnTypeIsVoid))}.cs",
+                new[] { AnalyzerIdentifiers.TestMethodSpecifiedExpectedResultForVoidUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -71,8 +74,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenExpectedResultIsProvidedAndTypeIsIncorrect()
         {
             await TestHelpers.RunAnalysisAsync<TestMethodUsageAnalyzer>(
-                $"{TestMethodUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndTypeIsIncorrect))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestMethodUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndTypeIsIncorrect))}.cs",
+                new[] { AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -86,8 +89,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenExpectedResultIsProvidedAndPassesNullToValueType()
         {
             await TestHelpers.RunAnalysisAsync<TestMethodUsageAnalyzer>(
-                $"{TestMethodUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndPassesNullToValueType))}.cs",
-                new[] { AnalyzerIdentifiers.TestCaseUsage },
+                $"{TestMethodUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndPassesNullToValueType))}.cs",
+                new[] { AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage },
                 diagnostics =>
                 {
                     var diagnostic = diagnostics[0];
@@ -101,7 +104,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenExpectedResultIsProvidedAndPassesNullToNullableType()
         {
             await TestHelpers.RunAnalysisAsync<TestMethodUsageAnalyzer>(
-                $"{TestMethodUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndPassesNullToNullableType))}.cs",
+                $"{TestMethodUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndPassesNullToNullableType))}.cs",
                 Array.Empty<string>());
         }
 
@@ -109,7 +112,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public async Task AnalyzeWhenExpectedResultIsProvidedAndPassesValueToNullableType()
         {
             await TestHelpers.RunAnalysisAsync<TestMethodUsageAnalyzer>(
-                $"{TestMethodUsageAnalyzerTests.BasePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndPassesValueToNullableType))}.cs",
+                $"{TestMethodUsageAnalyzerTests.basePath}{(nameof(this.AnalyzeWhenExpectedResultIsProvidedAndPassesValueToNullableType))}.cs",
                 Array.Empty<string>());
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -12,10 +12,9 @@ using static NUnit.Analyzers.Extensions.ITypeSymbolExtensions;
 namespace NUnit.Analyzers.ClassicModelAssertUsage
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ClassicModelAssertUsageAnalyzer
-        : DiagnosticAnalyzer
+    public sealed class ClassicModelAssertUsageAnalyzer : DiagnosticAnalyzer
     {
-        private static readonly ImmutableDictionary<string, DiagnosticDescriptor> Names =
+        private static readonly ImmutableDictionary<string, DiagnosticDescriptor> name =
           new Dictionary<string, DiagnosticDescriptor>
           {
               { NameOfAssertIsTrue, ClassicModelAssertUsageAnalyzer.CreateDescriptor(AnalyzerIdentifiers.IsTrueUsage) },
@@ -31,7 +30,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 ClassicModelUsageAnalyzerConstants.Message, Categories.Usage,
                 DiagnosticSeverity.Warning, true);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.Names.Values.ToImmutableArray();
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.name.Values.ToImmutableArray();
 
         public override void Initialize(AnalysisContext context)
         {
@@ -52,10 +51,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 {
                     context.CancellationToken.ThrowIfCancellationRequested();
 
-                    if (ClassicModelAssertUsageAnalyzer.Names.ContainsKey(invocationSymbol.Name))
+                    if (ClassicModelAssertUsageAnalyzer.name.ContainsKey(invocationSymbol.Name))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
-                            ClassicModelAssertUsageAnalyzer.Names[invocationSymbol.Name],
+                            ClassicModelAssertUsageAnalyzer.name[invocationSymbol.Name],
                             invocationNode.GetLocation(),
                             ClassicModelAssertUsageAnalyzer.GetProperties(invocationSymbol)));
                     }

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -2,14 +2,17 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class AnalyzerIdentifiers
     {
-        // Next is 9
-        internal const string AreEqualUsage = "NUNIT_5";
-        internal const string AreNotEqualUsage = "NUNIT_6";
         internal const string FalseUsage = "NUNIT_1";
         internal const string IsFalseUsage = "NUNIT_2";
         internal const string IsTrueUsage = "NUNIT_3";
-        internal const string TestCaseUsage = "NUNIT_7";
-        internal const string TestCaseSourceStringUsage = "NUNIT_8";
         internal const string TrueUsage = "NUNIT_4";
+        internal const string AreEqualUsage = "NUNIT_5";
+        internal const string AreNotEqualUsage = "NUNIT_6";
+        internal const string TestCaseParameterTypeMismatchUsage = "NUNIT_7";
+        internal const string TestCaseSourceStringUsage = "NUNIT_8";
+        internal const string TestCaseNotEnoughArgumentsUsage = "NUNIT_9";
+        internal const string TestCaseTooManyArgumentsUsage = "NUNIT_10";
+        internal const string TestMethodExpectedResultTypeMismatchUsage = "NUNIT_11";
+        internal const string TestMethodSpecifiedExpectedResultForVoidUsage = "NUNIT_12";
     }
 }


### PR DESCRIPTION
In order to use Gu.Roslyn.Asserts to make tests more succient, and
also to reduce the "magic" in the tests, we need that all analyzers
have unique identifers.

This PR just makes all the identifers unique, in a subsequent PR
we'll make use of Gu.Roslyn.Asserts.

Note that #84 will reassign the identifiers once more.

See GuOrg/Gu.Roslyn.Asserts#99 for a little context.