### PR TITLE
Add IgnoreCaseUsageAnalyzer

### DIFF
--- a/src/nunit.analyzers.tests/Constants/NunitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NunitFrameworkConstantsTests.cs
@@ -17,6 +17,9 @@ namespace NUnit.Analyzers.Tests.Constants
         [TestCase(NunitFrameworkConstants.NameOfIsFalse, nameof(Is.False))]
         [TestCase(NunitFrameworkConstants.NameOfIsTrue, nameof(Is.True))]
         [TestCase(NunitFrameworkConstants.NameOfIsEqualTo, nameof(Is.EqualTo))]
+        [TestCase(NunitFrameworkConstants.NameOfIsEquivalentTo, nameof(Is.EquivalentTo))]
+        [TestCase(NunitFrameworkConstants.NameOfIsSubsetOf, nameof(Is.SubsetOf))]
+        [TestCase(NunitFrameworkConstants.NameOfIsSupersetOf, nameof(Is.SupersetOf))]
         [TestCase(NunitFrameworkConstants.NameOfIsNot, nameof(Is.Not))]
         [TestCase(NunitFrameworkConstants.NameOfIsNotEqualTo, nameof(Is.Not.EqualTo))]
         [TestCase(NunitFrameworkConstants.NameOfIsSameAs, nameof(Is.SameAs))]
@@ -34,6 +37,7 @@ namespace NUnit.Analyzers.Tests.Constants
         [TestCase(NunitFrameworkConstants.NameOfTestCaseAttribute, nameof(TestCaseAttribute))]
         [TestCase(NunitFrameworkConstants.NameOfExpectedResult, nameof(TestCaseAttribute.ExpectedResult))]
         [TestCase(NunitFrameworkConstants.NameOfExpectedResult, nameof(TestAttribute.ExpectedResult))]
+        [TestCase(NunitFrameworkConstants.NameOfIgnoreCase, nameof(EqualConstraint.IgnoreCase))]
         public void TestConstant(string constant, string nameOfArgument)
         {
             Assert.That(constant, Is.EqualTo(nameOfArgument));

--- a/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
@@ -47,6 +47,56 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
         }
 
         [Test]
+        public void AnalyzeWhenValueTupleWithNoStringMemberProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = (1, 2, false);
+                Assert.That(actual, Is.EqualTo((1, 2, false)).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenTupleWithNoStringMemberProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = System.Tuple.Create(1, 2);
+                var expected = System.Tuple.Create(1, 2);
+                Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNonStringKeyValuePairProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var expected = new System.Collections.Generic.KeyValuePair<bool, int>(false, 1);
+                var actual = new System.Collections.Generic.KeyValuePair<bool, int>(true, 1);
+                Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNonStringRecurseGenericArgumentProvided()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                class RecurseClass : System.Collections.Generic.List<RecurseClass>
+                { }
+
+                [Test]
+                public void TestMethod()
+                {
+                    var actual = new RecurseClass();
+                    var expected = new RecurseClass();
+                    Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenIgnoreCaseUsedForStringEqualToArgument()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
@@ -89,6 +139,71 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 {
                     [1] = ""value1""
                 };
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForValueTupleWithStringMember()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = (""a"", 2, false);
+                Assert.That(actual, Is.EqualTo((""A"", 2, false)).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForTupleWithStringMember()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = System.Tuple.Create(1, ""a"");
+                var expected = System.Tuple.Create(1, ""A"");
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForKeyValuePairWithStringKey()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var expected = new System.Collections.Generic.KeyValuePair<string, int>(""a"", 1);
+                var actual = new System.Collections.Generic.KeyValuePair<string, int>(""A"", 1);
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForKeyValuePairWithStringValue()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var expected = new System.Collections.Generic.KeyValuePair<int, string>(1, ""a"");
+                var actual = new System.Collections.Generic.KeyValuePair<int, string>(1, ""A"");
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForDictionaryEntry()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var expected = new System.Collections.DictionaryEntry(1, ""a"");
+                var actual = new System.Collections.DictionaryEntry(1, ""A"");
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForDeepNesting()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = (1, new[] { new[] { ""a"" } });
+                var expected = (1, new[] { new[] { ""A"" } });
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
             AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);

--- a/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
@@ -33,6 +33,20 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
         }
 
         [Test]
+        public void AnalyzeWhenDictionaryWithNonStringValueProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] {""a"",""b""};
+                var expected = new System.Collections.Generic.Dictionary<string, int>
+                {
+                    [""key1""] = 1
+                };
+                Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenIgnoreCaseUsedForStringEqualToArgument()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
@@ -67,13 +81,13 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
         }
 
         [Test]
-        public void ValidWhenStringDictionaryProvided()
+        public void ValidWhenDictionaryWithStringValueProvided()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = new[] {""a"",""b""};
-                var expected = new System.Collections.Generic.Dictionary<string, string>
+                var expected = new System.Collections.Generic.Dictionary<int, string>
                 {
-                    [""key1""] = ""value1""
+                    [1] = ""value1""
                 };
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 

--- a/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
@@ -1,0 +1,83 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.IgnoreCaseUsage;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
+{
+    public class IgnoreCaseUsageAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new IgnoreCaseUsageAnalyzer();
+
+        [Test]
+        public void AnalyzeWhenIgnoreCaseUsedForNonStringEqualToArgument()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(1, Is.EqualTo(1).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [TestCase(nameof(Is.EqualTo))]
+        [TestCase(nameof(Is.EquivalentTo))]
+        [TestCase(nameof(Is.SubsetOf))]
+        [TestCase(nameof(Is.SupersetOf))]
+        public void AnalyzeWhenIgnoreCaseUsedForNonStringCollection(string constraintMethod)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                var actual = new[] {{1,2,3}};
+                var expected = new[] {{3,2,1}};
+                Assert.That(actual, Is.{constraintMethod}(expected).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenIgnoreCaseUsedForStringEqualToArgument()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(""A"", Is.EqualTo(""a"").IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [TestCase(nameof(Is.EqualTo))]
+        [TestCase(nameof(Is.EquivalentTo))]
+        [TestCase(nameof(Is.SubsetOf))]
+        [TestCase(nameof(Is.SupersetOf))]
+        public void ValidWhenIgnoreCaseUsedForStringCollection(string constraintMethod)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                var actual = new[] {{""a"",""b"",""c""}};
+                var expected = new[] {{""A"",""C"",""B""}};
+                Assert.That(actual, Is.{constraintMethod}(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenNonGenericIEnumerableProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] {""a"",""b"",""c""};
+                System.Collections.IEnumerable expected = new[] {""A"",""C"",""B""};
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenStringDictionaryProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] {""a"",""b""};
+                var expected = new System.Collections.Generic.Dictionary<string, string>
+                {
+                    [""key1""] = ""value1""
+                };
+                Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/TestUtility.cs
+++ b/src/nunit.analyzers.tests/TestUtility.cs
@@ -28,5 +28,14 @@ namespace NUnit.Analyzers.Tests.Targets.TestCaseUsage
     {{{method}
     }}");
         }
+
+        internal static string WrapInTestMethod(string code)
+        {
+            return WrapMethodInClassNamespaceAndAddUsings($@"
+        [Test]
+        public void TestMethod()
+        {{{code}
+        }}");
+        }
     }
 }

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Analyzers.Tests</RootNamespace>
     <TargetFramework>net461</TargetFramework>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Gu.Roslyn.Asserts" Version="2.6.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Gu.Roslyn.Asserts" Version="2.6.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -23,5 +23,6 @@ namespace NUnit.Analyzers.Constants
         internal const string TestMethodAsyncNoExpectedResultAndVoidReturnTypeUsage = "NUNIT_19";
         internal const string TestMethodAsyncNoExpectedResultAndNonTaskReturnTypeUsage = "NUNIT_20";
         internal const string TestMethodAsyncExpectedResultAndNonGenricTaskReturnTypeUsage = "NUNIT_21";
+        internal const string IgnoreCaseUsage = "NUNIT_22";
     }
 }

--- a/src/nunit.analyzers/Constants/IgnoreUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/IgnoreUsageAnalyzerConstants.cs
@@ -1,0 +1,8 @@
+namespace NUnit.Analyzers.Constants
+{
+    internal static class IgnoreCaseUsageAnalyzerConstants
+    {
+        internal const string Title = "Find Incorrect IgnoreCase usage";
+        internal const string Message = "IgnoreCase modifier can only be used for string or char argument!";
+    }
+}

--- a/src/nunit.analyzers/Constants/IgnoreUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/IgnoreUsageAnalyzerConstants.cs
@@ -2,7 +2,7 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class IgnoreCaseUsageAnalyzerConstants
     {
-        internal const string Title = "Find Incorrect IgnoreCase usage";
-        internal const string Message = "IgnoreCase modifier can only be used for string or char argument!";
+        internal const string Title = "Find incorrect IgnoreCase usage";
+        internal const string Message = "IgnoreCase modifier should only be used for string or char arguments.";
     }
 }

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -12,6 +12,9 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfIsFalse = "False";
         public const string NameOfIsTrue = "True";
         public const string NameOfIsEqualTo = "EqualTo";
+        public const string NameOfIsEquivalentTo = "EquivalentTo";
+        public const string NameOfIsSubsetOf = "SubsetOf";
+        public const string NameOfIsSupersetOf = "SupersetOf";
         public const string NameOfIsNot = "Not";
         public const string NameOfIsNotEqualTo = "EqualTo";
         public const string NameOfIsSameAs = "SameAs";
@@ -44,6 +47,8 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfActualParameter = "actual";
         public const string NameOfExpectedParameter = "expected";
         public const string NameOfExpressionParameter = "expression";
+
+        public const string NameOfIgnoreCase = "IgnoreCase";
 
         public const string AssemblyQualifiedNameOfTypeAssert =
             "NUnit.Framework.Assert, nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb";

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using NUnit.Analyzers.Constants;
@@ -20,6 +21,23 @@ namespace NUnit.Analyzers.Extensions
             return @this != null &&
                 NunitFrameworkConstants.AssemblyQualifiedNameOfTypeAssert.Contains(@this.ContainingAssembly.Name) &&
                 @this.Name == NunitFrameworkConstants.NameOfAssert;
+        }
+
+        internal static string GetFullMetadataName(this ITypeSymbol @this)
+        {
+            // e.g. System.Collections.Generic.IEnumerable`1
+
+            var namespaces = new Stack<string>();
+
+            var @namespace = @this.ContainingNamespace;
+
+            while (!@namespace.IsGlobalNamespace)
+            {
+                namespaces.Push(@namespace.Name);
+                @namespace = @namespace.ContainingNamespace;
+            }
+
+            return $"{string.Join(".", namespaces)}.{@this.MetadataName}";
         }
     }
 }

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -77,15 +77,15 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
 
             var fullName = namedType.GetFullMetadataName();
 
-            // Cannot determine if DictionaryEntry is valid
+            // Cannot determine if DictionaryEntry is valid, since not generic
             if (fullName == "System.Collections.DictionaryEntry")
                 return true;
 
-            if (fullName == "System.Collections.Generic.KeyValuePair`2"
-                || fullName == "System.Tuple`2")
-            {
+            if (fullName == "System.Collections.Generic.KeyValuePair`2")
                 return namedType.TypeArguments.Any(t => IsTypeSupported(t, checkedTypes));
-            }
+
+            if (fullName.StartsWith("System.Tuple`"))
+                return namedType.TypeArguments.Any(t => IsTypeSupported(t, checkedTypes));
 
             // Only value might be supported for Dictionary
             if (fullName == "System.Collections.Generic.Dictionary`2"

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -47,11 +47,8 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
                 return;
 
             // Allowed - string, char
-            if (expectedType.SpecialType == SpecialType.System_String
-                || expectedType.SpecialType == SpecialType.System_Char)
-            {
+            if (IsStringOrChar(expectedType))
                 return;
-            }
 
             var allInterfaces = expectedType.AllInterfaces.ToList();
 
@@ -63,11 +60,8 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
             var genericArgument = iEnumerableInterface?.TypeArguments.FirstOrDefault();
 
             // Collection of strings/chars is allowed
-            if (genericArgument != null && (genericArgument.SpecialType == SpecialType.System_String
-                || genericArgument.SpecialType == SpecialType.System_Char))
-            {
+            if (genericArgument != null && IsStringOrChar(genericArgument))
                 return;
-            }
 
             // Dictionary with string/char value is allowed
             if (genericArgument != null && genericArgument.Name == "KeyValuePair"
@@ -76,11 +70,8 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
             {
                 var valueType = namedType.TypeArguments[1];
 
-                if (valueType.SpecialType == SpecialType.System_String
-                    || valueType.SpecialType == SpecialType.System_Char)
-                {
+                if (IsStringOrChar(valueType))
                     return;
-                }
             }
 
             // Exception - if it implements only non-generic IEnumerable.
@@ -94,6 +85,12 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
             context.ReportDiagnostic(Diagnostic.Create(
                 descriptor,
                 ignoreCaseAccessSyntax.Name.GetLocation()));
+        }
+
+        private static bool IsStringOrChar(ITypeSymbol typeSymbol)
+        {
+            return typeSymbol.SpecialType == SpecialType.System_String
+                || typeSymbol.SpecialType == SpecialType.System_Char;
         }
 
         private static ITypeSymbol GetExpectedTypeSymbol(MemberAccessExpressionSyntax ignoreCaseAccessSyntax, SyntaxNodeAnalysisContext context)

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -1,0 +1,126 @@
+using System.Collections;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.IgnoreCaseUsage
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class IgnoreCaseUsageAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly string[] SupportedIsMethods = new[]
+        {
+            NunitFrameworkConstants.NameOfIsEqualTo,
+            NunitFrameworkConstants.NameOfIsEquivalentTo,
+            NunitFrameworkConstants.NameOfIsSupersetOf,
+            NunitFrameworkConstants.NameOfIsSubsetOf
+        };
+
+        private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
+            AnalyzerIdentifiers.IgnoreCaseUsage,
+            IgnoreCaseUsageAnalyzerConstants.Title,
+            IgnoreCaseUsageAnalyzerConstants.Message,
+            Categories.Usage,
+            DiagnosticSeverity.Warning,
+            true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeMemberAccess, SyntaxKind.SimpleMemberAccessExpression);
+        }
+
+        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
+        {
+            // e.g. Is.EqualTo(expected).IgnoreCase
+            // Need to check type of expected 
+            var ignoreCaseAccessSyntax = context.Node as MemberAccessExpressionSyntax;
+            var expectedType = GetExpectedTypeSymbol(ignoreCaseAccessSyntax, context);
+
+            if (expectedType == null)
+                return;
+
+            // Allowed - string, char
+            if (expectedType.SpecialType == SpecialType.System_String
+                || expectedType.SpecialType == SpecialType.System_Char)
+            {
+                return;
+            }
+
+            var allInterfaces = expectedType.AllInterfaces.ToList();
+
+            if (expectedType.TypeKind == TypeKind.Interface && expectedType is INamedTypeSymbol namedInterface)
+                allInterfaces.Add(namedInterface);
+
+            var iEnumerableInterface = allInterfaces
+                .FirstOrDefault(i => i.Name == nameof(IEnumerable) && i.IsGenericType);
+            var genericArgument = iEnumerableInterface?.TypeArguments.FirstOrDefault();
+
+            // Collection of strings/chars is allowed
+            if (genericArgument != null && (genericArgument.SpecialType == SpecialType.System_String
+                || genericArgument.SpecialType == SpecialType.System_Char))
+            {
+                return;
+            }
+
+            // Dictionary with string/char value is allowed
+            if (genericArgument != null && genericArgument.Name == "KeyValuePair"
+                && genericArgument is INamedTypeSymbol namedType
+                && namedType.TypeArguments.Length == 2)
+            {
+                var valueType = namedType.TypeArguments[1];
+
+                if (valueType.SpecialType == SpecialType.System_String
+                    || valueType.SpecialType == SpecialType.System_Char)
+                {
+                    return;
+                }
+            }
+
+            // Exception - if it implements only non-generic IEnumerable.
+            // It might be invalid, but we cannot determine that
+            if (genericArgument == null && allInterfaces
+                .Any(i => i.Name == nameof(IEnumerable) && !i.IsGenericType))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                descriptor,
+                ignoreCaseAccessSyntax.Name.GetLocation()));
+        }
+
+        private static ITypeSymbol GetExpectedTypeSymbol(MemberAccessExpressionSyntax ignoreCaseAccessSyntax, SyntaxNodeAnalysisContext context)
+        {
+            if (ignoreCaseAccessSyntax?.Name.ToString() != NunitFrameworkConstants.NameOfIgnoreCase)
+                return null;
+
+            if (!(ignoreCaseAccessSyntax.Expression is InvocationExpressionSyntax invocationExpression))
+                return null;
+
+            if (!(invocationExpression.Expression is MemberAccessExpressionSyntax isMethodAccess
+                && SupportedIsMethods.Contains(isMethodAccess.Name.ToString())))
+            {
+                return null;
+            }
+
+            var expectedArgument = invocationExpression.ArgumentList.Arguments.FirstOrDefault();
+
+            if (expectedArgument == null)
+                return null;
+
+            var expectedType = context.SemanticModel.GetTypeInfo(expectedArgument.Expression).Type;
+
+            if (expectedType == null || expectedType is IErrorTypeSymbol)
+                return null;
+
+            return expectedType;
+        }
+    }
+}

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
   </ItemGroup>
 
   <Target Name="AfterBuild">

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
   </ItemGroup>
 
   <Target Name="AfterBuild">


### PR DESCRIPTION
(fixes #124 )

Adds analyzer with warning if IgnoreCase modifier is used for non-applicable argument.

Valid usages:
string, char, 
IEnumerable<string/char>,
Dictionary with string/char value.

Also, if argument implements only non-generic IEnumerable - skip validation.

Supported constraints:
Is.EqualTo, Is.EquivalentTo, Is.SubsetOf, Is.SupersetOf