### PR TITLE
Tests checking documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,14 @@ Prerelease nuget packages can be found on [MyGet](https://www.myget.org/feed/nun
 
 ## Analyzers ##
 
-| Id       | Title
-| :--      | :--
-| [NUnit1001]()| Find Incorrect TestCaseAttribute Usage
-| [NUnit1002]()| Find TestCaseSource(StringConstant) Usage
-| [NUnit1003]()| Find Incorrect TestCaseAttribute Usage
-| [NUnit1004]()| Find Incorrect TestCaseAttribute Usage
-| [NUnit1005]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
-| [NUnit1006]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
-| [NUnit1007]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
-| [NUnit1008]()| Find Incorrect ParallelizableAttribute Usage
-| [NUnit1009]()| Find Incorrect ParallelizableAttribute Usage
-| [NUnit1010]()| Find Incorrect ParallelizableAttribute Usage
-| [NUnit1011]()| TestCaseSource argument does not specify an existing member.
-| [NUnit1012]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
-| [NUnit1013]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
-| [NUnit1014]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
-| [NUnit2001]()| Find Classic Assertion Usage
-| [NUnit2002]()| Find Classic Assertion Usage
-| [NUnit2003]()| Find Classic Assertion Usage
-| [NUnit2004]()| Find Classic Assertion Usage
-| [NUnit2005]()| Find Classic Assertion Usage
-| [NUnit2006]()| Find Classic Assertion Usage
-| [NUnit2007]()| Actual value should not be constant
-| [NUnit2008]()| Find incorrect IgnoreCase usage
-| [NUnit2009]()| Find same value provided as actual and expected argument
+The full list of analyzers can be found in the [documentation](documentation/index.md).
 
-Below we give two examples of analyzers. One will look for methods with the `[TestCase]` attribute and makes sure the argument values are correct for the types of the method parameters along with the `ExpectedResult` value if it is provided. 
-<!-- ![testcase](https://user-images.githubusercontent.com/1007631/44311794-269a7200-a3ee-11e8-86a0-1d290b355ac5.gif) -->
+Below we give two examples of analyzers. One will look for methods with the `[TestCase]` attribute and makes sure the argument values are correct for the types of the method parameters along with the `ExpectedResult` value if it is provided.
+
 <img src="https://user-images.githubusercontent.com/1007631/44311794-269a7200-a3ee-11e8-86a0-1d290b355ac5.gif" alt="testcase analyzers" width="750"/>
 
 The other analyzer looks for classic model assertions (e.g. `Assert.AreEqual()`, `Assert.IsTrue()`, etc.). This analyzer contains a fixer that can translate the classic model assertions into constraint model assertions (`Assert.That()`).
+
 <img src="https://user-images.githubusercontent.com/1007631/44311791-213d2780-a3ee-11e8-90b8-6d144c0e3dbd.gif" alt="classic model assertions analyzers" width="1000"/>
 
 ## License ##

--- a/README.md
+++ b/README.md
@@ -11,13 +11,38 @@ Prerelease nuget packages can be found on [MyGet](https://www.myget.org/feed/nun
 
 ## Analyzers ##
 
+| Id       | Title
+| :--      | :--
+| [NUnit1001]()| Find Incorrect TestCaseAttribute Usage
+| [NUnit1002]()| Find TestCaseSource(StringConstant) Usage
+| [NUnit1003]()| Find Incorrect TestCaseAttribute Usage
+| [NUnit1004]()| Find Incorrect TestCaseAttribute Usage
+| [NUnit1005]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1006]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1007]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1008]()| Find Incorrect ParallelizableAttribute Usage
+| [NUnit1009]()| Find Incorrect ParallelizableAttribute Usage
+| [NUnit1010]()| Find Incorrect ParallelizableAttribute Usage
+| [NUnit1011]()| TestCaseSource argument does not specify an existing member.
+| [NUnit1012]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1013]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1014]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit2001]()| Find Classic Assertion Usage
+| [NUnit2002]()| Find Classic Assertion Usage
+| [NUnit2003]()| Find Classic Assertion Usage
+| [NUnit2004]()| Find Classic Assertion Usage
+| [NUnit2005]()| Find Classic Assertion Usage
+| [NUnit2006]()| Find Classic Assertion Usage
+| [NUnit2007]()| Actual value should not be constant
+| [NUnit2008]()| Find incorrect IgnoreCase usage
+| [NUnit2009]()| Find same value provided as actual and expected argument
+
 Below we give two examples of analyzers. One will look for methods with the `[TestCase]` attribute and makes sure the argument values are correct for the types of the method parameters along with the `ExpectedResult` value if it is provided. 
 <!-- ![testcase](https://user-images.githubusercontent.com/1007631/44311794-269a7200-a3ee-11e8-86a0-1d290b355ac5.gif) -->
 <img src="https://user-images.githubusercontent.com/1007631/44311794-269a7200-a3ee-11e8-86a0-1d290b355ac5.gif" alt="testcase analyzers" width="750"/>
 
 The other analyzer looks for classic model assertions (e.g. `Assert.AreEqual()`, `Assert.IsTrue()`, etc.). This analyzer contains a fixer that can translate the classic model assertions into constraint model assertions (`Assert.That()`).
 <img src="https://user-images.githubusercontent.com/1007631/44311791-213d2780-a3ee-11e8-90b8-6d144c0e3dbd.gif" alt="classic model assertions analyzers" width="1000"/>
-
 
 ## License ##
 

--- a/documentation/NUnit1001.md
+++ b/documentation/NUnit1001.md
@@ -1,0 +1,51 @@
+# NUnit1001
+## Find Incorrect TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1001
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestCaseUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1001 // Find Incorrect TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1001 // Find Incorrect TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1001 // Find Incorrect TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1001:Find Incorrect TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1002.md
+++ b/documentation/NUnit1002.md
@@ -1,0 +1,51 @@
+# NUnit1002
+## Find TestCaseSource(StringConstant) Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1002
+| Severity | Warning
+| Enabled  | True
+| Category | Structure
+| Code     | [TestCaseSourceUsesStringAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1002 // Find TestCaseSource(StringConstant) Usage
+Code violating the rule here
+#pragma warning restore NUnit1002 // Find TestCaseSource(StringConstant) Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1002 // Find TestCaseSource(StringConstant) Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1002:Find TestCaseSource(StringConstant) Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1003.md
+++ b/documentation/NUnit1003.md
@@ -1,0 +1,51 @@
+# NUnit1003
+## Find Incorrect TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1003
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestCaseUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1003 // Find Incorrect TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1003 // Find Incorrect TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1003 // Find Incorrect TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1003:Find Incorrect TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1004.md
+++ b/documentation/NUnit1004.md
@@ -1,0 +1,51 @@
+# NUnit1004
+## Find Incorrect TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1004
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestCaseUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1004 // Find Incorrect TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1004 // Find Incorrect TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1004 // Find Incorrect TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1004:Find Incorrect TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1005.md
+++ b/documentation/NUnit1005.md
@@ -1,0 +1,51 @@
+# NUnit1005
+## Find Incorrect TestAttribute or TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1005
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestMethodUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1005 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1005 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1005 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1005:Find Incorrect TestAttribute or TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1006.md
+++ b/documentation/NUnit1006.md
@@ -1,0 +1,51 @@
+# NUnit1006
+## Find Incorrect TestAttribute or TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1006
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestMethodUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1006 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1006 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1006 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1006:Find Incorrect TestAttribute or TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1007.md
+++ b/documentation/NUnit1007.md
@@ -1,0 +1,51 @@
+# NUnit1007
+## Find Incorrect TestAttribute or TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1007
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestMethodUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1007 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1007 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1007 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1007:Find Incorrect TestAttribute or TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1008.md
+++ b/documentation/NUnit1008.md
@@ -1,0 +1,51 @@
+# NUnit1008
+## Find Incorrect ParallelizableAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1008
+| Severity | Warning
+| Enabled  | True
+| Category | Structure
+| Code     | [ParallelizableUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1008 // Find Incorrect ParallelizableAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1008 // Find Incorrect ParallelizableAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1008 // Find Incorrect ParallelizableAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1008:Find Incorrect ParallelizableAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1009.md
+++ b/documentation/NUnit1009.md
@@ -1,0 +1,51 @@
+# NUnit1009
+## Find Incorrect ParallelizableAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1009
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [ParallelizableUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1009 // Find Incorrect ParallelizableAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1009 // Find Incorrect ParallelizableAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1009 // Find Incorrect ParallelizableAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1009:Find Incorrect ParallelizableAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1010.md
+++ b/documentation/NUnit1010.md
@@ -1,0 +1,51 @@
+# NUnit1010
+## Find Incorrect ParallelizableAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1010
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [ParallelizableUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1010 // Find Incorrect ParallelizableAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1010 // Find Incorrect ParallelizableAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1010 // Find Incorrect ParallelizableAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1010:Find Incorrect ParallelizableAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1011.md
+++ b/documentation/NUnit1011.md
@@ -1,0 +1,51 @@
+# NUnit1011
+## TestCaseSource argument does not specify an existing member.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1011
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestCaseSourceUsesStringAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1011 // TestCaseSource argument does not specify an existing member.
+Code violating the rule here
+#pragma warning restore NUnit1011 // TestCaseSource argument does not specify an existing member.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1011 // TestCaseSource argument does not specify an existing member.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1011:TestCaseSource argument does not specify an existing member.", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1012.md
+++ b/documentation/NUnit1012.md
@@ -1,0 +1,51 @@
+# NUnit1012
+## Find Incorrect TestAttribute or TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1012
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestMethodUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1012 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1012 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1012 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1012:Find Incorrect TestAttribute or TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1013.md
+++ b/documentation/NUnit1013.md
@@ -1,0 +1,51 @@
+# NUnit1013
+## Find Incorrect TestAttribute or TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1013
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestMethodUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1013 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1013 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1013 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1013:Find Incorrect TestAttribute or TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit1014.md
+++ b/documentation/NUnit1014.md
@@ -1,0 +1,51 @@
+# NUnit1014
+## Find Incorrect TestAttribute or TestCaseAttribute Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1014
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [TestMethodUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit1014 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+Code violating the rule here
+#pragma warning restore NUnit1014 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit1014 // Find Incorrect TestAttribute or TestCaseAttribute Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit1014:Find Incorrect TestAttribute or TestCaseAttribute Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2001.md
+++ b/documentation/NUnit2001.md
@@ -1,0 +1,51 @@
+# NUnit2001
+## Find Classic Assertion Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2001
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2001 // Find Classic Assertion Usage
+Code violating the rule here
+#pragma warning restore NUnit2001 // Find Classic Assertion Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2001 // Find Classic Assertion Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2001:Find Classic Assertion Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2002.md
+++ b/documentation/NUnit2002.md
@@ -1,0 +1,51 @@
+# NUnit2002
+## Find Classic Assertion Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2002
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2002 // Find Classic Assertion Usage
+Code violating the rule here
+#pragma warning restore NUnit2002 // Find Classic Assertion Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2002 // Find Classic Assertion Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2002:Find Classic Assertion Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2003.md
+++ b/documentation/NUnit2003.md
@@ -1,0 +1,51 @@
+# NUnit2003
+## Find Classic Assertion Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2003
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2003 // Find Classic Assertion Usage
+Code violating the rule here
+#pragma warning restore NUnit2003 // Find Classic Assertion Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2003 // Find Classic Assertion Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2003:Find Classic Assertion Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2004.md
+++ b/documentation/NUnit2004.md
@@ -1,0 +1,51 @@
+# NUnit2004
+## Find Classic Assertion Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2004
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2004 // Find Classic Assertion Usage
+Code violating the rule here
+#pragma warning restore NUnit2004 // Find Classic Assertion Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2004 // Find Classic Assertion Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2004:Find Classic Assertion Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2005.md
+++ b/documentation/NUnit2005.md
@@ -1,0 +1,51 @@
+# NUnit2005
+## Find Classic Assertion Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2005
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2005 // Find Classic Assertion Usage
+Code violating the rule here
+#pragma warning restore NUnit2005 // Find Classic Assertion Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2005 // Find Classic Assertion Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2005:Find Classic Assertion Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2006.md
+++ b/documentation/NUnit2006.md
@@ -1,0 +1,51 @@
+# NUnit2006
+## Find Classic Assertion Usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2006
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2006 // Find Classic Assertion Usage
+Code violating the rule here
+#pragma warning restore NUnit2006 // Find Classic Assertion Usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2006 // Find Classic Assertion Usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2006:Find Classic Assertion Usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2007.md
+++ b/documentation/NUnit2007.md
@@ -1,0 +1,51 @@
+# NUnit2007
+## Actual value should not be constant
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2007
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ConstActualValueUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2007 // Actual value should not be constant
+Code violating the rule here
+#pragma warning restore NUnit2007 // Actual value should not be constant
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2007 // Actual value should not be constant
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2007:Actual value should not be constant", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2008.md
+++ b/documentation/NUnit2008.md
@@ -1,0 +1,51 @@
+# NUnit2008
+## Find incorrect IgnoreCase usage
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2008
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [IgnoreCaseUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2008 // Find incorrect IgnoreCase usage
+Code violating the rule here
+#pragma warning restore NUnit2008 // Find incorrect IgnoreCase usage
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2008 // Find incorrect IgnoreCase usage
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2008:Find incorrect IgnoreCase usage", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2009.md
+++ b/documentation/NUnit2009.md
@@ -1,0 +1,51 @@
+# NUnit2009
+## Find same value provided as actual and expected argument
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2009
+| Severity | Warning
+| Enabled  | True
+| Category | Structure
+| Code     | [SameActualExpectedValueAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs)
+
+
+## Description
+
+
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2009 // Find same value provided as actual and expected argument
+Code violating the rule here
+#pragma warning restore NUnit2009 // Find same value provided as actual and expected argument
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2009 // Find same value provided as actual and expected argument
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", 
+    "NUnit2009:Find same value provided as actual and expected argument", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,0 +1,28 @@
+# Analyzers #
+
+| Id       | Title
+| :--      | :--
+| [NUnit1001]()| Find Incorrect TestCaseAttribute Usage
+| [NUnit1002]()| Find TestCaseSource(StringConstant) Usage
+| [NUnit1003]()| Find Incorrect TestCaseAttribute Usage
+| [NUnit1004]()| Find Incorrect TestCaseAttribute Usage
+| [NUnit1005]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1006]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1007]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1008]()| Find Incorrect ParallelizableAttribute Usage
+| [NUnit1009]()| Find Incorrect ParallelizableAttribute Usage
+| [NUnit1010]()| Find Incorrect ParallelizableAttribute Usage
+| [NUnit1011]()| TestCaseSource argument does not specify an existing member.
+| [NUnit1012]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1013]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit1014]()| Find Incorrect TestAttribute or TestCaseAttribute Usage
+| [NUnit2001]()| Find Classic Assertion Usage
+| [NUnit2002]()| Find Classic Assertion Usage
+| [NUnit2003]()| Find Classic Assertion Usage
+| [NUnit2004]()| Find Classic Assertion Usage
+| [NUnit2005]()| Find Classic Assertion Usage
+| [NUnit2006]()| Find Classic Assertion Usage
+| [NUnit2007]()| Actual value should not be constant
+| [NUnit2008]()| Find incorrect IgnoreCase usage
+| [NUnit2009]()| Find same value provided as actual and expected argument
+

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -1,12 +1,41 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28922.388
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit.analyzers", "nunit.analyzers\nunit.analyzers.csproj", "{74151914-3C12-4EAC-8FD5-5766EBEA35A3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.analyzers", "nunit.analyzers\nunit.analyzers.csproj", "{74151914-3C12-4EAC-8FD5-5766EBEA35A3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit.analyzers.vsix", "nunit.analyzers.vsix\nunit.analyzers.vsix.csproj", "{5D87311B-74DE-4DF9-BCC3-E14D8EE4E7B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit.analyzers.tests", "nunit.analyzers.tests\nunit.analyzers.tests.csproj", "{070974CB-B483-4347-BA5A-53ED977E639C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.analyzers.tests", "nunit.analyzers.tests\nunit.analyzers.tests.csproj", "{070974CB-B483-4347-BA5A-53ED977E639C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-35D4-432A-9F93-810A0AAEA128}"
+	ProjectSection(SolutionItems) = preProject
+		..\documentation\NUnit1001.md = ..\documentation\NUnit1001.md
+		..\documentation\NUnit1002.md = ..\documentation\NUnit1002.md
+		..\documentation\NUnit1003.md = ..\documentation\NUnit1003.md
+		..\documentation\NUnit1004.md = ..\documentation\NUnit1004.md
+		..\documentation\NUnit1005.md = ..\documentation\NUnit1005.md
+		..\documentation\NUnit1006.md = ..\documentation\NUnit1006.md
+		..\documentation\NUnit1007.md = ..\documentation\NUnit1007.md
+		..\documentation\NUnit1008.md = ..\documentation\NUnit1008.md
+		..\documentation\NUnit1009.md = ..\documentation\NUnit1009.md
+		..\documentation\NUnit1010.md = ..\documentation\NUnit1010.md
+		..\documentation\NUnit1011.md = ..\documentation\NUnit1011.md
+		..\documentation\NUnit1012.md = ..\documentation\NUnit1012.md
+		..\documentation\NUnit1013.md = ..\documentation\NUnit1013.md
+		..\documentation\NUnit1014.md = ..\documentation\NUnit1014.md
+		..\documentation\NUnit2001.md = ..\documentation\NUnit2001.md
+		..\documentation\NUnit2002.md = ..\documentation\NUnit2002.md
+		..\documentation\NUnit2003.md = ..\documentation\NUnit2003.md
+		..\documentation\NUnit2004.md = ..\documentation\NUnit2004.md
+		..\documentation\NUnit2005.md = ..\documentation\NUnit2005.md
+		..\documentation\NUnit2006.md = ..\documentation\NUnit2006.md
+		..\documentation\NUnit2007.md = ..\documentation\NUnit2007.md
+		..\documentation\NUnit2008.md = ..\documentation\NUnit2008.md
+		..\documentation\NUnit2009.md = ..\documentation\NUnit2009.md
+		..\README.md = ..\README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -1,0 +1,335 @@
+namespace NUnit.Analyzers.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Gu.Roslyn.Asserts;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using NUnit.Framework;
+
+    public class DocumentationTests
+    {
+        private static readonly IReadOnlyList<DiagnosticAnalyzer> Analyzers = typeof(BaseAssertionAnalyzer)
+                                                                              .Assembly
+                                                                              .GetTypes()
+                                                                              .Where(t => typeof(DiagnosticAnalyzer).IsAssignableFrom(t) && !t.IsAbstract)
+                                                                              .OrderBy(x => x.Name)
+                                                                              .Select(t => (DiagnosticAnalyzer)Activator.CreateInstance(t))
+                                                                              .ToArray();
+
+        private static readonly IReadOnlyList<DescriptorInfo> DescriptorInfos = Analyzers
+                                                                                .SelectMany(DescriptorInfo.Create)
+                                                                                .ToArray();
+
+        private static IReadOnlyList<DescriptorInfo> DescriptorsWithDocs => DescriptorInfos.Where(d => d.DocumentationFile.Exists)
+                                                                                           .ToArray();
+
+        private static DirectoryInfo RepositoryDirectory => SolutionFile.Find("nunit.analyzers.sln").Directory.Parent;
+
+        private static DirectoryInfo DocumentsDirectory => RepositoryDirectory.EnumerateDirectories("documentation", SearchOption.TopDirectoryOnly).Single();
+
+        [TestCaseSource(nameof(DescriptorInfos))]
+        public void MissingDocs(DescriptorInfo descriptorInfo)
+        {
+            if (!descriptorInfo.DocumentationFile.Exists)
+            {
+                var descriptor = descriptorInfo.Descriptor;
+                var id = descriptor.Id;
+                DumpIfDebug(descriptorInfo.Stub);
+                File.WriteAllText(descriptorInfo.DocumentationFile.Name + ".generated", descriptorInfo.Stub);
+                Assert.Fail($"Documentation is missing for {id}");
+            }
+        }
+
+        [TestCaseSource(nameof(DescriptorInfos))]
+        public void UniqueIds(DescriptorInfo descriptorInfo)
+        {
+            Assert.AreEqual(1, DescriptorInfos.Select(x => x.Descriptor)
+                                              .Distinct()
+                                              .Count(d => d.Id == descriptorInfo.Descriptor.Id));
+        }
+
+        [TestCaseSource(nameof(DescriptorsWithDocs))]
+        public void TitleId(DescriptorInfo descriptorInfo)
+        {
+            Assert.AreEqual($"# {descriptorInfo.Descriptor.Id}", descriptorInfo.DocumentationFile.AllLines.First());
+        }
+
+        [TestCaseSource(nameof(DescriptorsWithDocs))]
+        public void Title(DescriptorInfo descriptorInfo)
+        {
+            var expected = $"## {descriptorInfo.Descriptor.Title}";
+            var actual = descriptorInfo.DocumentationFile.AllLines
+                                       .Skip(1)
+                                       .First()
+                                       .Replace("`", string.Empty);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Explicit("No descriptions. Remove this test and update doc stubs if we don't want descriptions.")]
+        [TestCaseSource(nameof(DescriptorsWithDocs))]
+        public void Description(DescriptorInfo descriptorInfo)
+        {
+            Assert.Inconclusive("VS test runner does not filter out [Explicit]");
+            var expected = descriptorInfo.Descriptor
+                                         .Description
+                                         .ToString(CultureInfo.InvariantCulture)
+                                         .Split('\n')
+                                         .First();
+            var actual = descriptorInfo.DocumentationFile.AllLines
+                                       .SkipWhile(l => !l.StartsWith("## Description", StringComparison.OrdinalIgnoreCase))
+                                       .Skip(1)
+                                       .FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))
+                                       ?.Replace("`", string.Empty);
+
+            DumpIfDebug(expected);
+            DumpIfDebug(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCaseSource(nameof(DescriptorsWithDocs))]
+        public void Table(DescriptorInfo descriptorInfo)
+        {
+            const string HeaderRow = "| Topic    | Value";
+            var expected = GetTable(descriptorInfo.Stub, HeaderRow);
+            DumpIfDebug(expected);
+            var actual = GetTable(descriptorInfo.DocumentationFile.AllText, HeaderRow);
+            CodeAssert.AreEqual(expected, actual);
+        }
+
+        [TestCaseSource(nameof(DescriptorsWithDocs))]
+        public void ConfigSeverity(DescriptorInfo descriptorInfo)
+        {
+            var expected = GetConfigSeverity(descriptorInfo.Stub);
+            DumpIfDebug(expected);
+            var actual = GetConfigSeverity(descriptorInfo.DocumentationFile.AllText);
+            CodeAssert.AreEqual(expected, actual);
+
+            string GetConfigSeverity(string doc)
+            {
+                return GetSection(doc, "<!-- start generated config severity -->", "<!-- end generated config severity -->");
+            }
+
+            string GetSection(string doc, string startToken, string endToken)
+            {
+                var start = doc.IndexOf(startToken, StringComparison.Ordinal);
+                var end = doc.IndexOf(endToken, StringComparison.Ordinal) + endToken.Length;
+                return doc.Substring(start, end - start);
+            }
+        }
+
+        [Test]
+        public void Index()
+        {
+            var builder = new StringBuilder();
+            const string HeaderRow = "| Id       | Title";
+            builder.AppendLine(HeaderRow)
+                   .AppendLine("| :--      | :--");
+            foreach (var descriptor in DescriptorsWithDocs.Select(x => x.Descriptor)
+                                                          .Distinct()
+                                                          .OrderBy(x => x.Id))
+            {
+                builder.Append($"| [{descriptor.Id}]({descriptor.HelpLinkUri})")
+                       .AppendLine($"| {descriptor.Title}");
+            }
+
+            var expected = builder.ToString();
+            DumpIfDebug(expected);
+            var actual = GetTable(File.ReadAllText(Path.Combine(RepositoryDirectory.FullName, "Readme.md")), HeaderRow);
+            CodeAssert.AreEqual(expected, actual);
+        }
+
+        private static string GetTable(string doc, string headerRow)
+        {
+            var startIndex = doc.IndexOf(headerRow);
+            if (startIndex < 0)
+            {
+                return string.Empty;
+            }
+
+            return doc.Substring(startIndex, TableLength());
+
+            int TableLength()
+            {
+                var length = 0;
+                while (startIndex + length < doc.Length)
+                {
+                    if (doc[startIndex + length] == '\n' &&
+                        doc.Length > startIndex + length &&
+                        doc[startIndex + length +1] != '|')
+                    {
+                        length++;
+                        return length;
+                    }
+
+                    length++;
+                }
+
+                return length;
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void DumpIfDebug(string text)
+        {
+            Console.Write(text);
+            Console.WriteLine();
+            Console.WriteLine();
+        }
+
+        public class DescriptorInfo
+        {
+            private DescriptorInfo(DiagnosticAnalyzer analyzer, DiagnosticDescriptor descriptor)
+            {
+                this.Analyzer = analyzer;
+                this.Descriptor = descriptor;
+                this.DocumentationFile = new MarkdownFile(Path.Combine(DocumentsDirectory.FullName, descriptor.Id + ".md"));
+                this.AnalyzerFile = CodeFile.Find(analyzer.GetType());
+                this.Stub = CreateStub(descriptor);
+            }
+
+            public DiagnosticAnalyzer Analyzer { get; }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public MarkdownFile DocumentationFile { get; }
+
+            public CodeFile AnalyzerFile { get; }
+
+            public string Stub { get; }
+
+            public static IEnumerable<DescriptorInfo> Create(DiagnosticAnalyzer analyzer)
+            {
+                foreach (var descriptor in analyzer.SupportedDiagnostics)
+                {
+                    yield return new DescriptorInfo(analyzer, descriptor);
+                }
+            }
+
+            public override string ToString() => this.Descriptor.Id;
+
+            private static string CreateStub(DiagnosticDescriptor descriptor)
+            {
+                var builder = new StringBuilder();
+                foreach (var analyzer in Analyzers.Where(x => x.SupportedDiagnostics.Any(d => d.Id == descriptor.Id)))
+                {
+                    _ = builder.Append($"|{(builder.Length == 0 ? " Code     " : "          ")}| ")
+                               .AppendLine($"[{analyzer.GetType().Name}]({CodeFile.Find(analyzer.GetType()).Uri})");
+                }
+
+                var text = builder.ToString();
+                var stub = $@"# {descriptor.Id}
+## {descriptor.Title.ToString(CultureInfo.InvariantCulture)}
+
+| Topic    | Value
+| :--      | :--
+| Id       | {descriptor.Id}
+| Severity | {descriptor.DefaultSeverity.ToString()}
+| Enabled  | {(descriptor.IsEnabledByDefault ? "True" : "False")}
+| Category | {descriptor.Category}
+| Code     | [<TYPENAME>](<URL>)
+
+
+## Description
+
+{descriptor.Description.ToString(CultureInfo.InvariantCulture)}
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable {descriptor.Id} // {descriptor.Title.ToString(CultureInfo.InvariantCulture)}
+Code violating the rule here
+#pragma warning restore {descriptor.Id} // {descriptor.Title.ToString(CultureInfo.InvariantCulture)}
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable {descriptor.Id} // {descriptor.Title.ToString(CultureInfo.InvariantCulture)}
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage(""{descriptor.Category}"", 
+    ""{descriptor.Id}:{descriptor.Title.ToString(CultureInfo.InvariantCulture)}"", 
+    Justification = ""Reason..."")]
+```
+<!-- end generated config severity -->";
+
+                return stub.Replace("| Code     | [<TYPENAME>](<URL>)\r\n", text)
+                           .Replace("| Code     | [<TYPENAME>](<URL>)\n", text);
+            }
+        }
+
+        public class MarkdownFile
+        {
+            public MarkdownFile(string name)
+            {
+                this.Name = name;
+                if (File.Exists(name))
+                {
+                    this.AllText = File.ReadAllText(name);
+                    this.AllLines = File.ReadAllLines(name);
+                }
+            }
+
+            public string Name { get; }
+
+            public bool Exists => File.Exists(this.Name);
+
+            public string AllText { get; }
+
+            public IReadOnlyList<string> AllLines { get; }
+        }
+
+        public class CodeFile
+        {
+            private static readonly ConcurrentDictionary<Type, CodeFile> Cache = new ConcurrentDictionary<Type, CodeFile>();
+
+            public CodeFile(string name)
+            {
+                this.Name = name;
+            }
+
+            public string Name { get; }
+
+            public string Uri => "https://github.com/nunit/nunit.analyzers/blob/master" + this.Name.Substring(RepositoryDirectory.FullName.Length).Replace("\\", "/");
+
+            public static CodeFile Find(Type type)
+            {
+                return Cache.GetOrAdd(type, x => FindCore(x.Name + ".cs"));
+            }
+
+            private static CodeFile FindCore(string name)
+            {
+                var fileName = Cache.Values.Select(x => Path.GetDirectoryName(x.Name))
+                                    .Distinct()
+                                    .SelectMany(d => Directory.EnumerateFiles(d, name, SearchOption.TopDirectoryOnly))
+                                    .FirstOrDefault() ??
+                               Directory.EnumerateFiles(RepositoryDirectory.FullName, name, SearchOption.AllDirectories)
+                                        .First();
+                return new CodeFile(fileName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
If a new analyzer is added with no documentation the test MissingDocs fails and creates a stub doc Id.md.generated.
Remove the .generated suffix and add it to the solution folder /docs
Not sure if the extra step with .generated suffix solves a problem but that is how I originally wrote it for some reason.

Currently the analyzers do not have Description, the stub docs have a `## Description` with an empty value and the test for description is set to [Explicit]. If no description is by design we should remove the test and the noise from the stub docs.

#96

We create help links in the analyzers so that clicking on the id in the VS error list navigates to the documentation. I can PR that later.

The code in this PR is not awesome, @jnm2 said it was fascinating, he is a polite man :) 