### PR TITLE
Fix CodeFix for logical not expression

### DIFF
--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -65,6 +65,16 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
+        public void AnalyzeStringBooleanMethod_AssertThat_Negated(string method, string analyzerId, string suggestedConstraint)
+        {
+            var code = TestUtility.WrapInTestMethod($@"Assert.That(↓!""abc"".{method}(""ab""));");
+
+            var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(NegativeAssertData))]
         public void AnalyzeStringBooleanMethod_AssertFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -33,6 +33,12 @@ namespace NUnit.Analyzers.ConstraintUsage
             if (conditionNode == null)
                 return;
 
+            // If condition is logical not expression - use operand
+            if (conditionNode is PrefixUnaryExpressionSyntax unarySyntax && unarySyntax.IsKind(SyntaxKind.LogicalNotExpression))
+            {
+                conditionNode = unarySyntax.Operand;
+            }
+
             var (actual, constraintExpression) = this.GetActualAndConstraintExpression(conditionNode, suggestedConstraintString);
 
             var assertNode = conditionNode.Ancestors()


### PR DESCRIPTION
For code:
`Assert.That(!"abc".Contains("ab"));`

there is analyzer present (to use `Does.Not.Contain`), but no code fix.

This PR fixes the issue