### PR TITLE
Introduce ConstraintExpression

### DIFF
--- a/src/nunit.analyzers.tests/Syntax/ConstraintExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Syntax/ConstraintExpressionTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Syntax;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Syntax
+{
+    public class ConstraintExpressionTests
+    {
+        [Test]
+        public async Task SimpleIsExpression()
+        {
+            var constraintExpression = await CreateConstraintExpression("Is.EqualTo(1)");
+
+            var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
+            Assert.That(constraintParts, Is.EqualTo(new[] { "Is.EqualTo(1)" }));
+        }
+
+        [Test]
+        public async Task ConstraintConstructor()
+        {
+            var constraintExpression = await CreateConstraintExpression(
+                "new NUnit.Framework.Constraints.EqualConstraint(1)");
+
+            var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
+            Assert.That(constraintParts, Is.EqualTo(new[] { "new NUnit.Framework.Constraints.EqualConstraint(1)" }));
+        }
+
+        [TestCase("&")]
+        [TestCase("|")]
+        public async Task CombinedWithBinaryOperator(string @operator)
+        {
+            var constraintExpression = await CreateConstraintExpression(
+                $"Has.Count.EqualTo(1) {@operator} Has.Some.EqualTo(2)");
+
+            var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
+            Assert.That(constraintParts, Is.EqualTo(new[] { "Has.Count.EqualTo(1)", "Has.Some.EqualTo(2)" }));
+        }
+
+        [TestCase("And")]
+        [TestCase("Or")]
+        [TestCase("With")]
+        public async Task CombinedWithOperatorMethod(string method)
+        {
+            var constraintExpression = await CreateConstraintExpression(
+                $"Has.Count.EqualTo(1).{method}.Some.EqualTo(2)");
+
+            var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
+            Assert.That(constraintParts, Is.EqualTo(new[] { "Has.Count.EqualTo(1)", "Some.EqualTo(2)" }));
+        }
+
+        [Test]
+        public async Task CombinedWithMixedOperators()
+        {
+            var constraintExpression = await CreateConstraintExpression(
+                "Is.Not.Empty & Is.EqualTo(new [] { \"1\" }).IgnoreCase.Or.EquivalentTo(new[] { \"1\", \"2\" })");
+
+            var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
+            Assert.That(constraintParts, Is.EqualTo(new[] {
+                "Is.Not.Empty", "Is.EqualTo(new [] { \"1\" }).IgnoreCase", "EquivalentTo(new[] { \"1\", \"2\" })" }));
+        }
+
+        private static async Task<ConstraintExpression> CreateConstraintExpression(string expressionString)
+        {
+            var testCode = TestUtility.WrapInTestMethod($"Assert.That(1, {expressionString});");
+            var (node, model) = await TestHelpers.GetRootAndModel(testCode);
+
+            var expression = node.DescendantNodes()
+                .OfType<ExpressionSyntax>()
+                .First(e => e.ToString() == expressionString);
+
+            return new ConstraintExpression(expression, model);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/Syntax/ConstraintPartExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Syntax/ConstraintPartExpressionTests.cs
@@ -192,7 +192,7 @@ namespace NUnit.Analyzers.Tests.Syntax
         }
 
         [Test]
-        public async Task GetExprectedArgumentExpression()
+        public async Task GetExpectedArgumentExpression()
         {
             var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(new[] {1, 2, 3}).After(1)");
 

--- a/src/nunit.analyzers.tests/Syntax/ConstraintPartExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Syntax/ConstraintPartExpressionTests.cs
@@ -1,0 +1,266 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Syntax;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Syntax
+{
+    public class ConstraintPartExpressionTests
+    {
+        [Test]
+        public async Task ConstraintMethodWithNoPrefixesAndSuffixes()
+        {
+            var constraintPart = await CreateConstraintPart("Does.Contain(1)");
+
+            Assert.That(constraintPart.SuffixExpressions, Is.Empty);
+            Assert.That(constraintPart.PrefixExpressions, Is.Empty);
+
+            Assert.That(constraintPart.RootExpression, IsInvocation("Contain(1)"));
+        }
+
+        [Test]
+        public async Task ConstraintPropertyWithNoPrefixesAndSuffixes()
+        {
+            var constraintPart = await CreateConstraintPart("Is.Null");
+
+            Assert.That(constraintPart.SuffixExpressions, Is.Empty);
+            Assert.That(constraintPart.PrefixExpressions, Is.Empty);
+
+            Assert.That(constraintPart.RootExpression, IsMemberAccess("Null"));
+        }
+
+        [Test]
+        public async Task WithPropertyPrefix()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Some.EqualTo(1)");
+
+            Assert.That(constraintPart.SuffixExpressions, Is.Empty);
+            Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(1)"));
+
+            Assert.That(constraintPart.PrefixExpressions.Single(), IsMemberAccess("Some"));
+        }
+
+        [Test]
+        public async Task WithMethodPrefix()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(2)");
+
+            Assert.That(constraintPart.SuffixExpressions, Is.Empty);
+            Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(2)"));
+
+            Assert.That(constraintPart.PrefixExpressions.Single(), IsInvocation("Property(\"Prop\")"));
+        }
+
+        [Test]
+        public async Task WithPropertySuffix()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase");
+
+            Assert.That(constraintPart.PrefixExpressions, Is.Empty);
+            Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(\"A\")"));
+
+            Assert.That(constraintPart.SuffixExpressions.Single(), IsMemberAccess("IgnoreCase"));
+        }
+
+        [Test]
+        public async Task WithMethodSuffix()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(10)");
+
+            Assert.That(constraintPart.PrefixExpressions, Is.Empty);
+            Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(1)"));
+
+            Assert.That(constraintPart.SuffixExpressions.Single(), IsInvocation("After(10)"));
+        }
+
+        [Test]
+        public async Task ConstraintIsBuiltUsingMethodOperator()
+        {
+            var constraintParts = await CreateConstraintParts("Is.Empty.Or.Some.EqualTo(\"A\").IgnoreCase");
+
+            var firstPart = constraintParts[0];
+            Assert.That(firstPart.PrefixExpressions, Is.Empty);
+            Assert.That(firstPart.RootExpression, IsMemberAccess("Empty"));
+            Assert.That(firstPart.SuffixExpressions, Is.Empty);
+
+            var secondPart = constraintParts[1];
+            Assert.That(secondPart.PrefixExpressions.Single(), IsMemberAccess("Some"));
+            Assert.That(secondPart.RootExpression, IsInvocation("EqualTo(\"A\")"));
+            Assert.That(secondPart.SuffixExpressions.Single(), IsMemberAccess("IgnoreCase"));
+        }
+
+        [Test]
+        public async Task ConstraintIsCreatedViaConstructor()
+        {
+            var constraintPart = await CreateConstraintPart("new NUnit.Framework.Constraints.EqualConstraint(1)");
+
+            Assert.That(constraintPart.PrefixExpressions, Is.Empty);
+            Assert.That(constraintPart.SuffixExpressions, Is.Empty);
+
+            Assert.That(constraintPart.RootExpression, Is.TypeOf<ObjectCreationExpressionSyntax>());
+            Assert.That(constraintPart.RootExpression.ToString(), Is.EqualTo("new NUnit.Framework.Constraints.EqualConstraint(1)"));
+        }
+
+        [Test]
+        public async Task PrefixNameReturnsPropertyName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.Not.Null");
+
+            Assert.That(constraintPart.GetPrefixesNames(), Is.EqualTo(new[] { "Not" }));
+        }
+
+        [Test]
+        public async Task PrefixNameReturnsMethodName()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).EqualTo(2)");
+
+            Assert.That(constraintPart.GetPrefixesNames(), Is.EqualTo(new[] { "Exactly" }));
+        }
+
+        [Test]
+        public async Task SuffixNameReturnsPropertyName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase");
+
+            Assert.That(constraintPart.GetSuffixesNames(), Is.EqualTo(new[] { "IgnoreCase" }));
+        }
+
+        [Test]
+        public async Task SuffixNameReturnsMethodName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(100, 10)");
+
+            Assert.That(constraintPart.GetSuffixesNames(), Is.EqualTo(new[] { "After" }));
+        }
+
+        [Test]
+        public async Task GetConstraintNameReturnsPropertyName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.Not.Empty");
+
+            Assert.That(constraintPart.GetConstraintName(), Is.EqualTo("Empty"));
+        }
+
+        [Test]
+        public async Task GetConstraintNameReturnsMethodName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(new[] {1, 2}).IgnoreCase");
+
+            Assert.That(constraintPart.GetConstraintName(), Is.EqualTo("EqualTo"));
+        }
+
+        [Test]
+        public async Task GetPrefixExpressionByName()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(1)");
+
+            var prefixExpression = constraintPart.GetPrefixExpression("Property");
+
+            Assert.That(prefixExpression, IsInvocation("Property(\"Prop\")"));
+        }
+
+        [Test]
+        public async Task GetSuffixExpressionByName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"a\").IgnoreCase");
+
+            var suffixExpression = constraintPart.GetSuffixExpression("IgnoreCase");
+
+            Assert.That(suffixExpression, IsMemberAccess("IgnoreCase"));
+        }
+
+        [Test]
+        public async Task GetConstraintMethodReturnsMethodSymbol()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(1.0).Within(0.01)");
+
+            var methodSymbol = constraintPart.GetConstraintMethod();
+
+            Assert.That(methodSymbol, Is.Not.Null);
+            Assert.That(methodSymbol.Name, Is.EqualTo("EqualTo"));
+            Assert.That(methodSymbol.ContainingAssembly.Name, Is.EqualTo(NunitFrameworkConstants.NUnitFrameworkAssemblyName));
+        }
+
+        [Test]
+        public async Task GetConstraintMethodReturnsNullForPropertyConstraint()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.Null.After(1)");
+
+            Assert.That(constraintPart.GetConstraintMethod(), Is.Null);
+        }
+
+        [Test]
+        public async Task GetExprectedArgumentExpression()
+        {
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(new[] {1, 2, 3}).After(1)");
+
+            var expectedExpression = constraintPart.GetExpectedArgumentExpression();
+
+            Assert.That(expectedExpression.ToString(), Is.EqualTo("new[] {1, 2, 3}"));
+        }
+
+        [Test]
+        public async Task HasUnknownExpressionsReturnsTrueIfTernaryExpressionPresent()
+        {
+            var constraintPart = await CreateConstraintPart("(true ? Has.Some : Has.None).EqualTo(1)");
+
+            Assert.That(constraintPart.HasUnknownExpressions(), Is.True);
+        }
+
+        [Test]
+        public async Task HasUnknownExpressionsReturnsTrueIfVariablePresent()
+        {
+            var constraintPart = (await CreateConstraintParts(
+                testMethod: @"
+                    var presentExpected = true;
+                    var prefix = presentExpected ? Has.Some : Has.None;
+                    Assert.That(new[] {1, 2, 3}, prefix.EqualTo(1));",
+                expressionString: "prefix.EqualTo(1)"))[0];
+
+            Assert.That(constraintPart.HasUnknownExpressions(), Is.True);
+        }
+
+        private static Framework.Constraints.Constraint IsInvocation(string text)
+        {
+            return new Framework.Constraints.PredicateConstraint<ExpressionSyntax>(e =>
+            {
+                return e is InvocationExpressionSyntax invocation
+                    && invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                    && (memberAccess.Name.ToString() + invocation.ArgumentList.ToString()) == text;
+            });
+        }
+
+        private static Framework.Constraints.Constraint IsMemberAccess(string text)
+        {
+            return new Framework.Constraints.PredicateConstraint<ExpressionSyntax>(e =>
+            {
+                return e is MemberAccessExpressionSyntax memberAccess
+                    && memberAccess.Name.ToString() == text;
+            });
+        }
+
+        private static async Task<ConstraintPartExpression> CreateConstraintPart(string expressionString)
+        {
+            return (await CreateConstraintParts(expressionString)).Single();
+        }
+
+        private static Task<ConstraintPartExpression[]> CreateConstraintParts(string expressionString)
+        {
+            return CreateConstraintParts($"Assert.That(1, {expressionString});", expressionString);
+        }
+
+        private static async Task<ConstraintPartExpression[]> CreateConstraintParts(string testMethod, string expressionString)
+        {
+            var testCode = TestUtility.WrapInTestMethod(testMethod);
+            var (node, model) = await TestHelpers.GetRootAndModel(testCode);
+
+            var expression = node.DescendantNodes()
+                .OfType<ExpressionSyntax>()
+                .First(e => e.ToString() == expressionString);
+
+            return new ConstraintExpression(expression, model).ConstraintParts;
+        }
+    }
+}

--- a/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
@@ -7,19 +7,19 @@ namespace NUnit.Analyzers.Extensions
 {
     internal static class ExpressionSyntaxExtensions
     {
-        public static List<ExpressionSyntax> SplitCallChain(this ExpressionSyntax expression)
+        public static IEnumerable<ExpressionSyntax> SplitCallChain(this ExpressionSyntax expression)
         {
             // e.g. 'Is.EqualTo(str).IgnoreCase'
             // returns 'Is', 'Is.EqualTo(str)', 'Is.EqualTo(str).IgnoreCase'
 
-            var parts = new List<ExpressionSyntax>();
+            var parts = new Stack<ExpressionSyntax>();
             var currentNode = expression;
 
             while (currentNode != null)
             {
                 if (currentNode is InvocationExpressionSyntax invocation)
                 {
-                    parts.Add(invocation);
+                    parts.Push(invocation);
                     currentNode = invocation.Expression;
                 }
                 else if (currentNode is MemberAccessExpressionSyntax memberAccess)
@@ -29,16 +29,14 @@ namespace NUnit.Analyzers.Extensions
                     // We don't need 'Is.EqualTo' and 'Is.EqualTo(str)' separately, 
                     // therefore add memberAccess only if parent is not invocation syntax
                     if (!(memberAccess.Parent is InvocationExpressionSyntax))
-                        parts.Add(memberAccess);
+                        parts.Push(memberAccess);
                 }
                 else
                 {
-                    parts.Add(currentNode);
+                    parts.Push(currentNode);
                     currentNode = null;
                 }
             }
-
-            parts.Reverse();
 
             return parts;
         }

--- a/src/nunit.analyzers/Helpers/AssertExpressionHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertExpressionHelper.cs
@@ -1,11 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
-using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Syntax;
 
 namespace NUnit.Analyzers.Helpers
 {
@@ -17,15 +13,18 @@ namespace NUnit.Analyzers.Helpers
         /// <returns>
         /// True, if arguments found. Otherwise - false.
         /// </returns>
-        public static bool TryGetActualAndConstraintExpressions(InvocationExpressionSyntax assertExpression,
-            out ExpressionSyntax actualExpression, out ExpressionSyntax constraintExpression)
+        public static bool TryGetActualAndConstraintExpressions(
+            InvocationExpressionSyntax assertExpression,
+            SemanticModel semanticModel,
+            out ExpressionSyntax actualExpression,
+            out ConstraintExpression constraintExpression)
         {
             if (assertExpression.Expression is MemberAccessExpressionSyntax memberAccessSyntax
                 && memberAccessSyntax.Name.Identifier.Text == NunitFrameworkConstants.NameOfAssertThat
                 && assertExpression.ArgumentList.Arguments.Count >= 2)
             {
                 actualExpression = assertExpression.ArgumentList.Arguments[0].Expression;
-                constraintExpression = assertExpression.ArgumentList.Arguments[1].Expression;
+                constraintExpression = new ConstraintExpression(assertExpression.ArgumentList.Arguments[1].Expression, semanticModel);
 
                 return true;
             }
@@ -36,226 +35,6 @@ namespace NUnit.Analyzers.Helpers
 
                 return false;
             }
-        }
-
-        /// <summary>
-        /// Returns 'expected' assertion arguments expressions, along with corresponding constraint method symbols.
-        /// Returns multiple pairs if multiple constraints are combined.
-        /// </summary>
-        public static List<(ExpressionSyntax expectedArgument, IMethodSymbol constraintMethod)> GetExpectedArguments(
-            ExpressionSyntax constraintExpression,
-            SemanticModel semanticModel,
-            CancellationToken cancellationToken)
-        {
-            var expectedArguments = new List<(ExpressionSyntax, IMethodSymbol)>();
-
-            var constraintParts = SplitConstraintByOperators(constraintExpression);
-
-            foreach (var constraintPart in constraintParts)
-            {
-                var expected = GetExpectedArgumentFromConstraintPart(constraintPart, semanticModel, cancellationToken);
-
-                if (expected != null)
-                {
-                    expectedArguments.Add(expected.Value);
-                }
-            }
-
-            return expectedArguments;
-        }
-
-        /// <summary>
-        /// Split constraints into parts by binary ('&' or '|')  or constraint expression operators
-        /// </summary>
-        public static IEnumerable<ExpressionSyntax> SplitConstraintByOperators(ExpressionSyntax constraintExpression)
-        {
-            return SplitConstraintByBinaryOperators(constraintExpression)
-                .SelectMany(SplitConstraintByConstraintExpressionOperators);
-        }
-
-        public static IEnumerable<ExpressionSyntax> GetConstraintExpressionPrefixes(
-            ExpressionSyntax constraintExpression, SemanticModel semanticModel)
-        {
-            // e.g. Has.Property("Prop").Not.EqualTo("1")
-            // -->
-            // Has.Property("Prop"),
-            // Has.Property("Prop").Not
-
-            // Take expressions until found expression returns a constraint
-            return GetExpressionsFromCurrentPart(constraintExpression)
-                .Where(e => e is MemberAccessExpressionSyntax || e is InvocationExpressionSyntax)
-                .TakeWhile(e => !ReturnsConstraint(e, semanticModel));
-        }
-
-        public static IEnumerable<ExpressionSyntax> GetConstraintExpressionSuffixes(
-            ExpressionSyntax constraintExpression, SemanticModel semanticModel)
-        {
-            // e.g. Has.Property("Prop").Not.EqualTo("1").IgnoreCase
-            // -->
-            // Has.Property("Prop").Not.EqualTo("1").IgnoreCase
-
-            // Skip all suffixes, and first expression returning constraint (e.g. 'EqualTo("1")')
-            return GetExpressionsFromCurrentPart(constraintExpression)
-                .SkipWhile(e => !ReturnsConstraint(e, semanticModel))
-                .Skip(1);
-        }
-
-        /// <summary>
-        /// Returns true if <paramref name="constraintExpression"/> has any conditional or variable expressions.
-        /// </summary>
-        public static bool HasUnknownExpressions(ExpressionSyntax constraintExpression, SemanticModel semanticModel)
-        {
-            var expressionParts = constraintExpression.SplitCallChain();
-
-            foreach (var part in expressionParts)
-            {
-                switch (part)
-                {
-                    // e.g. '.EqualTo(1)'
-                    case InvocationExpressionSyntax _:
-                    // e.g. '.IgnoreCase'
-                    case MemberAccessExpressionSyntax _:
-                        break;
-
-                    // Identifier is allowed only if it is type Symbol
-                    // e.g. 'Is', 'Has', etc.
-                    case IdentifierNameSyntax _:
-                        var symbol = semanticModel.GetSymbolInfo(part).Symbol;
-
-                        if (!(symbol is ITypeSymbol typeSymbol)
-                            || typeSymbol.ContainingAssembly.Name != NunitFrameworkConstants.NUnitFrameworkAssemblyName)
-                        {
-                            return true;
-                        }
-
-                        break;
-
-                    default:
-                        return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// If provided constraint expression is combined using &, | operators - return multiple split expressions.
-        /// Otherwise - returns single <paramref name="constraintExpression"/> value
-        /// </summary>
-        private static IEnumerable<ExpressionSyntax> SplitConstraintByBinaryOperators(ExpressionSyntax constraintExpression)
-        {
-            if (constraintExpression is BinaryExpressionSyntax binaryExpression)
-            {
-                foreach (var leftPart in SplitConstraintByOperators(binaryExpression.Left))
-                    yield return leftPart;
-
-                foreach (var rightPart in SplitConstraintByOperators(binaryExpression.Right))
-                    yield return rightPart;
-            }
-            else
-            {
-                yield return constraintExpression;
-            }
-        }
-
-        /// <summary>
-        /// If constraint expression is combined using And, Or, With properties - 
-        /// returns parts of expression split by those properties.
-        /// /// </summary>
-        private static IEnumerable<ExpressionSyntax> SplitConstraintByConstraintExpressionOperators(ExpressionSyntax constraintExpression)
-        {
-            // e.g. Does.Contain(a).IgnoreCase.And.Contain(b).And.Not.Null
-            // --> 
-            // Does.Contain(a).IgnoreCase,
-            // Does.Contain(a).IgnoreCase.And.Contain(b)
-            // Does.Contain(a).IgnoreCase.And.Contain(b).And.Not.Null
-
-            // (You cannot separate only Not.Null part in any way)
-
-            var callChainParts = constraintExpression.SplitCallChain();
-
-            for (var i = 1; i < callChainParts.Count; i++)
-            {
-                if (IsConstraintExpressionOperator(callChainParts[i]))
-                {
-                    yield return callChainParts[i - 1];
-                }
-            }
-
-            yield return constraintExpression;
-        }
-
-        private static (ExpressionSyntax expectedArgument, IMethodSymbol constraintMethod)? GetExpectedArgumentFromConstraintPart(
-            ExpressionSyntax constraintPart,
-            SemanticModel semanticModel,
-            CancellationToken cancellationToken)
-        {
-            // Each constraint part will at most have one method accepting an 'expected' argument.
-
-            foreach (var expression in GetExpressionsFromCurrentPart(constraintPart).Reverse())
-            {
-                if (expression is InvocationExpressionSyntax invocation && invocation.ArgumentList.Arguments.Count == 1)
-                {
-                    var symbol = semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol;
-
-                    if (symbol is IMethodSymbol methodSymbol
-                        && methodSymbol.Parameters.Length == 1
-                        && methodSymbol.Parameters[0].Name == NunitFrameworkConstants.NameOfExpectedParameter)
-                    {
-                        var argument = invocation.ArgumentList.Arguments[0];
-
-                        return (argument.Expression, methodSymbol);
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private static IEnumerable<ExpressionSyntax> GetExpressionsFromCurrentPart(ExpressionSyntax constraintPart)
-        {
-            return constraintPart.SplitCallChain().AsEnumerable()
-                .Reverse()
-                .TakeWhile(e => !(IsConstraintExpressionOperator(e)))
-                .Reverse();
-        }
-
-        /// <summary>
-        /// Returns true if current expression is And/Or/With constraint operator
-        /// </summary>
-        private static bool IsConstraintExpressionOperator(ExpressionSyntax expressionSyntax)
-        {
-            if (expressionSyntax is MemberAccessExpressionSyntax memberAccessExpression)
-            {
-                var name = memberAccessExpression.Name.Identifier.Text;
-
-                if (name == NunitFrameworkConstants.NameOfConstraintExpressionAnd
-                    || name == NunitFrameworkConstants.NameOfConstraintExpressionOr
-                    || name == NunitFrameworkConstants.NameOfConstraintExpressionWith)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool ReturnsConstraint(ExpressionSyntax expressionSyntax, SemanticModel semanticModel)
-        {
-            var symbol = semanticModel.GetSymbolInfo(expressionSyntax).Symbol;
-
-            ITypeSymbol returnType = null;
-
-            if (symbol is IMethodSymbol methodSymbol)
-            {
-                returnType = methodSymbol.ReturnType;
-            }
-            else if (symbol is IPropertySymbol propertySymbol)
-            {
-                returnType = propertySymbol.Type;
-            }
-
-            return returnType != null && returnType.IsConstraint();
         }
     }
 }

--- a/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.SameAsIncompatibleTypes
 
             var sameAsExpectedExpressions = constraintExpression.ConstraintParts
                 .Where(part => part.GetConstraintName() == NunitFrameworkConstants.NameOfIsSameAs
-                    && part.GetConstraintMethod()?.ReturnType?.GetFullMetadataName() == NunitFrameworkConstants.FullNameOfSameAsConstraint)
+                    && part.GetConstraintMethod()?.ReturnType.GetFullMetadataName() == NunitFrameworkConstants.FullNameOfSameAsConstraint)
                 .Select(part => part.GetExpectedArgumentExpression())
                 .Where(ex => ex != null)
                 .ToArray();

--- a/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
@@ -29,17 +29,17 @@ namespace NUnit.Analyzers.SameAsIncompatibleTypes
             var cancellationToken = context.CancellationToken;
             var semanticModel = context.SemanticModel;
 
-            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(assertExpression,
+            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
                 out var actualExpression, out var constraintExpression))
             {
                 return;
             }
 
-            var sameAsExpectedExpressions = AssertExpressionHelper
-                .GetExpectedArguments(constraintExpression, semanticModel, cancellationToken)
-                .Where(ex => ex.constraintMethod.Name == NunitFrameworkConstants.NameOfIsSameAs
-                    && ex.constraintMethod.ReturnType.GetFullMetadataName() == NunitFrameworkConstants.FullNameOfSameAsConstraint)
-                .Select(ex => ex.expectedArgument)
+            var sameAsExpectedExpressions = constraintExpression.ConstraintParts
+                .Where(part => part.GetConstraintName() == NunitFrameworkConstants.NameOfIsSameAs
+                    && part.GetConstraintMethod()?.ReturnType?.GetFullMetadataName() == NunitFrameworkConstants.FullNameOfSameAsConstraint)
+                .Select(part => part.GetExpectedArgumentExpression())
+                .Where(ex => ex != null)
                 .ToArray();
 
             if (sameAsExpectedExpressions.Length == 0)

--- a/src/nunit.analyzers/Syntax/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Syntax/ConstraintExpression.cs
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Syntax
         /// <summary>
         /// If constraint expression is combined using And, Or, With properties - 
         /// returns parts of expression split by those properties.
-        /// /// </summary>
+        /// </summary>
         private static IEnumerable<List<ExpressionSyntax>>
             SplitConstraintByConstraintExpressionOperators(ExpressionSyntax constraintExpression)
         {

--- a/src/nunit.analyzers/Syntax/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Syntax/ConstraintExpression.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.Syntax
+{
+    internal class ConstraintExpression
+    {
+        private readonly ExpressionSyntax expression;
+        private readonly SemanticModel semanticModel;
+        private ConstraintPartExpression[] constraintParts;
+
+        public ConstraintPartExpression[] ConstraintParts
+        {
+            get
+            {
+                if (this.constraintParts == null)
+                {
+                    this.constraintParts = SplitConstraintByOperators(this.expression)
+                        .Select(part => new ConstraintPartExpression(part, this.semanticModel))
+                        .ToArray();
+                }
+
+                return this.constraintParts;
+            }
+        }
+
+        public ConstraintExpression(ExpressionSyntax expression, SemanticModel semanticModel)
+        {
+            this.expression = expression;
+            this.semanticModel = semanticModel;
+        }
+
+        /// <summary>
+        /// Split constraints into parts by binary ('&' or '|')  or constraint expression operators
+        /// </summary>
+        private static IEnumerable<List<ExpressionSyntax>> SplitConstraintByOperators(ExpressionSyntax constraintExpression)
+        {
+            return SplitConstraintByBinaryOperators(constraintExpression)
+                .SelectMany(SplitConstraintByConstraintExpressionOperators);
+        }
+
+        /// <summary>
+        /// If provided constraint expression is combined using &, | operators - return multiple split expressions.
+        /// Otherwise - returns single <paramref name="constraintExpression"/> value
+        /// </summary>
+        private static IEnumerable<ExpressionSyntax> SplitConstraintByBinaryOperators(ExpressionSyntax constraintExpression)
+        {
+            if (constraintExpression is BinaryExpressionSyntax binaryExpression)
+            {
+                foreach (var leftPart in SplitConstraintByBinaryOperators(binaryExpression.Left))
+                    yield return leftPart;
+
+                foreach (var rightPart in SplitConstraintByBinaryOperators(binaryExpression.Right))
+                    yield return rightPart;
+            }
+            else
+            {
+                yield return constraintExpression;
+            }
+        }
+
+        /// <summary>
+        /// If constraint expression is combined using And, Or, With properties - 
+        /// returns parts of expression split by those properties.
+        /// /// </summary>
+        private static IEnumerable<List<ExpressionSyntax>>
+            SplitConstraintByConstraintExpressionOperators(ExpressionSyntax constraintExpression)
+        {
+            // e.g. Does.Contain(a).IgnoreCase.And.Contain(b).And.Not.Null
+            // --> 
+            // Does.Contain(a).IgnoreCase,
+            // Does.Contain(a).IgnoreCase.And.Contain(b)
+            // Does.Contain(a).IgnoreCase.And.Contain(b).And.Not.Null
+
+            var callChainParts = constraintExpression.SplitCallChain();
+
+            var currentPartExpressions = new List<ExpressionSyntax>();
+
+            foreach (var callChainPart in callChainParts)
+            {
+                if (IsConstraintExpressionOperator(callChainPart))
+                {
+                    yield return currentPartExpressions;
+                    currentPartExpressions = new List<ExpressionSyntax>();
+                }
+                else
+                {
+                    currentPartExpressions.Add(callChainPart);
+                }
+            }
+
+            yield return currentPartExpressions;
+        }
+
+        /// <summary>
+        /// Returns true if current expression is And/Or/With constraint operator
+        /// </summary>
+        private static bool IsConstraintExpressionOperator(ExpressionSyntax expressionSyntax)
+        {
+            if (expressionSyntax is MemberAccessExpressionSyntax memberAccessExpression)
+            {
+                var name = memberAccessExpression.Name.Identifier.Text;
+
+                if (name == NunitFrameworkConstants.NameOfConstraintExpressionAnd
+                    || name == NunitFrameworkConstants.NameOfConstraintExpressionOr
+                    || name == NunitFrameworkConstants.NameOfConstraintExpressionWith)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/nunit.analyzers/Syntax/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Syntax/ConstraintExpression.cs
@@ -7,6 +7,9 @@ using NUnit.Analyzers.Extensions;
 
 namespace NUnit.Analyzers.Syntax
 {
+    /// <summary>
+    /// Represents assert constraint expression, e.g. 'Is.EqualTo(expected)', 'Is.Not.Null & Is.Not.Empty'
+    /// </summary>
     internal class ConstraintExpression
     {
         private readonly ExpressionSyntax expression;

--- a/src/nunit.analyzers/Syntax/ConstraintPartExpression.cs
+++ b/src/nunit.analyzers/Syntax/ConstraintPartExpression.cs
@@ -8,6 +8,10 @@ using NUnit.Analyzers.Extensions;
 
 namespace NUnit.Analyzers.Syntax
 {
+    /// <summary>
+    /// Represents part of <see cref="ConstraintExpression"/>, which is combined with others with 
+    /// binary operators ('&', '|')  or methods ('And', 'Or', 'With').
+    /// </summary>
     internal class ConstraintPartExpression
     {
         private readonly SemanticModel semanticModel;
@@ -19,6 +23,10 @@ namespace NUnit.Analyzers.Syntax
             this.semanticModel = semanticModel;
         }
 
+        /// <summary>
+        /// Constraint modifiers that go before actual constraint,
+        /// e.g. 'Not', 'Some', 'Property(propertyName)', etc.
+        /// </summary>
         public IEnumerable<ExpressionSyntax> PrefixExpressions
         {
             get
@@ -35,6 +43,9 @@ namespace NUnit.Analyzers.Syntax
             }
         }
 
+        /// <summary>
+        /// Actual constraint, e.g. 'EqualTo(expected)', 'Null', 'Empty', etc.
+        /// </summary>
         public ExpressionSyntax RootExpression
         {
             get
@@ -43,6 +54,10 @@ namespace NUnit.Analyzers.Syntax
             }
         }
 
+        /// <summary>
+        /// Constraint modifiers that go after actual constraint,
+        /// e.g. 'IgnoreCase', 'After(timeout)', 'Within(range)', etc.
+        /// </summary>
         public IEnumerable<ExpressionSyntax> SuffixExpressions
         {
             get
@@ -58,6 +73,9 @@ namespace NUnit.Analyzers.Syntax
             }
         }
 
+        /// <summary>
+        /// Returns prefixes names (i.e. method or property names).
+        /// </summary>
         public string[] GetPrefixesNames()
         {
             return this.PrefixExpressions
@@ -66,6 +84,9 @@ namespace NUnit.Analyzers.Syntax
                 .ToArray();
         }
 
+        /// <summary>
+        /// Returns suffixes names (i.e. method or property names).
+        /// </summary>
         public string[] GetSuffixesNames()
         {
             return this.SuffixExpressions
@@ -74,21 +95,34 @@ namespace NUnit.Analyzers.Syntax
                 .ToArray();
         }
 
+        /// <summary>
+        /// Returns prefix expression with provided name, or null, if none found.
+        /// </summary>
         public ExpressionSyntax GetPrefixExpression(string name)
         {
             return this.PrefixExpressions.FirstOrDefault(p => GetName(p) == name);
         }
 
+        /// <summary>
+        /// Returns suffix expression with provided name, or null, if none found.
+        /// </summary>
         public ExpressionSyntax GetSuffixExpression(string name)
         {
             return this.SuffixExpressions.FirstOrDefault(s => GetName(s) == name);
         }
 
+        /// <summary>
+        /// Returns constraint root name (i.e. method or property names).
+        /// </summary>
         public string GetConstraintName()
         {
             return GetName(this.RootExpression);
         }
 
+        /// <summary>
+        /// If constraint root is method, returns expected argument expression.
+        /// Otherwise - null.
+        /// </summary>
         public ExpressionSyntax GetExpectedArgumentExpression()
         {
             if (this.RootExpression is InvocationExpressionSyntax invocationExpression)
@@ -99,6 +133,10 @@ namespace NUnit.Analyzers.Syntax
             return null;
         }
 
+        /// <summary>
+        /// If constraint root is method, return corresponding <see cref="IMethodSymbol"/>.
+        /// Otherwise (e.g. if constraint root is property) - null.
+        /// </summary>
         public IMethodSymbol GetConstraintMethod()
         {
             if (this.RootExpression == null)

--- a/src/nunit.analyzers/Syntax/ConstraintPartExpression.cs
+++ b/src/nunit.analyzers/Syntax/ConstraintPartExpression.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.Syntax
+{
+    internal class ConstraintPartExpression
+    {
+        private readonly SemanticModel semanticModel;
+        private readonly IReadOnlyList<ExpressionSyntax> expressions;
+
+        public ConstraintPartExpression(IReadOnlyList<ExpressionSyntax> expressions, SemanticModel semanticModel)
+        {
+            this.expressions = expressions;
+            this.semanticModel = semanticModel;
+        }
+
+        public IEnumerable<ExpressionSyntax> PrefixExpressions
+        {
+            get
+            {
+                // e.g. Has.Property("Prop").Not.EqualTo("1")
+                // -->
+                // Has.Property("Prop"),
+                // Has.Property("Prop").Not
+
+                // Take expressions until found expression returns a constraint
+                return this.expressions
+                    .Where(e => e is MemberAccessExpressionSyntax || e is InvocationExpressionSyntax)
+                    .TakeWhile(e => !ReturnsConstraint(e, this.semanticModel));
+            }
+        }
+
+        public ExpressionSyntax RootExpression
+        {
+            get
+            {
+                return this.expressions.FirstOrDefault(e => ReturnsConstraint(e, this.semanticModel));
+            }
+        }
+
+        public IEnumerable<ExpressionSyntax> SuffixExpressions
+        {
+            get
+            {
+                // e.g. Has.Property("Prop").Not.EqualTo("1").IgnoreCase
+                // -->
+                // Has.Property("Prop").Not.EqualTo("1").IgnoreCase
+
+                // Skip all suffixes, and first expression returning constraint (e.g. 'EqualTo("1")')
+                return this.expressions
+                    .SkipWhile(e => !ReturnsConstraint(e, this.semanticModel))
+                    .Skip(1);
+            }
+        }
+
+        public string[] GetPrefixesNames()
+        {
+            return this.PrefixExpressions
+                .Select(e => GetName(e))
+                .Where(e => e != null)
+                .ToArray();
+        }
+
+        public string[] GetSuffixesNames()
+        {
+            return this.SuffixExpressions
+                .Select(e => GetName(e))
+                .Where(e => e != null)
+                .ToArray();
+        }
+
+        public ExpressionSyntax GetPrefixExpression(string name)
+        {
+            return this.PrefixExpressions.FirstOrDefault(p => GetName(p) == name);
+        }
+
+        public ExpressionSyntax GetSuffixExpression(string name)
+        {
+            return this.SuffixExpressions.FirstOrDefault(s => GetName(s) == name);
+        }
+
+        public string GetConstraintName()
+        {
+            return GetName(this.RootExpression);
+        }
+
+        public ExpressionSyntax GetExpectedArgumentExpression()
+        {
+            if (this.RootExpression is InvocationExpressionSyntax invocationExpression)
+            {
+                return invocationExpression.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+            }
+
+            return null;
+        }
+
+        public IMethodSymbol GetConstraintMethod()
+        {
+            var symbol = this.semanticModel.GetSymbolInfo(this.RootExpression).Symbol;
+            return symbol as IMethodSymbol;
+        }
+
+        /// <summary>
+        /// Returns true if part has any conditional or variable expressions.
+        /// </summary>
+        public bool HasUnknownExpressions()
+        {
+            foreach (var part in this.expressions)
+            {
+                switch (part)
+                {
+                    // e.g. '.EqualTo(1)'
+                    case InvocationExpressionSyntax _:
+                    // e.g. '.IgnoreCase'
+                    case MemberAccessExpressionSyntax _:
+                        break;
+
+                    // Identifier is allowed only if it is type Symbol
+                    // e.g. 'Is', 'Has', etc.
+                    case IdentifierNameSyntax _:
+                        var symbol = this.semanticModel.GetSymbolInfo(part).Symbol;
+
+                        if (!(symbol is ITypeSymbol typeSymbol)
+                            || typeSymbol.ContainingAssembly.Name != NunitFrameworkConstants.NUnitFrameworkAssemblyName)
+                        {
+                            return true;
+                        }
+
+                        break;
+
+                    default:
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetName(ExpressionSyntax expression)
+        {
+            switch (expression)
+            {
+                case MemberAccessExpressionSyntax memberAccess:
+                    return memberAccess.Name.Identifier.Text;
+                case InvocationExpressionSyntax invocation:
+                    return GetName(invocation.Expression);
+                default:
+                    return null;
+            }
+        }
+
+        private static bool ReturnsConstraint(ExpressionSyntax expressionSyntax, SemanticModel semanticModel)
+        {
+            var symbol = semanticModel.GetSymbolInfo(expressionSyntax).Symbol;
+
+            ITypeSymbol returnType = null;
+
+            if (symbol is IMethodSymbol methodSymbol)
+            {
+                returnType = methodSymbol.ReturnType;
+            }
+            else if (symbol is IPropertySymbol propertySymbol)
+            {
+                returnType = propertySymbol.Type;
+            }
+
+            return returnType != null && returnType.IsConstraint();
+        }
+    }
+}

--- a/src/nunit.analyzers/Syntax/ConstraintPartExpression.cs
+++ b/src/nunit.analyzers/Syntax/ConstraintPartExpression.cs
@@ -100,6 +100,9 @@ namespace NUnit.Analyzers.Syntax
 
         public IMethodSymbol GetConstraintMethod()
         {
+            if (this.RootExpression == null)
+                return null;
+
             var symbol = this.semanticModel.GetSymbolInfo(this.RootExpression).Symbol;
             return symbol as IMethodSymbol;
         }


### PR DESCRIPTION
Created classes `ConstraintExpression` and `ConstraintPartExpression`, and moved methods from `AssertExpressionHelper` there.

`ConstraintExpression` represents the whole constraint expression (e.g. `Is.Not.Null & Is.EqualTo("1").Or.EqualTo("A").IgnoreCase`), and has property `ConstraintPartExpression[] ConstraintParts`.

`ConstraintPartExpression` represents single part of constraint expression, which are combined using binary operators (`|` or `&`) or constraint expression operator properties (`.And` or `.Or`). 
(e.g. `Is.Not.Null`, `Is.EqualTo("1")`, `EqualTo("A").IgnoreCase`)
`ConstraintPartExpression` has three main properties:
- `PrefixExpressions` - expressions which go before actual constraint method/property expression (`Not`, `None`, `Count`, `Property(...)` etc).
- `RootExpression` - actual constraint method/property expression (`Null`, `EqualTo("1")` etc.)
- `SuffixExpressions` - expressions which go after actual constraint expression (`IgnoreCase`, `Within(...)`, `Using(...)` etc)



Created draft PR to show idea and for discussion. If suggested approach makes sense, I will add tests, add docs, etc.