### PR TITLE
Add MissingPropertyAnalyzer

### DIFF
--- a/documentation/NUnit2022.md
+++ b/documentation/NUnit2022.md
@@ -1,0 +1,63 @@
+# NUnit2022
+## Missing property required for constraint.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2022
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [MissingPropertyAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs)
+
+
+## Description
+
+Provided 'actual' argument should have required property for constraint.
+
+## Motivation
+
+Using property constraints (e.g. `Has.Count.EqualTo(1)`, `Has.Property("Prop").EqualTo(expected)`, etc) 
+makes sense only when provided actual argument has those properties defined.
+
+```csharp
+[Test]
+public void Test()
+{
+    var enumerable = new [] {1,2,3}.Where(i => i > 1);
+
+    // Actual argument type 'IEnumerable<int>' has no property 'Count'.
+    Assert.That(enumerable, Has.Count.EqualTo(2));
+}
+```
+
+## How to fix violations
+
+Fix your property name, or use another constraint.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2022 // Missing property required for constraint.
+Code violating the rule here
+#pragma warning restore NUnit2022 // Missing property required for constraint.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2022 // Missing property required for constraint.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2022:Missing property required for constraint.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -37,3 +37,4 @@
 | [NUnit2019](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2019.md)| Consider using Assert.That(expr, Is.Not.Null) instead of Assert.IsNotNull(expr).
 | [NUnit2020](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2020.md)| Incompatible types for SameAs constraint.
 | [NUnit2021](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2021.md)| Incompatible types for EqualTo constraint.
+| [NUnit2022](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2022.md)| Missing property required for constraint.

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -47,6 +47,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2019.md = ..\documentation\NUnit2019.md
 		..\documentation\NUnit2020.md = ..\documentation\NUnit2020.md
 		..\documentation\NUnit2021.md = ..\documentation\NUnit2021.md
+		..\documentation\NUnit2022.md = ..\documentation\NUnit2022.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
@@ -1,0 +1,189 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.MissingProperty;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.MissingProperty
+{
+    public class MissingPropertyAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new MissingPropertyAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.MissingProperty);
+
+        [Test]
+        public void AnalyzeWhenHasCountIsUsedForIEnumerable()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new [] {1, 2, 3}.Where(i => i > 1);
+                Assert.That(actual, ↓Has.Count.EqualTo(2));",
+                additionalUsings: "using System.Linq;");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenHasLengthIsUsedForList()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new System.Collections.Generic.List<int> {1, 2, 3};
+                Assert.That(actual, ↓Has.Length.EqualTo(2));");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenHasMessageIsUsedForString()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = ""Can we consider string as message?..."";
+                Assert.That(actual, ↓Has.Message.EqualTo(2),
+                    ""Nope, we can't!"");");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenActualHasNoInnerException()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = 12345;
+                Assert.That(actual, ↓Has.InnerException.TypeOf<InvalidCastException>());");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenPropertyConstraintIsUsedWhenNoSuchInActual()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = 12345;
+                Assert.That(actual, Has.Property(""Whatever"").EqualTo(1));");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenPropertyConstraintIsUsedWhenNoSuchInDelegateActual()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                int getActual() => 12345;
+                Assert.That(getActual, Has.Property(""Whatever"").EqualTo(1));");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void ValidWhenHasCountIsUsedForList()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new [] {1, 2, 3}.Where(i => i > 1).ToList();
+                Assert.That(actual, Has.Count.EqualTo(2));",
+                additionalUsings: "using System.Linq;");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenHasLengthIsUsedForArray()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] {1, 2, 3};
+                Assert.That(actual, Has.Length.EqualTo(3));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenHasLengthIsUsedForString()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = ""ABCDefgh"";
+                Assert.That(actual, Has.Length.EqualTo(8));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenHasMessageIsUsedForException()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new Exception(""SomeMessage"");
+                Assert.That(actual, Has.Message.EqualTo(""SomeMessage""));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenHasInnerExceptionIsUsedForException()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var innerException = new Exception(""inner"");
+                var actual = new Exception(""SomeMessage"", innerException);
+                Assert.That(actual, Has.InnerException.Not.Null);");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenPropertyFromConstraintIsPresentInActual()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = DateTime.UtcNow;
+                Assert.That(actual, Has.Property(""Ticks"").GreaterThan(0));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenPropertyConstraintIsUsedWhenNoSuchInDelegateActual()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                string getActual() => ""12345"";
+                Assert.That(getActual, Has.Property(""Length"").EqualTo(5));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenPropertyIsUsedForAbsenseVerification()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                string actual = ""321"";
+                Assert.That(actual, Has.No.Property(""Whatever""));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenCountIsUsedForAbsenseVerification()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                int actual = 321;
+                Assert.That(actual, Has.No.Count);");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenPropertyChainIsUsed()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new { Foo = new { Bar = ""Baz"" } };
+                Assert.That(actual, Has.Property(""Foo"").With.Property(""Bar"").EqualTo(""Baz""));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenUsedWithThrowsConstraint()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                string getActual() => throw new System.Exception(""Oops"");
+                Assert.That(getActual, Throws.Exception.With.Message.EqualTo(""Oops""));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
@@ -59,7 +59,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = 12345;
-                Assert.That(actual, Has.Property(""Whatever"").EqualTo(1));");
+                Assert.That(actual, ↓Has.Property(""Whatever"").EqualTo(1));");
 
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 int getActual() => 12345;
-                Assert.That(getActual, Has.Property(""Whatever"").EqualTo(1));");
+                Assert.That(getActual, ↓Has.Property(""Whatever"").EqualTo(1));");
 
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
@@ -137,7 +137,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         }
 
         [Test]
-        public void ValidWhenPropertyConstraintIsUsedWhenNoSuchInDelegateActual()
+        public void ValidWhenPropertyConstraintIsUsedForDelegateAndPropertyIsPresentInReturnType()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 string getActual() => ""12345"";
@@ -147,7 +147,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         }
 
         [Test]
-        public void ValidWhenPropertyIsUsedForAbsenseVerification()
+        public void ValidWhenPropertyIsUsedForVerificationOfMissingProperty()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 string actual = ""321"";
@@ -157,7 +157,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         }
 
         [Test]
-        public void ValidWhenCountIsUsedForAbsenseVerification()
+        public void ValidWhenCountIsUsedForAbsenceVerification()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 int actual = 321;

--- a/src/nunit.analyzers.tests/Syntax/ConstraintExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Syntax/ConstraintExpressionTests.cs
@@ -61,6 +61,17 @@ namespace NUnit.Analyzers.Tests.Syntax
                 "Is.Not.Empty", "Is.EqualTo(new [] { \"1\" }).IgnoreCase", "EquivalentTo(new[] { \"1\", \"2\" })" }));
         }
 
+        [Test]
+        public async Task WhenWithIsNop()
+        {
+            var constraintExpression = await CreateConstraintExpression(
+                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")");
+
+            var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
+            Assert.That(constraintParts, Is.EqualTo(new[] {
+                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")" }));
+        }
+
         private static async Task<ConstraintExpression> CreateConstraintExpression(string expressionString)
         {
             var testCode = TestUtility.WrapInTestMethod($"Assert.That(1, {expressionString});");

--- a/src/nunit.analyzers.tests/Syntax/ConstraintPartExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Syntax/ConstraintPartExpressionTests.cs
@@ -14,6 +14,8 @@ namespace NUnit.Analyzers.Tests.Syntax
         {
             var constraintPart = await CreateConstraintPart("Does.Contain(1)");
 
+            Assert.That(constraintPart.HelperClassIdentifier.ToString(), Is.EqualTo("Does"));
+
             Assert.That(constraintPart.SuffixExpressions, Is.Empty);
             Assert.That(constraintPart.PrefixExpressions, Is.Empty);
 
@@ -24,6 +26,8 @@ namespace NUnit.Analyzers.Tests.Syntax
         public async Task ConstraintPropertyWithNoPrefixesAndSuffixes()
         {
             var constraintPart = await CreateConstraintPart("Is.Null");
+
+            Assert.That(constraintPart.HelperClassIdentifier.ToString(), Is.EqualTo("Is"));
 
             Assert.That(constraintPart.SuffixExpressions, Is.Empty);
             Assert.That(constraintPart.PrefixExpressions, Is.Empty);
@@ -36,6 +40,8 @@ namespace NUnit.Analyzers.Tests.Syntax
         {
             var constraintPart = await CreateConstraintPart("Has.Some.EqualTo(1)");
 
+            Assert.That(constraintPart.HelperClassIdentifier.ToString(), Is.EqualTo("Has"));
+
             Assert.That(constraintPart.SuffixExpressions, Is.Empty);
             Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(1)"));
 
@@ -47,6 +53,7 @@ namespace NUnit.Analyzers.Tests.Syntax
         {
             var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(2)");
 
+            Assert.That(constraintPart.HelperClassIdentifier.ToString(), Is.EqualTo("Has"));
             Assert.That(constraintPart.SuffixExpressions, Is.Empty);
             Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(2)"));
 
@@ -58,6 +65,7 @@ namespace NUnit.Analyzers.Tests.Syntax
         {
             var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase");
 
+            Assert.That(constraintPart.HelperClassIdentifier.ToString(), Is.EqualTo("Is"));
             Assert.That(constraintPart.PrefixExpressions, Is.Empty);
             Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(\"A\")"));
 
@@ -69,6 +77,7 @@ namespace NUnit.Analyzers.Tests.Syntax
         {
             var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(10)");
 
+            Assert.That(constraintPart.HelperClassIdentifier.ToString(), Is.EqualTo("Is"));
             Assert.That(constraintPart.PrefixExpressions, Is.Empty);
             Assert.That(constraintPart.RootExpression, IsInvocation("EqualTo(1)"));
 
@@ -81,11 +90,13 @@ namespace NUnit.Analyzers.Tests.Syntax
             var constraintParts = await CreateConstraintParts("Is.Empty.Or.Some.EqualTo(\"A\").IgnoreCase");
 
             var firstPart = constraintParts[0];
+            Assert.That(firstPart.HelperClassIdentifier.ToString(), Is.EqualTo("Is"));
             Assert.That(firstPart.PrefixExpressions, Is.Empty);
             Assert.That(firstPart.RootExpression, IsMemberAccess("Empty"));
             Assert.That(firstPart.SuffixExpressions, Is.Empty);
 
             var secondPart = constraintParts[1];
+            Assert.That(secondPart.HelperClassIdentifier, Is.Null);
             Assert.That(secondPart.PrefixExpressions.Single(), IsMemberAccess("Some"));
             Assert.That(secondPart.RootExpression, IsInvocation("EqualTo(\"A\")"));
             Assert.That(secondPart.SuffixExpressions.Single(), IsMemberAccess("IgnoreCase"));
@@ -96,6 +107,7 @@ namespace NUnit.Analyzers.Tests.Syntax
         {
             var constraintPart = await CreateConstraintPart("new NUnit.Framework.Constraints.EqualConstraint(1)");
 
+            Assert.That(constraintPart.HelperClassIdentifier, Is.Null);
             Assert.That(constraintPart.PrefixExpressions, Is.Empty);
             Assert.That(constraintPart.SuffixExpressions, Is.Empty);
 
@@ -149,6 +161,14 @@ namespace NUnit.Analyzers.Tests.Syntax
             var constraintPart = await CreateConstraintPart("Is.EqualTo(new[] {1, 2}).IgnoreCase");
 
             Assert.That(constraintPart.GetConstraintName(), Is.EqualTo("EqualTo"));
+        }
+
+        [Test]
+        public async Task GetHelperClassNameReturnsIdentifierName()
+        {
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).IgnoreCase");
+
+            Assert.That(constraintPart.GetHelperClassName(), Is.EqualTo("Is"));
         }
 
         [Test]

--- a/src/nunit.analyzers/BaseAssertionAnalyzer.cs
+++ b/src/nunit.analyzers/BaseAssertionAnalyzer.cs
@@ -19,7 +19,7 @@ namespace NUnit.Analyzers
             if (!(context.Node is InvocationExpressionSyntax invocationSyntax))
                 return;
 
-            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax).Symbol as IMethodSymbol;
+            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax, context.CancellationToken).Symbol as IMethodSymbol;
 
             if (methodSymbol == null || !methodSymbol.ContainingType.IsAssert())
                 return;

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -44,6 +44,7 @@ namespace NUnit.Analyzers.Constants
         internal const string IsNotNullUsage = "NUnit2019";
         internal const string SameAsIncompatibleTypes = "NUnit2020";
         internal const string EqualToIncompatibleTypes = "NUnit2021";
+        internal const string MissingProperty = "NUnit2022";
 
         #endregion Assertion
     }

--- a/src/nunit.analyzers/Constants/MissingPropertyConstants.cs
+++ b/src/nunit.analyzers/Constants/MissingPropertyConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers
+{
+    internal static class MissingPropertyConstants
+    {
+        internal const string Title = "Missing property required for constraint.";
+        internal const string MessageFormat = "Actual argument type '{0}' has no property '{1}'.";
+        internal const string Description = "Provided 'actual' argument should have required property for constraint.";
+    }
+}

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -27,6 +27,14 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfDoesStartWith = "StartWith";
         public const string NameOfDoesEndWith = "EndWith";
 
+        public const string NameOfHas = "Has";
+        public const string NameOfHasProperty = "Property";
+        public const string NameOfHasCount = "Count";
+        public const string NameOfHasLength = "Length";
+        public const string NameOfHasMessage = "Message";
+        public const string NameOfHasInnerException = "InnerException";
+        public const string NameOfHasNo = "No";
+
         public const string NameOfAssert = "Assert";
         public const string NameOfAssertIsTrue = "IsTrue";
         public const string NameOfAssertTrue = "True";

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
             var cancellationToken = context.CancellationToken;
             var semanticModel = context.SemanticModel;
 
-            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
                 out var actualExpression, out var constraintExpression))
             {
                 return;
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
 
                 var actualTypeInfo = semanticModel.GetTypeInfo(actualExpression, cancellationToken);
                 var actualType = actualTypeInfo.Type ?? actualTypeInfo.ConvertedType;
-                actualType = UnwrapActualType(actualType);
+                actualType = AssertHelper.UnwrapActualType(actualType);
 
                 if (actualType == null || actualType.TypeKind == TypeKind.Error)
                     continue;
@@ -185,17 +185,6 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
                 return true;
 
             return false;
-        }
-
-        private static ITypeSymbol UnwrapActualType(ITypeSymbol actualType)
-        {
-            if (actualType is INamedTypeSymbol namedType && namedType.DelegateInvokeMethod != null)
-                actualType = namedType.DelegateInvokeMethod.ReturnType;
-
-            if (actualType.IsAwaitable(out var awaitReturnType))
-                actualType = awaitReturnType;
-
-            return actualType;
         }
 
         private static bool IsStream(ITypeSymbol typeSymbol, string fullName)

--- a/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
@@ -66,5 +66,20 @@ namespace NUnit.Analyzers.Extensions
 
             return argument?.Expression;
         }
+
+        public static string GetName(this ExpressionSyntax expression)
+        {
+            switch (expression)
+            {
+                case MemberAccessExpressionSyntax memberAccess:
+                    return memberAccess.Name.Identifier.Text;
+                case InvocationExpressionSyntax invocation:
+                    return GetName(invocation.Expression);
+                case IdentifierNameSyntax identifierName:
+                    return identifierName.Identifier.Text;
+                default:
+                    return null;
+            }
+        }
     }
 }

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -63,6 +63,11 @@ namespace NUnit.Analyzers.Extensions
             }
         }
 
+        internal static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol @this)
+        {
+            return @this.GetMembers().Concat(@this.GetAllBaseTypes().SelectMany(t => t.GetMembers()));
+        }
+
         internal static bool IsTypeParameterAndDeclaredOnMethod(this ITypeSymbol typeSymbol)
             => typeSymbol.TypeKind == TypeKind.TypeParameter &&
                (typeSymbol as ITypeParameterSymbol)?.DeclaringMethod != null;

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -1,11 +1,12 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
 using NUnit.Analyzers.Syntax;
 
 namespace NUnit.Analyzers.Helpers
 {
-    internal static class AssertExpressionHelper
+    internal static class AssertHelper
     {
         /// <summary>
         /// Get provided 'actual' and 'expression' arguments to Assert.That method
@@ -35,6 +36,18 @@ namespace NUnit.Analyzers.Helpers
 
                 return false;
             }
+        }
+
+        // Unwrap underlying type from delegate or awaitable.
+        public static ITypeSymbol UnwrapActualType(ITypeSymbol actualType)
+        {
+            if (actualType is INamedTypeSymbol namedType && namedType.DelegateInvokeMethod != null)
+                actualType = namedType.DelegateInvokeMethod.ReturnType;
+
+            if (actualType.IsAwaitable(out var awaitReturnType))
+                actualType = awaitReturnType;
+
+            return actualType;
         }
     }
 }

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
         protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
             InvocationExpressionSyntax invocationSyntax, IMethodSymbol methodSymbol)
         {
-            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(invocationSyntax, context.SemanticModel,
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(invocationSyntax, context.SemanticModel,
                 out _, out var constraintExpression))
             {
                 return;

--- a/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
+++ b/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
@@ -78,7 +78,7 @@ namespace NUnit.Analyzers.MissingProperty
                     context.ReportDiagnostic(Diagnostic.Create(
                         descriptor,
                         prefix.GetLocation(),
-                        actualSymbol.Name, propertyName));
+                        actualSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat), propertyName));
                 }
             }
         }

--- a/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
+++ b/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Helpers;
+
+namespace NUnit.Analyzers.MissingProperty
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MissingPropertyAnalyzer : BaseAssertionAnalyzer
+    {
+        private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.MissingProperty,
+            title: MissingPropertyConstants.Title,
+            messageFormat: MissingPropertyConstants.MessageFormat,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: MissingPropertyConstants.Description);
+
+        private static readonly string[] implicitPropertyConstraints = new[]
+        {
+            NunitFrameworkConstants.NameOfHasCount,
+            NunitFrameworkConstants.NameOfHasLength,
+            NunitFrameworkConstants.NameOfHasMessage,
+            NunitFrameworkConstants.NameOfHasInnerException,
+        };
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(descriptor);
+
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
+        {
+            var semanticModel = context.SemanticModel;
+
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
+                out var actualExpression, out var constraintExpression))
+            {
+                return;
+            }
+
+            foreach (var constraintPart in constraintExpression.ConstraintParts)
+            {
+                // Only 'Has' allowed (or none) - e.g. 'Throws' leads to verification on exception, which is not supported here. 
+                var helperClassName = constraintPart.GetHelperClassName();
+                if (helperClassName != null && helperClassName != NunitFrameworkConstants.NameOfHas)
+                {
+                    return;
+                }
+
+                if (constraintPart.PrefixExpressions.Count == 0)
+                    continue;
+
+                // Only first prefix supported (as preceding prefixes might change validated type)
+                var prefix = constraintPart.PrefixExpressions.First();
+                var propertyName = TryGetRequiredPropertyName(prefix, semanticModel);
+
+                if (propertyName == null)
+                    continue;
+
+                var actualSymbol = semanticModel.GetTypeInfo(actualExpression).ConvertedType;
+
+                if (actualSymbol == null)
+                    continue;
+
+                actualSymbol = AssertHelper.UnwrapActualType(actualSymbol);
+
+                if (actualSymbol.TypeKind == TypeKind.Error
+                    || actualSymbol.TypeKind == TypeKind.Dynamic
+                    || actualSymbol.SpecialType == SpecialType.System_Object)
+                {
+                    continue;
+                }
+
+                if (!actualSymbol.GetAllMembers().Any(m => m.Kind == SymbolKind.Property && m.Name == propertyName))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        descriptor,
+                        prefix.GetLocation(),
+                        actualSymbol.Name, propertyName));
+                }
+            }
+        }
+
+        private static string TryGetRequiredPropertyName(ExpressionSyntax prefix, SemanticModel semanticModel)
+        {
+            var prefixName = prefix.GetName();
+
+            if (prefix is MemberAccessExpressionSyntax && implicitPropertyConstraints.Contains(prefixName))
+            {
+                return prefixName;
+            }
+            else if (prefix is InvocationExpressionSyntax invocationPrefix
+                && prefixName == NunitFrameworkConstants.NameOfHasProperty
+                && invocationPrefix.ArgumentList.Arguments.Count == 1)
+            {
+                // Get constant value from constraint argument (e.g. Has.Property("PropertyName"))
+                var argument = invocationPrefix.ArgumentList.Arguments[0].Expression;
+                var operation = semanticModel.GetOperation(argument);
+
+                return operation.ConstantValue.Value as string;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs
+++ b/src/nunit.analyzers/SameActualExpectedValue/SameActualExpectedValueAnalyzer.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.SameActualExpectedValue
         protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
             InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
         {
-            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(assertExpression, context.SemanticModel,
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, context.SemanticModel,
                 out var actualExpression, out var constraintExpression))
             {
                 return;

--- a/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.SameAsIncompatibleTypes
             var cancellationToken = context.CancellationToken;
             var semanticModel = context.SemanticModel;
 
-            if (!AssertExpressionHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
                 out var actualExpression, out var constraintExpression))
             {
                 return;

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #128 .

![image](https://user-images.githubusercontent.com/17177729/71786470-3e3ebe80-3014-11ea-8fcd-3ae5e918a359.png)


I've updated roslyn version to 2.6.1 with lowest supported VS 2017 version 15.5. I needed that to be able to use IOperation to get constant value.
(Technically it is possible to use it with 2.0 as well, but it requires explicit feature flag enabled, which makes tests to fail).

Hope that's not a big deal.