### PR TITLE
Replace manual lookup of value of parameter in attribute with GetConstantValue

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -310,5 +310,31 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     }");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenArgumentIsAReferenceToConstantThatNeedsConversion()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    class AnalyzeWhenArgumentIsAReferenceToConstantThatNeedsConversion
+    {
+        const int value = 42;
+
+        [TestCase(value)]
+        public void Test(decimal a) { }
+    }");
+            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenArgumentIsANegativeNumberThatNeedsConversion()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    class AnalyzeWhenArgumentIsANegativeNumberThatNeedsConversion
+    {
+        [TestCase(-600)]
+        public void Test(decimal a) { }
+    }");
+            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/Extensions/AttributeArgumentSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentSyntaxExtensions.cs
@@ -13,12 +13,12 @@ namespace NUnit.Analyzers.Extensions
         {
             //See https://github.com/nunit/nunit/blob/f16d12d6fa9e5c879601ad57b4b24ec805c66054/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs#L396
             //for the reasoning behind this implementation.
+            Optional<object> possibleConstantValue = model.GetConstantValue(@this.Expression);
             object argumentValue = null;
-            if (@this.Expression is LiteralExpressionSyntax syntax)
+            if (possibleConstantValue.HasValue)
             {
-                argumentValue = syntax.Token.Value;
+                argumentValue = possibleConstantValue.Value;
             }
-
             TypeInfo sourceTypeInfo = model.GetTypeInfo(@this.Expression);
             ITypeSymbol argumentType = sourceTypeInfo.Type;
 


### PR DESCRIPTION
This ensure us that we can get the correct constant value in all cases.

Fixes #83 