### PR TITLE
Partition the analyzers into categories

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
                 Assert.That(diagnostic.MessageFormat.ToString(), Is.EqualTo(ClassicModelUsageAnalyzerConstants.Message),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.MessageFormat)}");
-                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Usage),
+                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Assertion),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
                 Assert.That(diagnostic.DefaultSeverity, Is.EqualTo(DiagnosticSeverity.Warning),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.DefaultSeverity)}");

--- a/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.ParallelizableUsage
             {
                 Assert.That(diagnostic.Title.ToString(), Is.EqualTo(ParallelizableUsageAnalyzerConstants.Title),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
-                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Usage),
+                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Structure),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
             }
 

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
             {
                 Assert.That(diagnostic.Title.ToString(), Is.EqualTo(TestCaseUsageAnalyzerConstants.Title),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
-                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Usage),
+                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Structure),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
                 Assert.That(diagnostic.DefaultSeverity, Is.EqualTo(DiagnosticSeverity.Error),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.DefaultSeverity)}");

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
             {
                 Assert.That(diagnostic.Title.ToString(), Is.EqualTo(TestMethodUsageAnalyzerConstants.Title),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
-                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Usage),
+                Assert.That(diagnostic.Category, Is.EqualTo(Categories.Structure),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
                 Assert.That(diagnostic.DefaultSeverity, Is.EqualTo(DiagnosticSeverity.Error),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.DefaultSeverity)}");

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -27,7 +27,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 
         private static DiagnosticDescriptor CreateDescriptor(string identifier) =>
             new DiagnosticDescriptor(identifier, ClassicModelUsageAnalyzerConstants.Title,
-                ClassicModelUsageAnalyzerConstants.Message, Categories.Usage,
+                ClassicModelUsageAnalyzerConstants.Message, Categories.Assertion,
                 DiagnosticSeverity.Warning, true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.name.Values.ToImmutableArray();

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -16,7 +16,7 @@ namespace NUnit.Analyzers.ConstActualValueUsage
             AnalyzerIdentifiers.ConstActualValueUsage,
             ConstActualValueUsageAnalyzerConstants.Title,
             ConstActualValueUsageAnalyzerConstants.Message,
-            Categories.Usage,
+            Categories.Assertion,
             DiagnosticSeverity.Warning,
             true);
 

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -2,28 +2,37 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class AnalyzerIdentifiers
     {
-        internal const string FalseUsage = "NUNIT_1";
-        internal const string IsFalseUsage = "NUNIT_2";
-        internal const string IsTrueUsage = "NUNIT_3";
-        internal const string TrueUsage = "NUNIT_4";
-        internal const string AreEqualUsage = "NUNIT_5";
-        internal const string AreNotEqualUsage = "NUNIT_6";
-        internal const string TestCaseParameterTypeMismatchUsage = "NUNIT_7";
-        internal const string TestCaseSourceStringUsage = "NUNIT_8";
-        internal const string TestCaseNotEnoughArgumentsUsage = "NUNIT_9";
-        internal const string TestCaseTooManyArgumentsUsage = "NUNIT_10";
-        internal const string TestMethodExpectedResultTypeMismatchUsage = "NUNIT_11";
-        internal const string TestMethodSpecifiedExpectedResultForVoidUsage = "NUNIT_12";
-        internal const string TestMethodNoExpectedResultButNonVoidReturnType = "NUNIT_13";
-        internal const string ParallelScopeSelfNoEffectOnAssemblyUsage = "NUNIT_14";
-        internal const string ParallelScopeChildrenOnNonParameterizedTestMethodUsage = "NUNIT_15";
-        internal const string ParallelScopeFixturesOnTestMethodUsage = "NUNIT_16";
-        internal const string TestCaseSourceIsMissing = "NUNIT_17";
-        internal const string ConstActualValueUsage = "NUNIT_18";
-        internal const string TestMethodAsyncNoExpectedResultAndVoidReturnTypeUsage = "NUNIT_19";
-        internal const string TestMethodAsyncNoExpectedResultAndNonTaskReturnTypeUsage = "NUNIT_20";
-        internal const string TestMethodAsyncExpectedResultAndNonGenricTaskReturnTypeUsage = "NUNIT_21";
-        internal const string IgnoreCaseUsage = "NUNIT_22";
-        internal const string SameActualExpectedValue = "NUNIT_23";
+        #region Structure
+
+        internal const string TestCaseParameterTypeMismatchUsage = "NUnit1001";
+        internal const string TestCaseSourceStringUsage = "NUnit1002";
+        internal const string TestCaseNotEnoughArgumentsUsage = "NUnit1003";
+        internal const string TestCaseTooManyArgumentsUsage = "NUnit1004";
+        internal const string TestMethodExpectedResultTypeMismatchUsage = "NUnit1005";
+        internal const string TestMethodSpecifiedExpectedResultForVoidUsage = "NUnit1006";
+        internal const string TestMethodNoExpectedResultButNonVoidReturnType = "NUnit1007";
+        internal const string ParallelScopeSelfNoEffectOnAssemblyUsage = "NUnit1008";
+        internal const string ParallelScopeChildrenOnNonParameterizedTestMethodUsage = "NUnit1009";
+        internal const string ParallelScopeFixturesOnTestMethodUsage = "NUnit1010";
+        internal const string TestCaseSourceIsMissing = "NUnit1011";
+        internal const string TestMethodAsyncNoExpectedResultAndVoidReturnTypeUsage = "NUnit1012";
+        internal const string TestMethodAsyncNoExpectedResultAndNonTaskReturnTypeUsage = "NUnit1013";
+        internal const string TestMethodAsyncExpectedResultAndNonGenricTaskReturnTypeUsage = "NUnit1014";
+
+        #endregion Structure
+
+        #region Assertion
+
+        internal const string FalseUsage = "NUnit2001";
+        internal const string IsFalseUsage = "NUnit2002";
+        internal const string IsTrueUsage = "NUnit2003";
+        internal const string TrueUsage = "NUnit2004";
+        internal const string AreEqualUsage = "NUnit2005";
+        internal const string AreNotEqualUsage = "NUnit2006";
+        internal const string ConstActualValueUsage = "NUnit2007";
+        internal const string IgnoreCaseUsage = "NUnit2008";
+        internal const string SameActualExpectedValue = "NUnit2009";
+
+        #endregion Assertion
     }
 }

--- a/src/nunit.analyzers/Constants/Categories.cs
+++ b/src/nunit.analyzers/Constants/Categories.cs
@@ -2,6 +2,7 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class Categories
     {
-        internal const string Usage = "Usage";
+        internal const string Structure = nameof(Structure);
+        internal const string Assertion = nameof(Assertion);
     }
 }

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -25,7 +25,7 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
             AnalyzerIdentifiers.IgnoreCaseUsage,
             IgnoreCaseUsageAnalyzerConstants.Title,
             IgnoreCaseUsageAnalyzerConstants.Message,
-            Categories.Usage,
+            Categories.Assertion,
             DiagnosticSeverity.Warning,
             true);
 

--- a/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
@@ -16,7 +16,7 @@ namespace NUnit.Analyzers.ParallelizableUsage
 
         private static DiagnosticDescriptor CreateDescriptor(string id, string message, DiagnosticSeverity severity) =>
             new DiagnosticDescriptor(id, ParallelizableUsageAnalyzerConstants.Title,
-                message, Categories.Usage, severity, true);
+                message, Categories.Structure, severity, true);
 
         private static readonly DiagnosticDescriptor scopeSelfNoEffectOnAssemblyUsage =
             ParallelizableUsageAnalyzer.CreateDescriptor(

--- a/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs
+++ b/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs
@@ -17,7 +17,7 @@ namespace NUnit.Analyzers.SameActualExpectedValue
             AnalyzerIdentifiers.SameActualExpectedValue,
             SameActualExpectedValueAnalyzerConstants.Title,
             SameActualExpectedValueAnalyzerConstants.Message,
-            Categories.Usage,
+            Categories.Structure,
             DiagnosticSeverity.Warning,
             true);
 

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -14,7 +14,7 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
             AnalyzerIdentifiers.TestCaseSourceIsMissing,
             "TestCaseSource argument does not specify an existing member.",
             "TestCaseSource argument does not specify an existing member.",
-            Categories.Usage,
+            Categories.Structure,
             DiagnosticSeverity.Error,
             true);
 
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
                 AnalyzerIdentifiers.TestCaseSourceStringUsage,
                 TestCaseSourceUsageConstants.ConsiderNameOfInsteadOfStringConstantAnalyzerTitle,
                 message,
-                Categories.Usage,
+                Categories.Structure,
                 DiagnosticSeverity.Warning,
                 true);
 

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -15,7 +15,7 @@ namespace NUnit.Analyzers.TestCaseUsage
     {
         private static DiagnosticDescriptor CreateDescriptor(string id, string message) =>
             new DiagnosticDescriptor(id, TestCaseUsageAnalyzerConstants.Title,
-                message, Categories.Usage, DiagnosticSeverity.Error, true);
+                message, Categories.Structure, DiagnosticSeverity.Error, true);
 
         private static readonly DiagnosticDescriptor notEnoughArguments =
             TestCaseUsageAnalyzer.CreateDescriptor(

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -17,7 +17,7 @@ namespace NUnit.Analyzers.TestCaseUsage
 
         private static DiagnosticDescriptor CreateDescriptor(string id, string message) =>
             new DiagnosticDescriptor(id, TestMethodUsageAnalyzerConstants.Title,
-                message, Categories.Usage, DiagnosticSeverity.Error, true);
+                message, Categories.Structure, DiagnosticSeverity.Error, true);
 
         private static readonly DiagnosticDescriptor expectedResultTypeMismatch = TestMethodUsageAnalyzer.CreateDescriptor(
             AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,


### PR DESCRIPTION
Fix #84

Changed Categories to `Structure` and `Assertion`.

Changed analyzer identifiers according to rule: `NUnitxxxx`
Structure - Range from 1000 to 1999. 
Assertion - Range from 2000 to 2999. 