### PR TITLE
Do not replace line breaks in code fixes

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -121,5 +121,21 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void CodeFixPreservesLineBreakBeforeMessage()
+        {
+            var code = TestUtility.WrapInTestMethod($@"
+            Assert.AreEqual(2d, 3d, 0.0000001d,
+                ""message"",
+                Guid.NewGuid());");
+
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+            Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d),
+                ""message"",
+                Guid.NewGuid());");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
@@ -240,5 +240,23 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
+
+        [Test]
+        public void CodeFixPreservesLineBreakBeforeMessage()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+                var actual = ""abc"";
+
+                Assert.False(actual.Equals(""bcd""),
+                    ""Assertion message from new line"");");
+
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+                var actual = ""abc"";
+
+                Assert.That(actual, Is.Not.EqualTo(""bcd""),
+                    ""Assertion message from new line"");");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+        }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
 
 namespace NUnit.Analyzers.ClassicModelAssertUsage
 {
@@ -41,26 +42,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var arguments = invocationNode.ArgumentList.Arguments.ToList();
             this.UpdateArguments(diagnostic, arguments);
 
-            var totalArgumentCount = (2 * arguments.Count) - 1;
-            var newArgumentList = new SyntaxNodeOrToken[totalArgumentCount];
-
-            context.CancellationToken.ThrowIfCancellationRequested();
-
-            for (var x = 0; x < totalArgumentCount; x++)
-            {
-                if (x % 2 == 0)
-                {
-                    newArgumentList[x] = arguments[x / 2];
-                }
-                else
-                {
-                    newArgumentList[x] = SyntaxFactory.Token(SyntaxKind.CommaToken);
-                }
-            }
-
-            newInvocationNode = newInvocationNode.WithArgumentList(
-                SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SeparatedList<ArgumentSyntax>(newArgumentList)));
+            var newArgumentsList = invocationNode.ArgumentList.WithArguments(arguments);
+            newInvocationNode = newInvocationNode.WithArgumentList(newArgumentsList);
 
             context.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.ConstraintUsage
                 SyntaxFactory.Argument(constraintExpression)
             }.Union(remainingArguments);
 
-            var newArgumentsList = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(newArguments));
+            var newArgumentsList = assertNode.ArgumentList.WithArguments(newArguments);
 
             return assertNode
                 .WithExpression(newExpression)

--- a/src/nunit.analyzers/Extensions/ArgumentListSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ArgumentListSyntaxExtensions.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace NUnit.Analyzers.Extensions
+{
+    internal static class ArgumentListSyntaxExtensions
+    {
+        public static ArgumentListSyntax WithArguments(
+            this ArgumentListSyntax @this,
+            IEnumerable<ArgumentSyntax> newArguments)
+        {
+            var originalArguments = @this.Arguments;
+            var originalSeparators = originalArguments.GetSeparators();
+
+            var nodesAndTokens = new List<SyntaxNodeOrToken> { newArguments.First() };
+
+            foreach (var newArgument in newArguments.Skip(1))
+            {
+                // If argument is not replaced - take original separator. Otherwise - comma
+                var oldIndex = originalArguments.IndexOf(newArgument);
+                var separator = originalSeparators.ElementAtOrDefault(oldIndex - 1);
+
+                if (separator == default)
+                {
+                    separator = SyntaxFactory.Token(SyntaxKind.CommaToken);
+                }
+
+                nodesAndTokens.Add(separator);
+                nodesAndTokens.Add(newArgument);
+            }
+
+            var newSeparatedList = SyntaxFactory.SeparatedList<ArgumentSyntax>(nodesAndTokens);
+
+            return @this.WithArguments(newSeparatedList);
+        }
+    }
+}

--- a/src/nunit.analyzers/Extensions/ArgumentListSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ArgumentListSyntaxExtensions.cs
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.Extensions
                 var oldIndex = originalArguments.IndexOf(newArgument);
                 var separator = originalSeparators.ElementAtOrDefault(oldIndex - 1);
 
-                if (separator == default)
+                if (separator == default(SyntaxToken))
                 {
                     separator = SyntaxFactory.Token(SyntaxKind.CommaToken);
                 }


### PR DESCRIPTION
Example.

Code with diagnostic:
```csharp
            Assert.AreEqual(expected, actual,
                "Some Test Message",
                "With format");
```

Code fix before PR:
```csharp
            Assert.That(actual, Is.EqualTo(expected), "Some Test Message", "With format");
```

Code fix after PR:
```csharp
            Assert.That(actual, Is.EqualTo(expected),
                "Some Test Message",
                "With format");
```
