### PR TITLE
Refactor assertion analyzers

### DIFF
--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     int expected = 5;
-                    Assert.AreEqual(↓actual: 1, expected: expected);
+                    Assert.AreEqual(actual: ↓1, expected: expected);
                 }");
 
             AnalyzerAssert.Diagnostics(analyzer, testCode);
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 {
                     const string actual = ""act"";
                     string expected = ""exp"";
-                    Assert.AreEqual(↓actual: actual, expected: expected);
+                    Assert.AreEqual(actual: ↓actual, expected: expected);
                 }");
 
             AnalyzerAssert.Diagnostics(analyzer, testCode);

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageCodeFixTests.cs
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     int expected = 5;
-                    Assert.AreEqual(↓actual: 1, expected: expected);
+                    Assert.AreEqual(actual: ↓1, expected: expected);
                 }");
 
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"

--- a/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
@@ -97,6 +97,15 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
         }
 
         [Test]
+        public void AnalyzeWhenIgnoreCaseUsedInConstraintCombinedByOperators()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(1, Is.EqualTo(1).↓IgnoreCase | Is.EqualTo(true).↓IgnoreCase);");
+
+            AnalyzerAssert.Diagnostics(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenIgnoreCaseUsedForStringEqualToArgument()
         {
             var testCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers/BaseAssertionAnalyzer.cs
+++ b/src/nunit.analyzers/BaseAssertionAnalyzer.cs
@@ -1,0 +1,35 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers
+{
+    public abstract class BaseAssertionAnalyzer : DiagnosticAnalyzer
+    {
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(this.AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            if (!(context.Node is InvocationExpressionSyntax invocationSyntax))
+                return;
+
+            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax).Symbol as IMethodSymbol;
+
+            if (methodSymbol == null || !methodSymbol.ContainingType.IsAssert())
+                return;
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            this.AnalyzeAssertInvocation(context, invocationSyntax, methodSymbol);
+        }
+
+        protected abstract void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
+            InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol);
+    }
+}

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -1,18 +1,15 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
-using static NUnit.Analyzers.Extensions.ITypeSymbolExtensions;
 
 namespace NUnit.Analyzers.ClassicModelAssertUsage
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ClassicModelAssertUsageAnalyzer : DiagnosticAnalyzer
+    public sealed class ClassicModelAssertUsageAnalyzer : BaseAssertionAnalyzer
     {
         private static readonly ImmutableDictionary<string, DiagnosticDescriptor> name =
           new Dictionary<string, DiagnosticDescriptor>
@@ -32,35 +29,15 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.name.Values.ToImmutableArray();
 
-        public override void Initialize(AnalysisContext context)
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
+            InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
         {
-            context.EnableConcurrentExecution();
-
-            context.RegisterSyntaxNodeAction(
-                ClassicModelAssertUsageAnalyzer.AnalyzeInvocation, SyntaxKind.InvocationExpression);
-        }
-
-        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
-        {
-            var methodNode = context.Node.Ancestors().OfType<MethodDeclarationSyntax>().SingleOrDefault();
-            if (methodNode != null && !methodNode.ContainsDiagnostics)
+            if (ClassicModelAssertUsageAnalyzer.name.ContainsKey(methodSymbol.Name))
             {
-                var invocationNode = (InvocationExpressionSyntax)context.Node;
-
-                var symbol = context.SemanticModel.GetSymbolInfo(invocationNode.Expression).Symbol;
-
-                if (symbol is IMethodSymbol invocationSymbol && invocationSymbol.ContainingType.IsAssert())
-                {
-                    context.CancellationToken.ThrowIfCancellationRequested();
-
-                    if (ClassicModelAssertUsageAnalyzer.name.ContainsKey(invocationSymbol.Name))
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            ClassicModelAssertUsageAnalyzer.name[invocationSymbol.Name],
-                            invocationNode.GetLocation(),
-                            ClassicModelAssertUsageAnalyzer.GetProperties(invocationSymbol)));
-                    }
-                }
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ClassicModelAssertUsageAnalyzer.name[methodSymbol.Name],
+                    assertExpression.GetLocation(),
+                    ClassicModelAssertUsageAnalyzer.GetProperties(methodSymbol)));
             }
         }
 

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -10,7 +9,7 @@ using NUnit.Analyzers.Extensions;
 namespace NUnit.Analyzers.ConstActualValueUsage
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class ConstActualValueUsageAnalyzer : DiagnosticAnalyzer
+    public class ConstActualValueUsageAnalyzer : BaseAssertionAnalyzer
     {
         private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
             AnalyzerIdentifiers.ConstActualValueUsage,
@@ -22,43 +21,23 @@ namespace NUnit.Analyzers.ConstActualValueUsage
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
+            InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
         {
-            context.EnableConcurrentExecution();
+            var actualExpression = assertExpression.GetArgumentExpression(methodSymbol, NunitFrameworkConstants.NameOfActualParameter);
 
-            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.Argument);
-        }
-
-        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
-        {
-            var argumentSyntax = context.Node as ArgumentSyntax;
-            var argumentListSyntax = argumentSyntax?.Parent as ArgumentListSyntax;
-            var invocationSyntax = argumentSyntax?.Ancestors().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-
-            if (argumentSyntax == null || argumentListSyntax == null || invocationSyntax == null)
+            if (actualExpression == null)
                 return;
 
-            var symbol = context.SemanticModel.GetSymbolInfo(invocationSyntax.Expression).Symbol;
+            var argumentSymbol = context.SemanticModel.GetSymbolInfo(actualExpression).Symbol;
 
-            if (!(symbol is IMethodSymbol methodSymbol) || !methodSymbol.ContainingType.IsAssert())
-                return;
-
-            var parameterSymbol = argumentSyntax.NameColon != null
-                ? methodSymbol.Parameters.FirstOrDefault(p => p.Name == argumentSyntax.NameColon.Name.Identifier.Text)
-                : methodSymbol.Parameters.ElementAtOrDefault(argumentListSyntax.Arguments.IndexOf(argumentSyntax));
-
-            if (parameterSymbol?.Name == NunitFrameworkConstants.NameOfActualParameter)
+            if (actualExpression is LiteralExpressionSyntax
+                || (argumentSymbol is ILocalSymbol localSymbol && localSymbol.IsConst)
+                || (argumentSymbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst))
             {
-                var argumentSymbol = context.SemanticModel.GetSymbolInfo(argumentSyntax.Expression).Symbol;
-
-                if (argumentSyntax.Expression is LiteralExpressionSyntax
-                    || (argumentSymbol is ILocalSymbol localSymbol && localSymbol.IsConst)
-                    || (argumentSymbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst))
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        descriptor,
-                        argumentSyntax.GetLocation()));
-                }
+                context.ReportDiagnostic(Diagnostic.Create(
+                    descriptor,
+                    actualExpression.GetLocation()));
             }
         }
     }

--- a/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace NUnit.Analyzers.Extensions
@@ -38,6 +40,32 @@ namespace NUnit.Analyzers.Extensions
             parts.Reverse();
 
             return parts;
+        }
+
+        /// <summary>
+        /// Returns argument expression by parameter name.
+        /// </summary>
+        public static ExpressionSyntax GetArgumentExpression(this InvocationExpressionSyntax invocationSyntax,
+            IMethodSymbol methodSymbol, string parameterName)
+        {
+            var arguments = invocationSyntax.ArgumentList.Arguments;
+
+            // Try find named argument
+            var argument = arguments.FirstOrDefault(a => a.NameColon?.Name.Identifier.Text == parameterName);
+
+            if (argument == null)
+            {
+                var methodParameter = methodSymbol.Parameters.FirstOrDefault(p => p.Name == parameterName);
+
+                if (methodParameter == null)
+                    return null;
+
+                var parameterIndex = methodSymbol.Parameters.IndexOf(methodParameter);
+
+                argument = arguments.ElementAtOrDefault(parameterIndex);
+            }
+
+            return argument?.Expression;
         }
     }
 }

--- a/src/nunit.analyzers/Helpers/AssertExpressionHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertExpressionHelper.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.Helpers
+{
+    internal static class AssertExpressionHelper
+    {
+        /// <summary>
+        /// Get provided 'actual' and 'expression' arguments to Assert.That method
+        /// </summary>
+        /// <returns>
+        /// True, if arguments found. Otherwise - false.
+        /// </returns>
+        public static bool TryGetActualAndConstraintExpressions(InvocationExpressionSyntax assertExpression,
+            out ExpressionSyntax actualExpression, out ExpressionSyntax constraintExpression)
+        {
+            if (assertExpression.Expression is MemberAccessExpressionSyntax memberAccessSyntax
+                && memberAccessSyntax.Name.Identifier.Text == NunitFrameworkConstants.NameOfAssertThat
+                && assertExpression.ArgumentList.Arguments.Count >= 2)
+            {
+                actualExpression = assertExpression.ArgumentList.Arguments[0].Expression;
+                constraintExpression = assertExpression.ArgumentList.Arguments[1].Expression;
+
+                return true;
+            }
+            else
+            {
+                actualExpression = null;
+                constraintExpression = null;
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns 'expected' assertion arguments expressions, along with corresponding constraint method symbols.
+        /// Returns multiple pairs if multiple constraints are combined.
+        /// </summary>
+        public static List<(ExpressionSyntax expectedArgument, IMethodSymbol constraintMethod)> GetExpectedArguments(
+            ExpressionSyntax constraintExpression, SemanticModel semanticModel)
+        {
+            var expectedArguments = new List<(ExpressionSyntax, IMethodSymbol)>();
+
+            var constraintParts = SplitConstraintByOperators(constraintExpression);
+
+            foreach (var constraintPart in constraintParts)
+            {
+                var invocations = constraintPart.SplitCallChain()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Where(i => i.ArgumentList.Arguments.Count == 1);
+
+                foreach (var invocation in invocations)
+                {
+                    var symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
+
+                    if (symbol is IMethodSymbol methodSymbol
+                        && methodSymbol.Parameters.Length == 1
+                        && methodSymbol.Parameters[0].Name == NunitFrameworkConstants.NameOfExpectedParameter)
+                    {
+                        var argument = invocation.ArgumentList.Arguments[0];
+                        expectedArguments.Add((argument.Expression, methodSymbol));
+                    }
+                }
+            }
+
+            return expectedArguments;
+        }
+
+        /// <summary>
+        /// If provided constraint expression is combined using &, | operators - return multiple split expressions.
+        /// Otherwise - returns single <paramref name="constraintExpression"/> value
+        /// </summary>
+        public static IEnumerable<ExpressionSyntax> SplitConstraintByOperators(ExpressionSyntax constraintExpression)
+        {
+            if (constraintExpression is BinaryExpressionSyntax binaryExpression)
+            {
+                foreach (var leftPart in SplitConstraintByOperators(binaryExpression.Left))
+                    yield return leftPart;
+
+                foreach (var rightPart in SplitConstraintByOperators(binaryExpression.Right))
+                    yield return rightPart;
+            }
+            else
+            {
+                yield return constraintExpression;
+            }
+        }
+    }
+}

--- a/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs
+++ b/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs
@@ -1,17 +1,15 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
-using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Helpers;
 
 namespace NUnit.Analyzers.SameActualExpectedValue
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SameActualExpectedValueAnalyzer : DiagnosticAnalyzer
+    public class SameActualExpectedValueAnalyzer : BaseAssertionAnalyzer
     {
         private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
             AnalyzerIdentifiers.SameActualExpectedValue,
@@ -23,84 +21,23 @@ namespace NUnit.Analyzers.SameActualExpectedValue
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
+            InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
         {
-            context.EnableConcurrentExecution();
-
-            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
-        }
-
-        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
-        {
-            if (!(context.Node is InvocationExpressionSyntax invocationSyntax))
-                return;
-
-            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax).Symbol as IMethodSymbol;
-
-            if (methodSymbol == null
-                || !methodSymbol.ContainingType.IsAssert()
-                || methodSymbol.Name != NunitFrameworkConstants.NameOfAssertThat
-                || methodSymbol.Parameters.Length < 2)
+            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(assertExpression,
+                out var actualExpression, out var constraintExpression))
             {
                 return;
             }
 
-            var actualExpression = invocationSyntax.ArgumentList.Arguments[0].Expression;
-            var constraintExpression = invocationSyntax.ArgumentList.Arguments[1].Expression;
+            var expectedExpressions = AssertExpressionHelper.GetExpectedArguments(constraintExpression, context.SemanticModel);
+            var sameExpectedExpressions = expectedExpressions.Where(e => e.expectedArgument.IsEquivalentTo(actualExpression));
 
-            var expectedExpressions = GetExpectedArgumentsFromConstraintExpression(constraintExpression, context.SemanticModel);
-            var sameExpectedExpressions = expectedExpressions.Where(e => e.IsEquivalentTo(actualExpression));
-
-            foreach (var expected in sameExpectedExpressions)
+            foreach (var (expected, _) in sameExpectedExpressions)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     descriptor,
                     expected.GetLocation()));
-            }
-        }
-
-        private static List<ExpressionSyntax> GetExpectedArgumentsFromConstraintExpression(ExpressionSyntax constraintExpression, SemanticModel semanticModel)
-        {
-            var expectedArguments = new List<ExpressionSyntax>();
-
-            var constraintParts = SplitConstraintByOperators(constraintExpression);
-
-            foreach (var constraintPart in constraintParts)
-            {
-                var invocations = constraintPart.SplitCallChain()
-                    .OfType<InvocationExpressionSyntax>()
-                    .Where(i => i.ArgumentList.Arguments.Count == 1);
-
-                foreach (var invocation in invocations)
-                {
-                    var symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
-
-                    if (symbol is IMethodSymbol methodSymbol
-                        && methodSymbol.Parameters.Length == 1
-                        && methodSymbol.Parameters[0].Name == NunitFrameworkConstants.NameOfExpectedParameter)
-                    {
-                        var argument = invocation.ArgumentList.Arguments[0];
-                        expectedArguments.Add(argument.Expression);
-                    }
-                }
-            }
-
-            return expectedArguments;
-        }
-
-        private static IEnumerable<ExpressionSyntax> SplitConstraintByOperators(ExpressionSyntax constraintExpression)
-        {
-            if (constraintExpression is BinaryExpressionSyntax binaryExpression)
-            {
-                foreach (var leftPart in SplitConstraintByOperators(binaryExpression.Left))
-                    yield return leftPart;
-
-                foreach (var rightPart in SplitConstraintByOperators(binaryExpression.Right))
-                    yield return rightPart;
-            }
-            else
-            {
-                yield return constraintExpression;
             }
         }
     }


### PR DESCRIPTION
Fix #134

Added abstract class `BaseAssertionAnalyzer`, which has abstract method `AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol);` to avoid checks that expression is actually assert in each analyzer.

Added helper class `AssertExpressionHelper` with methods to get actual and constraint arguments, get expected values from constraint expression, split constraint by operators.