### PR TITLE
Add analyzer for const actual value

### DIFF
--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -7,8 +7,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
 {
     public class ActualConstValueUsageAnalyzerTests
     {
-        private readonly DiagnosticAnalyzer analyzer = new ActualConstValueUsageAnalyzer();
-
+        private static readonly DiagnosticAnalyzer analyzer = new ActualConstValueUsageAnalyzer();
 
         [Test]
         public void AnalyzeWhenLiteralArgumentIsProvidedForAreEqual()
@@ -20,7 +19,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                     Assert.AreEqual(expected, ↓1);
                 }");
 
-            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -32,7 +31,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                     Assert.That(↓true, Is.EqualTo(false));
                 }");
 
-            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -46,7 +45,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                     Assert.AreEqual(expected, ↓actual);
                 }");
 
-            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -60,7 +59,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                     Assert.That(↓actual, Is.EqualTo(expected));
                 }");
 
-            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -78,7 +77,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                 }
             }");
 
-            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -96,7 +95,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                 }
             }");
 
-            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -114,7 +113,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(this.analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -132,7 +131,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(this.analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -1,0 +1,138 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.ConstActualValueUsage;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ActualConstValueUsage
+{
+    public class ActualConstValueUsageAnalyzerTests
+    {
+        private readonly DiagnosticAnalyzer analyzer = new ActualConstValueUsageAnalyzer();
+
+
+        [Test]
+        public void AnalyzeWhenLiteralArgumentIsProvidedForAreEqual()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    int expected = 5;
+                    Assert.AreEqual(expected, ↓1);
+                }");
+
+            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLiteralArgumentIsProvidedForAssertThat()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    Assert.That(↓true, Is.EqualTo(false));
+                }");
+
+            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLocalConstArgumentIsProvidedForAreEqual()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    string expected = ""exp"";
+                    Assert.AreEqual(expected, ↓actual);
+                }");
+
+            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLocalConstArgumentIsProvidedForAssertThat()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    string expected = ""exp"";
+                    Assert.That(↓actual, Is.EqualTo(expected));
+                }");
+
+            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenConstFieldArgumentIsProvidedForAreEqual()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string actual = ""act"";
+
+                public void Test()
+                {
+                    string expected = ""exp"";
+                    Assert.AreEqual(expected, ↓actual);
+                }
+            }");
+
+            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenConstFieldArgumentIsProvidedForAssertThat()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string actual = ""act"";
+
+                public void Test()
+                {
+                    string expected = ""exp"";
+                    Assert.That(↓actual, Is.EqualTo(expected));
+                }
+            }");
+
+            AnalyzerAssert.Diagnostics(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenNonConstValueIsProvidedAsActualForAreEqual()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    string actual = ""act"";
+                    Assert.AreEqual(expected, actual);
+                }
+            }");
+
+            AnalyzerAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenNonConstValueIsProvidedAsActualForAssertThat()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    string actual = ""act"";
+                    Assert.That(actual, Is.EqualTo(expected));
+                }
+            }");
+
+            AnalyzerAssert.Valid(this.analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -3,11 +3,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.ConstActualValueUsage;
 using NUnit.Framework;
 
-namespace NUnit.Analyzers.Tests.ActualConstValueUsage
+namespace NUnit.Analyzers.Tests.ConstActualValueUsage
 {
-    public class ActualConstValueUsageAnalyzerTests
+    public class ConstActualValueUsageAnalyzerTests
     {
-        private static readonly DiagnosticAnalyzer analyzer = new ActualConstValueUsageAnalyzer();
+        private static readonly DiagnosticAnalyzer analyzer = new ConstActualValueUsageAnalyzer();
 
         [Test]
         public void AnalyzeWhenLiteralArgumentIsProvidedForAreEqual()
@@ -17,6 +17,19 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                 {
                     int expected = 5;
                     Assert.AreEqual(expected, ↓1);
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLiteralNamedArgumentIsProvidedForAreEqual()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    int expected = 5;
+                    Assert.AreEqual(↓actual: 1, expected: expected);
                 }");
 
             AnalyzerAssert.Diagnostics(analyzer, testCode);
@@ -43,6 +56,20 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
                     const string actual = ""act"";
                     string expected = ""exp"";
                     Assert.AreEqual(expected, ↓actual);
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLocalConstNamedArgumentIsProvidedForAreEqual()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    string expected = ""exp"";
+                    Assert.AreEqual(↓actual: actual, expected: expected);
                 }");
 
             AnalyzerAssert.Diagnostics(analyzer, testCode);
@@ -99,7 +126,7 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
         }
 
         [Test]
-        public void ValidWhenNonConstValueIsProvidedAsActualForAreEqual()
+        public void ValidWhenNonConstValueIsProvidedAsActualArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
             public class TestFixure
@@ -117,7 +144,25 @@ namespace NUnit.Analyzers.Tests.ActualConstValueUsage
         }
 
         [Test]
-        public void ValidWhenNonConstValueIsProvidedAsActualForAssertThat()
+        public void ValidWhenNonConstValueIsProvidedAsActualNamedArgumentForAreEqual()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    string actual = ""act"";
+                    Assert.AreEqual(actual: actual, expected: expected);
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenNonConstValueIsProvidedAsActualArgumentForAssertThat()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
             public class TestFixure

--- a/src/nunit.analyzers.tests/Constants/NunitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NunitFrameworkConstantsTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Analyzers.Constants;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
@@ -40,6 +41,17 @@ namespace NUnit.Analyzers.Tests.Constants
             Assert.That(
                 NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute,
                 Is.EqualTo(typeof(TestCaseAttribute).FullName));
+        }
+
+        [Test]
+        public void NameOfActualParameter()
+        {
+            var parameterNames = typeof(Assert).GetMethods()
+                .First(m => m.Name == nameof(Assert.AreEqual))
+                .GetParameters()
+                .Select(p => p.Name);
+
+            Assert.That(parameterNames, Does.Contain(NunitFrameworkConstants.NameOfActualParameter));
         }
 
         [Test]

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -10,10 +10,10 @@ using NUnit.Analyzers.Extensions;
 namespace NUnit.Analyzers.ConstActualValueUsage
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class ActualConstValueUsageAnalyzer : DiagnosticAnalyzer
+    public class ConstActualValueUsageAnalyzer : DiagnosticAnalyzer
     {
         private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
-            AnalyzerIdentifiers.ConstActualValueUsageAnalyzer,
+            AnalyzerIdentifiers.ConstActualValueUsage,
             ConstActualValueUsageAnalyzerConstants.Title,
             ConstActualValueUsageAnalyzerConstants.Message,
             Categories.Usage,
@@ -61,4 +61,3 @@ namespace NUnit.Analyzers.ConstActualValueUsage
         }
     }
 }
-

--- a/src/nunit.analyzers/ConstActualValueUsageAnalyzer/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsageAnalyzer/ConstActualValueUsageAnalyzer.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.ConstActualValueUsage
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ActualConstValueUsageAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
+            AnalyzerIdentifiers.ConstActualValueUsageAnalyzer,
+            ConstActualValueUsageAnalyzerConstants.Title,
+            ConstActualValueUsageAnalyzerConstants.Message,
+            Categories.Usage,
+            DiagnosticSeverity.Warning,
+            true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.Argument);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var argumentSyntax = context.Node as ArgumentSyntax;
+            var argumentListSyntax = argumentSyntax?.Parent as ArgumentListSyntax;
+            var invocationSyntax = argumentSyntax?.Ancestors().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+
+            if (argumentSyntax == null || argumentListSyntax == null || invocationSyntax == null)
+                return;
+
+            var symbol = context.SemanticModel.GetSymbolInfo(invocationSyntax.Expression).Symbol;
+
+            if (!(symbol is IMethodSymbol methodSymbol) || !methodSymbol.ContainingType.IsAssert())
+                return;
+
+            var parameterSymbol = argumentSyntax.NameColon != null
+                ? methodSymbol.Parameters.FirstOrDefault(p => p.Name == argumentSyntax.NameColon.Name.Identifier.Text)
+                : methodSymbol.Parameters.ElementAtOrDefault(argumentListSyntax.Arguments.IndexOf(argumentSyntax));
+
+            if (parameterSymbol?.Name == NunitFrameworkConstants.NameOfActualParameter)
+            {
+                var argumentSymbol = context.SemanticModel.GetSymbolInfo(argumentSyntax.Expression).Symbol;
+
+                if (argumentSyntax.Expression is LiteralExpressionSyntax
+                    || (argumentSymbol is ILocalSymbol localSymbol && localSymbol.IsConst)
+                    || (argumentSymbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        descriptor,
+                        argumentSyntax.GetLocation()));
+                }
+            }
+        }
+    }
+}
+

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -19,5 +19,6 @@ namespace NUnit.Analyzers.Constants
         internal const string ParallelScopeChildrenOnNonParameterizedTestMethodUsage = "NUNIT_15";
         internal const string ParallelScopeFixturesOnTestMethodUsage = "NUNIT_16";
         internal const string TestCaseSourceIsMissing = "NUNIT_17";
+        internal const string ConstActualValueUsageAnalyzer = "NUNIT_18";
     }
 }

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -19,6 +19,6 @@ namespace NUnit.Analyzers.Constants
         internal const string ParallelScopeChildrenOnNonParameterizedTestMethodUsage = "NUNIT_15";
         internal const string ParallelScopeFixturesOnTestMethodUsage = "NUNIT_16";
         internal const string TestCaseSourceIsMissing = "NUNIT_17";
-        internal const string ConstActualValueUsageAnalyzer = "NUNIT_18";
+        internal const string ConstActualValueUsage = "NUNIT_18";
     }
 }

--- a/src/nunit.analyzers/Constants/ConstActualValueUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/ConstActualValueUsageAnalyzerConstants.cs
@@ -4,6 +4,6 @@ namespace NUnit.Analyzers.Constants
     {
         public const string Title = "Actual value should not be constant";
         public const string Message = "Actual value should not be constant - " +
-            "possible that actual and expected values are switched places";
+            "perhaps the actual and expected values have switched places";
     }
 }

--- a/src/nunit.analyzers/Constants/ConstActualValueUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/ConstActualValueUsageAnalyzerConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.Constants
+{
+    internal static class ConstActualValueUsageAnalyzerConstants
+    {
+        public const string Title = "Actual value should not be constant";
+        public const string Message = "Actual value should not be constant - " +
+            "possible that actual and expected values are switched places";
+    }
+}

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -37,6 +37,8 @@ namespace NUnit.Analyzers.Constants
 
         public const string NameOfExpectedResult = "ExpectedResult";
 
+        public const string NameOfActualParameter = "actual";
+
         public const string AssemblyQualifiedNameOfTypeAssert =
             "NUnit.Framework.Assert, nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb";
     }


### PR DESCRIPTION
(fix #40 #113)

Warning if `actual` value provided to Assert method is literal or const.
Applies for all methods in Assert class, having 'actual' parameter.