### PR TITLE
Fix for TestCaseSource(StringLiteralExpression)

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzerTests.cs
@@ -63,9 +63,9 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         }
 
         [TestCase("private static readonly TestCaseData[] TestCases = new TestCaseData[0];")]
-        [TestCase("private static readonly TestCaseData[] TestCases => new TestCaseData[0];")]
-        [TestCase("private static readonly TestCaseData[] TestCases() => new TestCaseData[0];")]
-        public void FixWhenStringLiteral(string testCaseMemmber)
+        [TestCase("private static TestCaseData[] TestCases => new TestCaseData[0];")]
+        [TestCase("private static TestCaseData[] TestCases() => new TestCaseData[0];")]
+        public void FixWhenStringLiteral(string testCaseMember)
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public class AnalyzeWhenStringConstant
@@ -76,7 +76,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         public void Test()
         {
         }
-    }").AssertReplace("private static readonly TestCaseData[] TestCases = new TestCaseData[0];", testCaseMemmber);
+    }").AssertReplace("private static readonly TestCaseData[] TestCases = new TestCaseData[0];", testCaseMember);
 
             var fixedCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public class AnalyzeWhenStringConstant
@@ -87,10 +87,10 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         public void Test()
         {
         }
-    }").AssertReplace("private static readonly TestCaseData[] TestCases = new TestCaseData[0];", testCaseMemmber);
+    }").AssertReplace("private static readonly TestCaseData[] TestCases = new TestCaseData[0];", testCaseMember);
 
             var message = "Consider using nameof(TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode, allowCompilationErrors: AllowCompilationErrors.Yes);
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -131,7 +131,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }");
 
             var message = "Consider using nameof(TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode, allowCompilationErrors: AllowCompilationErrors.Yes);
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -24,10 +24,10 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(AnalyzeAttribute, SyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(x => AnalyzeAttribute(x), SyntaxKind.Attribute);
         }
 
-        private void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
         {
             var testCaseSourceType = context.SemanticModel.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestCaseSourceAttribute);
             if (testCaseSourceType == null)
@@ -45,7 +45,7 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
 
                 if (attributeNode.ArgumentList is AttributeArgumentListSyntax argumentList &&
                     argumentList.Arguments.Count == 1 &&
-                    argumentList.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax literal &&
+                    argumentList.Arguments[0]?.Expression is LiteralExpressionSyntax literal &&
                     literal.IsKind(SyntaxKind.StringLiteralExpression))
                 {
                     if (HasMember(context, literal))
@@ -66,13 +66,13 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
                 return false;
             }
 
-
             foreach (var symbol in context.SemanticModel.LookupSymbols(literal.SpanStart, container: context.ContainingSymbol.ContainingType, name: literal.Token.ValueText))
             {
                 switch (symbol.Kind)
                 {
                     case SymbolKind.Field:
                     case SymbolKind.Property:
+                    case SymbolKind.Method:
                         return true;
                 }
             }

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -43,22 +43,41 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                var arguments = attributeNode.ArgumentList.Arguments;
-
-                // If the First Argument is a String Constant we're in trouble
-                var firstArgument = arguments.FirstOrDefault().Expression;
-                var firstArgumentIsStringConstant = firstArgument.Kind() == SyntaxKind.StringLiteralExpression;
-
-                if (firstArgumentIsStringConstant)
+                if (attributeNode.ArgumentList is AttributeArgumentListSyntax argumentList &&
+                    argumentList.Arguments.Count == 1 &&
+                    argumentList.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax literal &&
+                    literal.IsKind(SyntaxKind.StringLiteralExpression))
                 {
-                    var stringConstant = ((LiteralExpressionSyntax)firstArgument).Token.ValueText;
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        CreateDescriptor(string.Format(TestCaseSourceUsageConstants.ConsiderNameOfInsteadOfStringConstantMessage, stringConstant)),
-                        attributeNode.GetLocation(),
-                        ImmutableDictionary.Create<string, string>().Add("StringConstant", stringConstant)
-                        ));
+                    if (HasMember(context, literal))
+                    {
+                        var stringConstant = literal.Token.ValueText;
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            CreateDescriptor(string.Format(TestCaseSourceUsageConstants.ConsiderNameOfInsteadOfStringConstantMessage, stringConstant)),
+                            literal.GetLocation()));
+                    }
                 }
             }
+        }
+
+        private static bool HasMember(SyntaxNodeAnalysisContext context, LiteralExpressionSyntax literal)
+        {
+            if (!SyntaxFacts.IsValidIdentifier(literal.Token.ValueText))
+            {
+                return false;
+            }
+
+
+            foreach (var symbol in context.SemanticModel.LookupSymbols(literal.SpanStart, container: context.ContainingSymbol.ContainingType, name: literal.Token.ValueText))
+            {
+                switch (symbol.Kind)
+                {
+                    case SymbolKind.Field:
+                    case SymbolKind.Property:
+                        return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/nunit.analyzers/TestCaseSourceUsage/UseNameofFix.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/UseNameofFix.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.TestCaseSourceUsage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseNameofFix))]
+    [Shared]
+    public class UseNameofFix : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+            AnalyzerIdentifiers.TestCaseSourceStringUsage);
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken)
+                                          .ConfigureAwait(false);
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is LiteralExpressionSyntax literal)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            "Use nameof()",
+                            _ => Task.FromResult(
+                                context.Document.WithSyntaxRoot(
+                                    syntaxRoot.ReplaceNode(
+                                        literal,
+                                        SyntaxFactory.InvocationExpression(
+                                            SyntaxFactory.IdentifierName(SyntaxFacts.GetText(SyntaxKind.NameOfKeyword)),
+                                            SyntaxFactory.ArgumentList(
+                                                SyntaxFactory.SingletonSeparatedList(
+                                                    SyntaxFactory.Argument(
+                                                        SyntaxFactory.IdentifierName(literal.Token.ValueText)))))))),
+                            nameof(UseNameofFix)),
+                        diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/src/nunit.analyzers/TestCaseSourceUsage/UseNameofFix.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/UseNameofFix.cs
@@ -35,12 +35,7 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
                                 context.Document.WithSyntaxRoot(
                                     syntaxRoot.ReplaceNode(
                                         literal,
-                                        SyntaxFactory.InvocationExpression(
-                                            SyntaxFactory.IdentifierName(SyntaxFacts.GetText(SyntaxKind.NameOfKeyword)),
-                                            SyntaxFactory.ArgumentList(
-                                                SyntaxFactory.SingletonSeparatedList(
-                                                    SyntaxFactory.Argument(
-                                                        SyntaxFactory.IdentifierName(literal.Token.ValueText)))))))),
+                                        SyntaxFactory.ParseExpression($"nameof({literal.Token.ValueText})")))),
                             nameof(UseNameofFix)),
                         diagnostic);
                 }


### PR DESCRIPTION
1. Moved the squiggle position to the string literal. Think it is clearer this way.
2. Checking that there is a member that we can nameof.
3. UseNameofFix and update tests.

Fix #106 