### PR TITLE
Add Analyzers for Assert.[Is][Not]Null(expr)

### DIFF
--- a/documentation/NUnit2016.md
+++ b/documentation/NUnit2016.md
@@ -1,0 +1,71 @@
+# NUnit2016
+## Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2016
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+Consider using the constraint model, Assert.That(expr, Is.Null), instead of the classic model, Assert.Null(expr).
+
+## Motivation
+
+The classic Assert model contains less flexibility and reads more clumsy than the constraint model,
+so this analyzer marks usages of `Assert.Null` from the classic Assert model.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.Null(obj);
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.Null(expression)` with
+`Assert.That(expression, Is.Null)`. So the code block above will be changed into.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.That(obj, Is.Null);
+}
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2016 // Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).
+Code violating the rule here
+#pragma warning restore NUnit2016 // Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2016 // Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2016:Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2017.md
+++ b/documentation/NUnit2017.md
@@ -1,0 +1,71 @@
+# NUnit2017
+## Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2017
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+Consider using the constraint model, Assert.That(expr, Is.Null), instead of the classic model, Assert.IsNull(expr).
+
+## Motivation
+
+The classic Assert model contains less flexibility and reads more clumsy than the constraint model,
+so this analyzer marks usages of `Assert.Null` from the classic Assert model.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.IsNull(obj);
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.IsNull(expression)` with
+`Assert.That(expression, Is.Null)`. So the code block above will be changed into.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.That(obj, Is.Null);
+}
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2017 // Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).
+Code violating the rule here
+#pragma warning restore NUnit2017 // Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2017 // Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2017:Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2018.md
+++ b/documentation/NUnit2018.md
@@ -1,0 +1,71 @@
+# NUnit2018
+## Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2018
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+Consider using the constraint model, Assert.That(expr, Is.Not.Null), instead of the classic model, Assert.NotNull(expr).
+
+## Motivation
+
+The classic Assert model contains less flexibility and reads more clumsy than the constraint model,
+so this analyzer marks usages of `Assert.NotNull` from the classic Assert model.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.NotNull(obj);
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.NotNull(expression)` with
+`Assert.That(expression, Is.Not.Null)`. So the code block above will be changed into.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.That(obj, Is.Not.Null);
+}
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2018 // Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).
+Code violating the rule here
+#pragma warning restore NUnit2018 // Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2018 // Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2018:Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit2019.md
+++ b/documentation/NUnit2019.md
@@ -1,0 +1,71 @@
+# NUnit2019
+## Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2019
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ClassicModelAssertUsageAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs)
+
+
+## Description
+
+Consider using the constraint model, Assert.That(expr, Is.Not.Null), instead of the classic model, Assert.IsNotNull(expr).
+
+## Motivation
+
+The classic Assert model contains less flexibility and reads more clumsy than the constraint model,
+so this analyzer marks usages of `Assert.IsNotNull` from the classic Assert model.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.IsNotNull(obj);
+}
+```
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace `Assert.IsNotNull(expression)` with
+`Assert.That(expression, Is.Not.Null)`. So the code block above will be changed into.
+
+```csharp
+[Test]
+public void Test()
+{
+    object obj = null;
+    Assert.That(obj, Is.Not.Null);
+}
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2019 // Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).
+Code violating the rule here
+#pragma warning restore NUnit2019 // Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2019 // Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2019:Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -31,4 +31,8 @@
 | [NUnit2013](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2013.md)| Use EndsWithConstraint.
 | [NUnit2014](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2014.md)| Use SomeItemsConstraint.
 | [NUnit2015](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2015.md)| Consider using Assert.That(expr2, Is.SameAs(expr1)) instead of Assert.AreSame(expr1, expr2).
+| [NUnit2016](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2016.md)| Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).
+| [NUnit2017](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2017.md)| Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).
+| [NUnit2018](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2018.md)| Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).
+| [NUnit2019](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2019.md)| Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).
 

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -40,6 +40,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2012.md = ..\documentation\NUnit2012.md
 		..\documentation\NUnit2013.md = ..\documentation\NUnit2013.md
 		..\documentation\NUnit2014.md = ..\documentation\NUnit2014.md
+		..\documentation\NUnit2015.md = ..\documentation\NUnit2015.md
+		..\documentation\NUnit2016.md = ..\documentation\NUnit2016.md
+		..\documentation\NUnit2017.md = ..\documentation\NUnit2017.md
+		..\documentation\NUnit2018.md = ..\documentation\NUnit2018.md
+		..\documentation\NUnit2019.md = ..\documentation\NUnit2019.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var analyzer = new ClassicModelAssertUsageAnalyzer();
             var diagnostics = analyzer.SupportedDiagnostics;
 
-            Assert.That(diagnostics.Length, Is.EqualTo(7), nameof(DiagnosticAnalyzer.SupportedDiagnostics));
+            Assert.That(diagnostics.Length, Is.EqualTo(11), nameof(DiagnosticAnalyzer.SupportedDiagnostics));
 
             foreach (var diagnostic in diagnostics)
             {
@@ -50,6 +50,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                 $"{AnalyzerIdentifiers.TrueUsage} is missing.");
             Assert.That(diagnosticIds, Contains.Item(AnalyzerIdentifiers.AreSameUsage),
                 $"{AnalyzerIdentifiers.AreSameUsage} is missing.");
+            Assert.That(diagnosticIds, Contains.Item(AnalyzerIdentifiers.NullUsage),
+                $"{AnalyzerIdentifiers.NullUsage} is missing.");
+            Assert.That(diagnosticIds, Contains.Item(AnalyzerIdentifiers.IsNullUsage),
+                $"{AnalyzerIdentifiers.IsNullUsage} is missing.");
+            Assert.That(diagnosticIds, Contains.Item(AnalyzerIdentifiers.NotNullUsage),
+                $"{AnalyzerIdentifiers.NotNullUsage} is missing.");
+            Assert.That(diagnosticIds, Contains.Item(AnalyzerIdentifiers.IsNotNullUsage),
+                $"{AnalyzerIdentifiers.IsNotNullUsage} is missing.");
         }
 
         [Test]
@@ -208,6 +216,74 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void Test()
         {
             ↓Assert.AreSame(2, 3);
+        }
+    }");
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenIsNullIsUsed()
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.IsNullUsage);
+
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenIsNullIsUsed
+    {
+        public void Test()
+        {
+            object obj = null;
+            ↓Assert.IsNull(obj);
+        }
+    }");
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNullIsUsed()
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.NullUsage);
+
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenNullIsUsed
+    {
+        public void Test()
+        {
+            object obj = null;
+            ↓Assert.Null(obj);
+        }
+    }");
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenIsNotNullIsUsed()
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.IsNotNullUsage);
+
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenIsNotNullIsUsed
+    {
+        public void Test()
+        {
+            object obj = null;
+            ↓Assert.IsNotNull(obj);
+        }
+    }");
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNotNullIsUsed()
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.NotNullUsage);
+
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenNotNullIsUsed
+    {
+        public void Test()
+        {
+            object obj = null;
+            ↓Assert.NotNull(obj);
         }
     }");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.ClassicModelAssertUsage;
+using NUnit.Analyzers.Constants;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
+{
+    [TestFixture]
+    public sealed class IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new ClassicModelAssertUsageAnalyzer();
+        private static readonly CodeFixProvider fix = new IsNotNullAndNotNullClassicModelAssertUsageCodeFix();
+
+        [Test]
+        public void VerifyGetFixableDiagnosticIds()
+        {
+            var fix = new IsNotNullAndNotNullClassicModelAssertUsageCodeFix();
+            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+
+            Assert.That(ids.Length, Is.EqualTo(2), nameof(ids.Length));
+            Assert.That(ids, Contains.Item(AnalyzerIdentifiers.IsNotNullUsage), nameof(AnalyzerIdentifiers.IsNotNullUsage));
+            Assert.That(ids, Contains.Item(AnalyzerIdentifiers.NotNullUsage), nameof(AnalyzerIdentifiers.NotNullUsage));
+        }
+
+        [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
+        [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
+        public void VerifyIsNotNullAndNotNullFixes(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object obj = null;
+            ↓Assert.{assertion}(obj);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object obj = null;
+            Assert.That(obj, Is.Not.Null);
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
+        [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
+        public void VerifyIsNotNullAndNotNullFixesWithMessage(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object obj = null;
+            ↓Assert.{assertion}(obj, ""message"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object obj = null;
+            Assert.That(obj, Is.Not.Null, ""message"");
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
+        [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
+        public void VerifyIsNotNullAndNotNullFixesWithMessageAndParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object obj = null;
+            ↓Assert.{assertion}(obj, ""message"", Guid.NewGuid());
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object obj = null;
+            Assert.That(obj, Is.Not.Null, ""message"", Guid.NewGuid());
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.ClassicModelAssertUsage;
+using NUnit.Analyzers.Constants;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
+{
+    [TestFixture]
+    public sealed class IsNullAndNullClassicModelAssertUsageCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new ClassicModelAssertUsageAnalyzer();
+        private static readonly CodeFixProvider fix = new IsNullAndNullClassicModelAssertUsageCodeFix();
+
+        [Test]
+        public void VerifyGetFixableDiagnosticIds()
+        {
+            var fix = new IsNullAndNullClassicModelAssertUsageCodeFix();
+            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+
+            Assert.That(ids.Length, Is.EqualTo(2), nameof(ids.Length));
+            Assert.That(ids, Contains.Item(AnalyzerIdentifiers.IsNullUsage), nameof(AnalyzerIdentifiers.IsNullUsage));
+            Assert.That(ids, Contains.Item(AnalyzerIdentifiers.NullUsage), nameof(AnalyzerIdentifiers.NullUsage));
+        }
+
+        [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
+        [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
+        public void VerifyIsNullAndNullFixes(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object obj = null;
+            ↓Assert.{assertion}(obj);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object obj = null;
+            Assert.That(obj, Is.Null);
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
+        [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
+        public void VerifyIsNullAndNullFixesWithMessage(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object obj = null;
+            ↓Assert.{assertion}(obj, ""message"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object obj = null;
+            Assert.That(obj, Is.Null, ""message"");
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
+        [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
+        public void VerifyIsNullAndNullFixesWithMessageAndParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object obj = null;
+            ↓Assert.{assertion}(obj, ""message"", Guid.NewGuid());
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object obj = null;
+            Assert.That(obj, Is.Null, ""message"", Guid.NewGuid());
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+    }
+}

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -67,6 +67,37 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             defaultSeverity: DiagnosticSeverity.Warning,
             description: ClassicModelUsageAnalyzerConstants.AreSameDescription);
 
+        private static readonly DiagnosticDescriptor isNullDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.IsNullUsage,
+            title: ClassicModelUsageAnalyzerConstants.IsNullTitle,
+            messageFormat: ClassicModelUsageAnalyzerConstants.IsNullMessage,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: ClassicModelUsageAnalyzerConstants.IsNullDescription);
+
+        private static readonly DiagnosticDescriptor nullDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.NullUsage,
+            title: ClassicModelUsageAnalyzerConstants.NullTitle,
+            messageFormat: ClassicModelUsageAnalyzerConstants.NullMessage,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: ClassicModelUsageAnalyzerConstants.NullDescription);
+
+        private static readonly DiagnosticDescriptor isNotNullDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.IsNotNullUsage,
+            title: ClassicModelUsageAnalyzerConstants.IsNotNullTitle,
+            messageFormat: ClassicModelUsageAnalyzerConstants.IsNotNullMessage,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: ClassicModelUsageAnalyzerConstants.IsNotNullDescription);
+
+        private static readonly DiagnosticDescriptor notNullDescriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.NotNullUsage,
+            title: ClassicModelUsageAnalyzerConstants.NotNullTitle,
+            messageFormat: ClassicModelUsageAnalyzerConstants.NotNullMessage,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: ClassicModelUsageAnalyzerConstants.NotNullDescription);
 
         private static readonly ImmutableDictionary<string, DiagnosticDescriptor> name =
           new Dictionary<string, DiagnosticDescriptor>
@@ -77,7 +108,11 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
               { NameOfAssertFalse, falseDescriptor },
               { NameOfAssertAreEqual, areEqualDescriptor },
               { NameOfAssertAreNotEqual, areNotEqualDescriptor },
-              { NameOfAssertAreSame, areSameDescriptor }
+              { NameOfAssertAreSame, areSameDescriptor },
+              { NameOfAssertIsNull, isNullDescriptor },
+              { NameOfAssertNull, nullDescriptor },
+              { NameOfAssertIsNotNull, isNotNullDescriptor },
+              { NameOfAssertNotNull, notNullDescriptor }
           }.ToImmutableDictionary();
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.name.Values.ToImmutableArray();

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.ClassicModelAssertUsage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public sealed class IsNotNullAndNotNullClassicModelAssertUsageCodeFix
+        : ClassicModelAssertUsageCodeFix
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+            AnalyzerIdentifiers.IsNotNullUsage,
+            AnalyzerIdentifiers.NotNullUsage);
+
+        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        {
+            arguments.Insert(1, SyntaxFactory.Argument(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIs),
+                        SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIsNot)),
+                    SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfNull))));
+        }
+    }
+}

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.ClassicModelAssertUsage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public sealed class IsNullAndNullClassicModelAssertUsageCodeFix
+        : ClassicModelAssertUsageCodeFix
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+            AnalyzerIdentifiers.IsNullUsage,
+            AnalyzerIdentifiers.NullUsage);
+
+        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        {
+            arguments.Insert(1, SyntaxFactory.Argument(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfIs),
+                    SyntaxFactory.IdentifierName(NunitFrameworkConstants.NameOfNull))));
+        }
+    }
+}

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -38,6 +38,10 @@ namespace NUnit.Analyzers.Constants
         internal const string StringEndsWithConstraintUsage = "NUnit2013";
         internal const string CollectionContainsConstraintUsage = "NUnit2014";
         internal const string AreSameUsage = "NUnit2015";
+        internal const string NullUsage = "NUnit2016";
+        internal const string IsNullUsage = "NUnit2017";
+        internal const string NotNullUsage = "NUnit2018";
+        internal const string IsNotNullUsage = "NUnit2019";
 
         #endregion Assertion
     }

--- a/src/nunit.analyzers/Constants/ClassicModelUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/ClassicModelUsageAnalyzerConstants.cs
@@ -29,5 +29,21 @@ namespace NUnit.Analyzers.Constants
         internal const string AreSameTitle = "Consider using Assert.That(expr2, Is.SameAs(expr1)) instead of Assert.AreSame(expr1, expr2).";
         internal const string AreSameMessage = "Consider using the constraint model, Assert.That(expr2, Is.SameAs(expr1)), instead of the classic model, Assert.AreSame(expr1, expr2).";
         internal const string AreSameDescription = "Consider using the constraint model, Assert.That(expr2, Is.SameAs(expr1)), instead of the classic model, Assert.AreSame(expr1, expr2).";
+
+        internal const string IsNullTitle = "Consider using Assert.That(expr, Is.Null) instead of Assert.IsNull(expr).";
+        internal const string IsNullMessage = "Consider using the constraint model, Assert.That(expr, Is.Null), instead of the classic model, Assert.IsNull(expr).";
+        internal const string IsNullDescription = "Consider using the constraint model, Assert.That(expr, Is.Null), instead of the classic model, Assert.IsNull(expr).";
+
+        internal const string NullTitle = "Consider using Assert.That(expr, Is.Null) instead of Assert.Null(expr).";
+        internal const string NullMessage = "Consider using the constraint model, Assert.That(expr, Is.Null), instead of the classic model, Assert.Null(expr).";
+        internal const string NullDescription = "Consider using the constraint model, Assert.That(expr, Is.Null), instead of the classic model, Assert.Null(expr).";
+
+        internal const string IsNotNullTitle = "Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).";
+        internal const string IsNotNullMessage = "Consider using the constraint model, Assert.That(expr, Is.Not.Null), instead of the classic model, Assert.IsNotNull(expr).";
+        internal const string IsNotNullDescription = "Consider using the constraint model, Assert.That(expr, Is.Not.Null), instead of the classic model, Assert.IsNotNull(expr).";
+
+        internal const string NotNullTitle = "Consider using Assert.That(expr, Is.Not.Null) instead of Assert.NotNull(expr).";
+        internal const string NotNullMessage = "Consider using the constraint model, Assert.That(expr, Is.Not.Null), instead of the classic model, Assert.NotNull(expr).";
+        internal const string NotNullDescription = "Consider using the constraint model, Assert.That(expr, Is.Not.Null), instead of the classic model, Assert.NotNull(expr).";
     }
 }

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -19,6 +19,7 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfIsNotEqualTo = "EqualTo";
         public const string NameOfIsSameAs = "SameAs";
         public const string NameOfIsSamePath = "SamePath";
+        public const string NameOfNull = "Null";
 
         public const string NameOfDoes = "Does";
         public const string NameOfDoesNot = "Not";
@@ -35,6 +36,10 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfAssertAreNotEqual = "AreNotEqual";
         public const string NameOfAssertAreSame = "AreSame";
         public const string NameOfAssertAreNotSame = "AreNotSame";
+        public const string NameOfAssertNull = "Null";
+        public const string NameOfAssertIsNull = "IsNull";
+        public const string NameOfAssertNotNull = "NotNull";
+        public const string NameOfAssertIsNotNull = "IsNotNull";
         public const string NameOfAssertThat = "That";
 
         public const string FullNameOfTypeTestCaseAttribute = "NUnit.Framework.TestCaseAttribute";


### PR DESCRIPTION
Took the Assert.IsFalse() implementation and adapted it for Assert.Null, Assert.IsNull, Assert.NotNull and Assert.IsNotNull.

All unit test cases pass. Compiled and installed the VSIX into VS2019 and the analyzers are detected and code fixes work.

Issue: https://github.com/nunit/nunit.analyzers/issues/163