### PR TITLE
Handle generic test methods

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -384,5 +384,17 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     }");
             AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenTestMethodHasTypeParameterArgumentType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenTestMethodHasTypeParameterArgumentType
+    {
+        [TestCase(1)]
+        public void TestWithGenericParameter<T>(T arg1) { }
+    }");
+            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -305,5 +305,20 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     }");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenTestMethodHasTypeParameterAsReturnType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenTestMethodHasTypeParameterAsReturnType
+    {
+        [TestCase(1, ExpectedResult = 1)]
+        public T TestWithGenericReturnType<T>(T arg1)
+        {
+            return arg1;
+        }
+    }");
+            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -39,5 +39,9 @@ namespace NUnit.Analyzers.Extensions
 
             return $"{string.Join(".", namespaces)}.{@this.MetadataName}";
         }
+
+        internal static bool IsTypeParameterAndDeclaredOnMethod(this ITypeSymbol typeSymbol)
+            => typeSymbol.TypeKind == TypeKind.TypeParameter &&
+               (typeSymbol as ITypeParameterSymbol)?.DeclaringMethod != null;
     }
 }

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -162,6 +162,9 @@ namespace NUnit.Analyzers.TestCaseUsage
                 var methodParameterType = methodParametersSymbol.Item1;
                 var methodParameterName = methodParametersSymbol.Item2;
 
+                if (methodParameterType.IsTypeParameterAndDeclaredOnMethod())
+                    continue;
+
                 if (!attributeArgument.CanAssignTo(methodParameterType, model))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(parameterTypeMismatch,

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -160,6 +160,9 @@ namespace NUnit.Analyzers.TestCaseUsage
             AttributeArgumentSyntax expectedResultNamedArgument,
             ITypeSymbol typeSymbol)
         {
+            if (typeSymbol.IsTypeParameterAndDeclaredOnMethod())
+                return;
+
             if (!expectedResultNamedArgument.CanAssignTo(typeSymbol, context.SemanticModel))
             {
                 context.ReportDiagnostic(Diagnostic.Create(expectedResultTypeMismatch,


### PR DESCRIPTION
To begin with we will not try to handle the case when the type parameter or
the return type is a generic type parameter declared on the test method.
This avoids introducing false positives. I think that the complexity of
solving this correctly far outweighs the benefits.

Fixes #54