### PR TITLE
Handle async test methods with no ExpectedResult and non-Task return type

### DIFF
--- a/src/nunit.analyzers.tests/TestUtility.cs
+++ b/src/nunit.analyzers.tests/TestUtility.cs
@@ -1,7 +1,8 @@
+using System.Threading.Tasks;
 using Gu.Roslyn.Asserts;
 using NUnit.Framework;
 
-[assembly: MetadataReferences(typeof(Assert), typeof(object))]
+[assembly: MetadataReferences(typeof(Assert), typeof(object), typeof(Task))]
 
 namespace NUnit.Analyzers.Tests
 {
@@ -11,6 +12,7 @@ namespace NUnit.Analyzers.Tests
         {
             return $@"
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace NUnit.Analyzers.Tests.Targets.TestCaseUsage

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -20,5 +20,7 @@ namespace NUnit.Analyzers.Constants
         internal const string ParallelScopeFixturesOnTestMethodUsage = "NUNIT_16";
         internal const string TestCaseSourceIsMissing = "NUNIT_17";
         internal const string ConstActualValueUsage = "NUNIT_18";
+        internal const string TestMethodAsyncNoExpectedResultAndVoidReturnTypeUsage = "NUNIT_19";
+        internal const string TestMethodAsyncNoExpectedResultAndNonTaskReturnTypeUsage = "NUNIT_20";
     }
 }

--- a/src/nunit.analyzers/Constants/TestMethodUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/TestMethodUsageAnalyzerConstants.cs
@@ -5,6 +5,8 @@ namespace NUnit.Analyzers.Constants
         internal const string ExpectedResultTypeMismatchMessage = "The ExpectedResult value cannot be assigned to the return type, {0}";
         internal const string SpecifiedExpectedResultForVoidMethodMessage = "Cannot specify ExpectedResult when the method returns void";
         internal const string NoExpectedResultButNonVoidReturnType = "Method has non-void return type, but no result is expected in ExpectedResult";
+        internal const string AsyncNoExpectedResultAndVoidReturnType = "Async test method must have non-void return type";
+        internal const string AsyncNoExpectedResultAndNonTaskReturnType = "Async test method must have non-generic Task return type when no result is expected";
 
         internal const string Title = "Find Incorrect TestAttribute or TestCaseAttribute Usage";
     }


### PR DESCRIPTION
Fixes #118, fixes #7, fixes #48.