### PR TITLE
String boolean methods analyzer

### DIFF
--- a/documentation/NUnit2011.md
+++ b/documentation/NUnit2011.md
@@ -1,0 +1,74 @@
+# NUnit2011
+## Use ContainsConstraint.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2011
+| Severity | Info
+| Enabled  | True
+| Category | Assertion
+| Code     | [StringConstraintUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs)
+
+
+## Description
+
+Using constraints instead of boolean methods will lead to better assertion messages in case of failure.
+
+## Motivation
+
+Using `Does.Contain` (or `Does.Not.Contain`) constraint will lead to better assertion messages in case of failure, 
+so this analyzer marks all usages of string `Contains` method where it is possible to replace 
+with `Does.Contain` constraint.
+
+```csharp
+[Test]
+public void Test()
+{
+    string actual = "...";
+    string expected = "...";
+    Assert.True(actual.Contains(expected));
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.True(actual.Contains(expected))` with
+`Assert.That(actual, Does.Contain(expected))`. So the code block above will be changed into
+
+```csharp
+[Test]
+public void Test()
+{
+    string actual = "...";
+    string expected = "...";
+    Assert.That(actual, Does.Contain(expected));
+}
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2011 // Use ContainsConstraint.
+Code violating the rule here
+#pragma warning restore NUnit2011 // Use ContainsConstraint.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2011 // Use ContainsConstraint.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2011:Use ContainsConstraint.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2012.md
+++ b/documentation/NUnit2012.md
@@ -1,0 +1,74 @@
+# NUnit2012
+## Use StartsWithConstraint.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2012
+| Severity | Info
+| Enabled  | True
+| Category | Assertion
+| Code     | [StringConstraintUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs)
+
+
+## Description
+
+Using constraints instead of boolean methods will lead to better assertion messages in case of failure.
+
+## Motivation
+
+Using `Does.StartWith` (or `Does.Not.StartWith`) constraint will lead to better assertion messages in case of failure, 
+so this analyzer marks all usages of string `StartsWith` method where it is possible to replace 
+with `Does.StartWith` constraint.
+
+```csharp
+[Test]
+public void Test()
+{
+    string actual = "...";
+    string expected = "...";
+    Assert.True(actual.StartsWith(expected));
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.True(actual.StartWith(expected))` with
+`Assert.That(actual, Does.StartWith(expected))`. So the code block above will be changed into
+
+```csharp
+[Test]
+public void Test()
+{
+    string actual = "...";
+    string expected = "...";
+    Assert.That(actual, Does.StartWith(expected));
+}
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2012 // Use StartsWithConstraint.
+Code violating the rule here
+#pragma warning restore NUnit2012 // Use StartsWithConstraint.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2012 // Use StartsWithConstraint.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2012:Use StartsWithConstraint.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2013.md
+++ b/documentation/NUnit2013.md
@@ -1,0 +1,73 @@
+# NUnit2013
+## Use EndsWithConstraint.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2013
+| Severity | Info
+| Enabled  | True
+| Category | Assertion
+| Code     | [StringConstraintUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs)
+
+
+## Description
+
+Using constraints instead of boolean methods will lead to better assertion messages in case of failure.
+
+## Motivation
+
+Using `Does.EndWith` (or `Does.Not.EndWith`) constraint will lead to better assertion messages in case of failure, 
+so this analyzer marks all usages of string `EndsWith` method where it is possible to replace 
+with `Does.EndWith` constraint.
+
+```csharp
+[Test]
+public void Test()
+{
+    string actual = "...";
+    string expected = "...";
+    Assert.True(actual.EndsWith(expected));
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.True(actual.EndsWith(expected))` with
+`Assert.That(actual, Does.EndWith(expected))`. So the code block above will be changed into
+
+```csharp
+[Test]
+public void Test()
+{
+    string actual = "...";
+    string expected = "...";
+    Assert.That(actual, Does.EndWith(expected));
+}
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2013 // Use EndsWithConstraint.
+Code violating the rule here
+#pragma warning restore NUnit2013 // Use EndsWithConstraint.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2013 // Use EndsWithConstraint.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2013:Use EndsWithConstraint.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -26,4 +26,7 @@
 | [NUnit2008](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2008.md)| Incorrect IgnoreCase usage.
 | [NUnit2009](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2009.md)| Same value provided as actual and expected argument.
 | [NUnit2010](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2010.md)| Use EqualConstraint.
+| [NUnit2011](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2011.md)| Use ContainsConstraint.
+| [NUnit2012](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2012.md)| Use StartsWithConstraint.
+| [NUnit2013](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2013.md)| Use EndsWithConstraint.
 

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -36,6 +36,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2008.md = ..\documentation\NUnit2008.md
 		..\documentation\NUnit2009.md = ..\documentation\NUnit2009.md
 		..\documentation\NUnit2010.md = ..\documentation\NUnit2010.md
+		..\documentation\NUnit2011.md = ..\documentation\NUnit2011.md
+		..\documentation\NUnit2012.md = ..\documentation\NUnit2012.md
+		..\documentation\NUnit2013.md = ..\documentation\NUnit2013.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -10,10 +10,20 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
     {
         private static readonly DiagnosticAnalyzer analyzer = new StringConstraintUsageAnalyzer();
 
-        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain")]
-        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith")]
-        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith")]
-        public void AnalyzeStringBooleanMethodPositiveAssert(string method, string analyzerId, string suggestedConstraint)
+        private static readonly object[] PositiveAssertData = new[] {
+            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain" },
+            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith" },
+            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith" }
+        };
+
+        private static readonly object[] NegativeAssertData = new[] {
+            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain" },
+            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith" },
+            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith" }
+        };
+
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
 
@@ -22,12 +32,60 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
-        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain")]
-        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith")]
-        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith")]
-        public void AnalyzeStringBooleanMethodNegativeAssert(string method, string analyzerId, string suggestedConstraint)
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertIsTrue(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.IsTrue(↓""abc"".{method}(""ab""));");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""));");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat_IsTrue(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.True);");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertIsFalse(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.IsFalse(↓""abc"".{method}(""ab""));");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat_IsFalse(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.False);");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -1,0 +1,54 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.ConstraintUsage;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ConstraintsUsage
+{
+    public class StringConstraintUsageAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new StringConstraintUsageAnalyzer();
+
+        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain")]
+        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith")]
+        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith")]
+        public void AnalyzeStringBooleanMethodPositiveAssert(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain")]
+        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith")]
+        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith")]
+        public void AnalyzeStringBooleanMethodNegativeAssert(string method, string analyzerId, string suggestedConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
+
+            var diagnostic = ExpectedDiagnostic.Create(analyzerId,
+                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+        }
+
+        [Test]
+        public void ValidForUnsupportedStringMethods()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"Assert.That(↓""abc"".IsNormalized());");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidForNonStringMethods()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                @"Assert.That(new List<string> { ""a"",""ab""}.Contains(""ab""));");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -12,10 +12,20 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         private static readonly DiagnosticAnalyzer analyzer = new StringConstraintUsageAnalyzer();
         private static readonly CodeFixProvider fix = new StringConstraintUsageCodeFix();
 
-        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain")]
-        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith")]
-        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith")]
-        public void AnalyzeStringBooleanMethodPositiveAssert(string method, string analyzerId, string suggestedConstraint)
+        private static readonly object[] PositiveAssertData = new[] {
+            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain" },
+            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith" },
+            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith" }
+        };
+
+        private static readonly object[] NegativeAssertData = new[] {
+            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain" },
+            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith" },
+            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith" }
+        };
+
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
 
@@ -24,12 +34,60 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
-        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain")]
-        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith")]
-        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith")]
-        public void AnalyzeStringBooleanMethodNegativeAssert(string method, string analyzerId, string suggestedConstraint)
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertIsTrue(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.IsTrue(↓""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(PositiveAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat_IsTrue(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.True);");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertIsFalse(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.IsFalse(↓""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat_IsFalse(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.False);");
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -1,0 +1,39 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.ConstraintUsage;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ConstraintsUsage
+{
+    public class StringConstraintUsageCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new StringConstraintUsageAnalyzer();
+        private static readonly CodeFixProvider fix = new StringConstraintUsageCodeFix();
+
+        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain")]
+        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith")]
+        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith")]
+        public void AnalyzeStringBooleanMethodPositiveAssert(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.True(""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCase(nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain")]
+        [TestCase(nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith")]
+        [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith")]
+        public void AnalyzeStringBooleanMethodNegativeAssert(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -17,7 +17,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         [TestCase(nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith")]
         public void AnalyzeStringBooleanMethodPositiveAssert(string method, string analyzerId, string suggestedConstraint)
         {
-            var code = TestUtility.WrapInTestMethod($@"Assert.True(""abc"".{method}(""ab""));");
+            var code = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -33,6 +33,9 @@ namespace NUnit.Analyzers.Constants
         internal const string IgnoreCaseUsage = "NUnit2008";
         internal const string SameActualExpectedValue = "NUnit2009";
         internal const string EqualConstraintUsage = "NUnit2010";
+        internal const string StringContainsConstraintUsage = "NUnit2011";
+        internal const string StringStartsWithConstraintUsage = "NUnit2012";
+        internal const string StringEndsWithConstraintUsage = "NUnit2013";
 
         #endregion Assertion
     }

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -20,6 +20,12 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfIsSameAs = "SameAs";
         public const string NameOfIsSamePath = "SamePath";
 
+        public const string NameOfDoes = "Does";
+        public const string NameOfDoesNot = "Not";
+        public const string NameOfDoesContain = "Contain";
+        public const string NameOfDoesStartWith = "StartWith";
+        public const string NameOfDoesEndWith = "EndWith";
+
         public const string NameOfAssert = "Assert";
         public const string NameOfAssertIsTrue = "IsTrue";
         public const string NameOfAssertTrue = "True";

--- a/src/nunit.analyzers/Constants/StringConstraintUsageConstants.cs
+++ b/src/nunit.analyzers/Constants/StringConstraintUsageConstants.cs
@@ -1,0 +1,11 @@
+namespace NUnit.Analyzers.Constants
+{
+    internal static class StringConstraintUsageConstants
+    {
+        internal const string ContainsTitle = "Use ContainsConstraint.";
+        internal const string StartsWithTitle = "Use StartsWithConstraint.";
+        internal const string EndsWithTitle = "Use EndsWithConstraint.";
+        internal const string Message = "Use {0} constraint instead of boolean method.";
+        internal const string Description = "Using constraints instead of boolean methods will lead to better assertion messages in case of failure.";
+    }
+}

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
@@ -1,0 +1,96 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Extensions;
+using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
+
+namespace NUnit.Analyzers.ConstraintUsage
+{
+    public abstract class BaseConditionConstraintAnalyzer : BaseAssertionAnalyzer
+    {
+        internal const string SuggestedConstraintString = nameof(SuggestedConstraintString);
+
+        protected static readonly string[] SupportedPositiveAssertMethods = new[] {
+            NameOfAssertThat,
+            NameOfAssertTrue,
+            NameOfAssertIsTrue
+        };
+
+        protected static readonly string[] SupportedNegativeAssertMethods = new[] {
+            NameOfAssertFalse,
+            NameOfAssertIsFalse
+        };
+
+        protected abstract (DiagnosticDescriptor descriptor, string suggestedConstraint) GetDiagnosticData(
+            SyntaxNodeAnalysisContext context, ExpressionSyntax actual, bool negated);
+
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
+        {
+            var negated = false;
+
+            if (SupportedNegativeAssertMethods.Contains(methodSymbol.Name))
+            {
+                negated = true;
+            }
+            else if (!SupportedPositiveAssertMethods.Contains(methodSymbol.Name))
+            {
+                return;
+            }
+
+            var constraint = assertExpression.GetArgumentExpression(methodSymbol, NameOfExpressionParameter);
+
+            // Constraint should be either absent, or Is.True, or Is.False
+            if (constraint != null)
+            {
+                if (!(constraint is MemberAccessExpressionSyntax memberAccess
+                       && memberAccess.Expression is IdentifierNameSyntax identifierSyntax
+                       && identifierSyntax.Identifier.Text == NameOfIs
+                       && (memberAccess.Name.Identifier.Text == NameOfIsTrue
+                           || memberAccess.Name.Identifier.Text == NameOfIsFalse)))
+                {
+                    return;
+                }
+
+                if (memberAccess.Name.Identifier.Text == NameOfIsFalse)
+                {
+                    negated = !negated;
+                }
+            }
+
+            var actual = assertExpression.GetArgumentExpression(methodSymbol, NameOfActualParameter)
+                ?? assertExpression.GetArgumentExpression(methodSymbol, NameOfConditionParameter);
+
+            if (IsPrefixNotExpression(actual, out var unwrappedActual))
+            {
+                negated = !negated;
+            }
+
+            var (descriptor, suggestedConstraint) = this.GetDiagnosticData(context, unwrappedActual ?? actual, negated);
+
+            if (descriptor != null && suggestedConstraint != null)
+            {
+                var properties = ImmutableDictionary.Create<string, string>().Add(SuggestedConstraintString, suggestedConstraint);
+                var diagnostic = Diagnostic.Create(descriptor, actual.GetLocation(), properties, suggestedConstraint);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private static bool IsPrefixNotExpression(ExpressionSyntax expression, out ExpressionSyntax operand)
+        {
+            if (expression is PrefixUnaryExpressionSyntax unarySyntax
+                && unarySyntax.IsKind(SyntaxKind.LogicalNotExpression))
+            {
+                operand = unarySyntax.Operand;
+                return true;
+            }
+            else
+            {
+                operand = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.ConstraintUsage
             if (conditionNode == null)
                 return;
 
-            var (actual, constraintExpression) = GetActualAndConstraintExpression(conditionNode, suggestedConstraintString);
+            var (actual, constraintExpression) = this.GetActualAndConstraintExpression(conditionNode, suggestedConstraintString);
 
             var assertNode = conditionNode.Ancestors()
                 .OfType<InvocationExpressionSyntax>()

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -1,0 +1,100 @@
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
+
+namespace NUnit.Analyzers.ConstraintUsage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public abstract class BaseConditionConstraintCodeFix : CodeFixProvider
+    {
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var suggestedConstraintString = context.Diagnostics[0].Properties[BaseConditionConstraintAnalyzer.SuggestedConstraintString];
+
+            var description = string.Format(CodeFixConstants.UseConstraintDescriptionFormat, suggestedConstraintString);
+
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+            var conditionNode = (root.FindNode(context.Span) as ArgumentSyntax)?.Expression;
+
+            if (conditionNode == null)
+                return;
+
+            var (actual, constraintExpression) = GetActualAndConstraintExpression(conditionNode, suggestedConstraintString);
+
+            var assertNode = conditionNode.Ancestors()
+                .OfType<InvocationExpressionSyntax>()
+                .FirstOrDefault();
+
+            var assertMethod = semanticModel.GetSymbolInfo(assertNode).Symbol as IMethodSymbol;
+
+            if (actual == null || constraintExpression == null || assertNode == null || assertMethod == null)
+                return;
+
+            var newAssertNode = UpdateAssertNode(assertNode, assertMethod, actual, constraintExpression);
+            var newRoot = root.ReplaceNode(assertNode, newAssertNode);
+
+            var codeAction = CodeAction.Create(
+                description,
+                _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
+                description);
+
+            context.RegisterCodeFix(codeAction, context.Diagnostics);
+        }
+
+        protected abstract (ExpressionSyntax actual, ExpressionSyntax constraintExpression) GetActualAndConstraintExpression(
+            ExpressionSyntax conditionNode, string suggestedConstraintString);
+
+        protected static InvocationExpressionSyntax GetConstraintExpression(string constraintString, ExpressionSyntax expected)
+        {
+            if (expected == null)
+                return null;
+
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.ParseExpression(constraintString),
+                SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(expected))));
+        }
+
+        protected static InvocationExpressionSyntax UpdateAssertNode(InvocationExpressionSyntax assertNode, IMethodSymbol assertMethod,
+            ExpressionSyntax actual, ExpressionSyntax constraintExpression)
+        {
+            // Replace Assert method to Assert.That
+            var newExpression = ((MemberAccessExpressionSyntax)assertNode.Expression)
+                .WithName(SyntaxFactory.IdentifierName(NameOfAssertThat));
+
+            // Replace arguments
+            var hasConstraint = assertNode.GetArgumentExpression(assertMethod, NameOfExpressionParameter) != null;
+
+            var remainingArguments = hasConstraint
+                ? assertNode.ArgumentList.Arguments.Skip(2)
+                : assertNode.ArgumentList.Arguments.Skip(1);
+
+            var newArguments = new[] {
+                SyntaxFactory.Argument(actual),
+                SyntaxFactory.Argument(constraintExpression)
+            }.Union(remainingArguments);
+
+            var newArgumentsList = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(newArguments));
+
+            return assertNode
+                .WithExpression(newExpression)
+                .WithArgumentList(newArgumentsList);
+        }
+    }
+}

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -1,4 +1,3 @@
-using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -12,8 +11,6 @@ using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
 
 namespace NUnit.Analyzers.ConstraintUsage
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp)]
-    [Shared]
     public abstract class BaseConditionConstraintCodeFix : CodeFixProvider
     {
         public sealed override FixAllProvider GetFixAllProvider()

--- a/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageAnalyzer.cs
@@ -1,20 +1,16 @@
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
-using NUnit.Analyzers.Extensions;
 using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
 
 namespace NUnit.Analyzers.ConstraintUsage
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class EqualConstraintUsageAnalyzer : BaseAssertionAnalyzer
+    public class EqualConstraintUsageAnalyzer : BaseConditionConstraintAnalyzer
     {
-        internal const string SuggestedConstraintString = nameof(SuggestedConstraintString);
-
         private static readonly string IsEqualTo = $"{NameOfIs}.{NameOfIsEqualTo}";
         private static readonly string IsNotEqualTo = $"{NameOfIs}.{NameOfIsNot}.{NameOfIsEqualTo}";
 
@@ -26,56 +22,11 @@ namespace NUnit.Analyzers.ConstraintUsage
             defaultSeverity: DiagnosticSeverity.Info,
             description: EqualConstraintUsageConstants.Description);
 
-        private static readonly string[] SupportedPositiveAssertMethods = new[] {
-            NameOfAssertThat,
-            NameOfAssertTrue,
-            NameOfAssertIsTrue
-        };
-
-        private static readonly string[] SupportedNegativeAssertMethods = new[] {
-            NameOfAssertFalse,
-            NameOfAssertIsFalse
-        };
-
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
-        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
-            InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
+        protected override (DiagnosticDescriptor descriptor, string suggestedConstraint) GetDiagnosticData(
+            SyntaxNodeAnalysisContext context, ExpressionSyntax actual, bool negated)
         {
-            var negated = false;
-
-            if (SupportedNegativeAssertMethods.Contains(methodSymbol.Name))
-            {
-                negated = true;
-            }
-            else if (!SupportedPositiveAssertMethods.Contains(methodSymbol.Name))
-            {
-                return;
-            }
-
-            var constraint = assertExpression.GetArgumentExpression(methodSymbol, NameOfExpressionParameter);
-
-            // Constraint should be either absent, or Is.True, or Is.False
-            if (constraint != null)
-            {
-                if (!(constraint is MemberAccessExpressionSyntax memberAccess
-                       && memberAccess.Expression is IdentifierNameSyntax identifierSyntax
-                       && identifierSyntax.Identifier.Text == NameOfIs
-                       && (memberAccess.Name.Identifier.Text == NameOfIsTrue
-                           || memberAccess.Name.Identifier.Text == NameOfIsFalse)))
-                {
-                    return;
-                }
-
-                if (memberAccess.Name.Identifier.Text == NameOfIsFalse)
-                {
-                    negated = !negated;
-                }
-            }
-
-            var actual = assertExpression.GetArgumentExpression(methodSymbol, NameOfActualParameter)
-                ?? assertExpression.GetArgumentExpression(methodSymbol, NameOfConditionParameter);
-
             var shouldReport = false;
 
             // 'actual == expected', 'Equals(actual, expected)' or 'actual.Equals(expected)'
@@ -86,11 +37,8 @@ namespace NUnit.Analyzers.ConstraintUsage
                 shouldReport = true;
             }
 
-            // 'actual != expected', '!Equals(actual, expected)' or '!actual.Equals(expected)'
-            else if (actual.IsKind(SyntaxKind.NotEqualsExpression)
-                || (IsPrefixNotExpression(actual, out var notOperand)
-                    && (IsStaticObjectEquals(notOperand, context)
-                        || IsInstanceObjectEquals(notOperand, context))))
+            // 'actual != expected'
+            else if (actual.IsKind(SyntaxKind.NotEqualsExpression))
             {
                 shouldReport = true;
                 negated = !negated;
@@ -99,24 +47,10 @@ namespace NUnit.Analyzers.ConstraintUsage
             if (shouldReport)
             {
                 var suggestedConstraint = negated ? IsNotEqualTo : IsEqualTo;
-                var properties = ImmutableDictionary.Create<string, string>().Add(SuggestedConstraintString, suggestedConstraint);
-                context.ReportDiagnostic(Diagnostic.Create(descriptor, actual.GetLocation(), properties, suggestedConstraint));
+                return (descriptor, suggestedConstraint);
             }
-        }
 
-        private static bool IsPrefixNotExpression(ExpressionSyntax expression, out ExpressionSyntax operand)
-        {
-            if (expression is PrefixUnaryExpressionSyntax unarySyntax
-                && unarySyntax.IsKind(SyntaxKind.LogicalNotExpression))
-            {
-                operand = unarySyntax.Operand;
-                return true;
-            }
-            else
-            {
-                operand = null;
-                return false;
-            }
+            return (null, null);
         }
 
         private static bool IsStaticObjectEquals(ExpressionSyntax expressionSyntax, SyntaxNodeAnalysisContext context)

--- a/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageCodeFix.cs
@@ -1,65 +1,24 @@
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Analyzers.Extensions;
-using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
 
 namespace NUnit.Analyzers.ConstraintUsage
 {
     [ExportCodeFixProvider(LanguageNames.CSharp)]
     [Shared]
-    public class EqualConstraintUsageCodeFix : CodeFixProvider
+    public class EqualConstraintUsageCodeFix : BaseConditionConstraintCodeFix
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.EqualConstraintUsage);
 
-        public sealed override FixAllProvider GetFixAllProvider()
+        protected override (ExpressionSyntax actual, ExpressionSyntax constraintExpression) GetActualAndConstraintExpression(ExpressionSyntax conditionNode, string suggestedConstraintString)
         {
-            return WellKnownFixAllProviders.BatchFixer;
-        }
-
-        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-        {
-            var suggestedConstraintString = context.Diagnostics[0].Properties[EqualConstraintUsageAnalyzer.SuggestedConstraintString];
-
-            var description = string.Format(CodeFixConstants.UseConstraintDescriptionFormat, suggestedConstraintString);
-
-            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-
-            context.CancellationToken.ThrowIfCancellationRequested();
-            var conditionNode = (root.FindNode(context.Span) as ArgumentSyntax)?.Expression;
-
-            if (conditionNode == null)
-                return;
-
             var (actual, expected) = GetActualExpected(conditionNode);
-
-            var assertNode = conditionNode.Ancestors()
-                .OfType<InvocationExpressionSyntax>()
-                .FirstOrDefault();
-
-            var assertMethod = semanticModel.GetSymbolInfo(assertNode).Symbol as IMethodSymbol;
-
-            if (actual == null || expected == null || assertNode == null || assertMethod == null)
-                return;
-
-            var newAssertNode = UpdateAssertNode(assertNode, assertMethod, actual, expected, suggestedConstraintString);
-            var newRoot = root.ReplaceNode(assertNode, newAssertNode);
-
-            var codeAction = CodeAction.Create(
-                description,
-                _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
-                description);
-
-            context.RegisterCodeFix(codeAction, context.Diagnostics);
-
+            var constraintExpression = GetConstraintExpression(suggestedConstraintString, expected);
+            return (actual, constraintExpression);
         }
 
         private static (ExpressionSyntax actual, ExpressionSyntax expected) GetActualExpected(SyntaxNode conditionNode)
@@ -97,37 +56,6 @@ namespace NUnit.Analyzers.ConstraintUsage
             }
 
             return (null, null);
-        }
-
-        private static InvocationExpressionSyntax UpdateAssertNode(InvocationExpressionSyntax assertNode, IMethodSymbol assertMethod,
-            ExpressionSyntax actual, ExpressionSyntax expected,
-            string constraintString)
-        {
-            // Replace Assert method to Assert.That
-            var newExpression = ((MemberAccessExpressionSyntax)assertNode.Expression)
-                .WithName(SyntaxFactory.IdentifierName(NameOfAssertThat));
-
-            // Replace arguments
-            var hasConstraint = assertNode.GetArgumentExpression(assertMethod, NameOfExpressionParameter) != null;
-
-            var remainingArguments = hasConstraint
-                ? assertNode.ArgumentList.Arguments.Skip(2)
-                : assertNode.ArgumentList.Arguments.Skip(1);
-
-            var constraintExpression = SyntaxFactory.InvocationExpression(
-                SyntaxFactory.ParseExpression(constraintString),
-                SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(expected))));
-
-            var newArguments = new[] {
-                SyntaxFactory.Argument(actual),
-                SyntaxFactory.Argument(constraintExpression)
-            }.Union(remainingArguments);
-
-            var newArgumentsList = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(newArguments));
-
-            return assertNode
-                .WithExpression(newExpression)
-                .WithArgumentList(newArgumentsList);
         }
     }
 }

--- a/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.ConstraintUsage
         #endregion Descriptors
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
-            = new[] { containsDescriptor, startsWithDescriptor, endsWithDescriptor }.ToImmutableArray();
+            = ImmutableArray.Create(containsDescriptor, startsWithDescriptor, endsWithDescriptor);
 
         private static readonly Dictionary<string, (string doesMethod, DiagnosticDescriptor descriptor)> SupportedMethods
             = new Dictionary<string, (string, DiagnosticDescriptor)>

--- a/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.ConstraintUsage
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class StringConstraintUsageAnalyzer : BaseConditionConstraintAnalyzer
+    {
+        #region Descriptors
+
+        private static readonly DiagnosticDescriptor containsDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.StringContainsConstraintUsage,
+            title: StringConstraintUsageConstants.ContainsTitle,
+            messageFormat: StringConstraintUsageConstants.Message,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Info,
+            description: StringConstraintUsageConstants.Description);
+
+        private static readonly DiagnosticDescriptor startsWithDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.StringStartsWithConstraintUsage,
+            title: StringConstraintUsageConstants.StartsWithTitle,
+            messageFormat: StringConstraintUsageConstants.Message,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Info,
+            description: StringConstraintUsageConstants.Description);
+
+        private static readonly DiagnosticDescriptor endsWithDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.StringEndsWithConstraintUsage,
+            title: StringConstraintUsageConstants.EndsWithTitle,
+            messageFormat: StringConstraintUsageConstants.Message,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Info,
+            description: StringConstraintUsageConstants.Description);
+
+        #endregion Descriptors
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = new[] { containsDescriptor, startsWithDescriptor, endsWithDescriptor }.ToImmutableArray();
+
+        private static readonly Dictionary<string, (string doesMethod, DiagnosticDescriptor descriptor)> SupportedMethods
+            = new Dictionary<string, (string, DiagnosticDescriptor)>
+            {
+                [nameof(string.Contains)] = (NunitFrameworkConstants.NameOfDoesContain, containsDescriptor),
+                [nameof(string.StartsWith)] = (NunitFrameworkConstants.NameOfDoesStartWith, startsWithDescriptor),
+                [nameof(string.EndsWith)] = (NunitFrameworkConstants.NameOfDoesEndWith, endsWithDescriptor)
+            };
+
+        protected override (DiagnosticDescriptor descriptor, string suggestedConstraint) GetDiagnosticData(
+            SyntaxNodeAnalysisContext context, ExpressionSyntax actual, bool negated)
+        {
+            if (actual is InvocationExpressionSyntax invocationExpression
+                && invocationExpression.ArgumentList.Arguments.Count == 1
+                && invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression
+                && IsMethodSupported(memberAccessExpression.Name, context, out var methodName))
+            {
+                return GetDiagnosticData(methodName, negated);
+            }
+
+            return (null, null);
+        }
+
+        private static bool IsMethodSupported(SimpleNameSyntax nameSyntax, SyntaxNodeAnalysisContext context, out string methodName)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(nameSyntax).Symbol;
+
+            if (symbol is IMethodSymbol methodSymbol
+                && methodSymbol.ContainingType.SpecialType == SpecialType.System_String
+                && SupportedMethods.ContainsKey(methodSymbol.Name))
+            {
+                methodName = methodSymbol.Name;
+                return true;
+            }
+            else
+            {
+                methodName = null;
+                return false;
+            }
+        }
+
+        private static (DiagnosticDescriptor, string) GetDiagnosticData(string stringMethod, bool negated)
+        {
+            var (doesMethod, descriptor) = SupportedMethods[stringMethod];
+
+            var suggestedContstraint = negated
+                ? $"{NunitFrameworkConstants.NameOfDoes}.{NunitFrameworkConstants.NameOfDoesNot}.{doesMethod}"
+                : $"{NunitFrameworkConstants.NameOfDoes}.{doesMethod}";
+
+            return (descriptor, suggestedContstraint);
+        }
+    }
+}

--- a/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageCodeFix.cs
@@ -1,0 +1,37 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.ConstraintUsage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public class StringConstraintUsageCodeFix : BaseConditionConstraintCodeFix
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+            AnalyzerIdentifiers.StringContainsConstraintUsage,
+            AnalyzerIdentifiers.StringStartsWithConstraintUsage,
+            AnalyzerIdentifiers.StringEndsWithConstraintUsage);
+
+        protected override (ExpressionSyntax actual, ExpressionSyntax constraintExpression) GetActualAndConstraintExpression(ExpressionSyntax conditionNode, string suggestedConstraintString)
+        {
+            // actual.Contains(expected)
+            if (conditionNode is InvocationExpressionSyntax invocation
+                && invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+            {
+                var actual = memberAccess.Expression;
+                var expected = invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+                var constraintExpression = GetConstraintExpression(suggestedConstraintString, expected);
+
+                return (actual, constraintExpression);
+            }
+            else
+            {
+                return (null, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes #150 

Extracted common code from `EqualConstraintUsageAnalyzer` and `EqualConstraintUsageCodeFix` to `BaseConditionConstraintAnalyzer` and `BaseConditionConstraintCodeFix` respectively.

![2019-08-31_14-51-56](https://user-images.githubusercontent.com/17177729/64063603-f8ee2880-cbfe-11e9-9f6c-dfd3759ce28f.gif)

Supported constraints:
`Does.Contain`, `Does.StartWith`, `Does.EndWith`, and corresponding `Does.Not.*` constraints.