### PR TITLE
Fix EqualToIncompatibleTypesAnalyzer boxing false positive

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -661,5 +661,15 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
 
             AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
+
+        [Test]
+        public void NoDiagnosticWhenObjectComparedToInt()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                object actual = 3;
+                Assert.That(actual, Is.EqualTo(3));");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -98,7 +98,7 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
             var conversion = semanticModel.Compilation.ClassifyConversion(actualType, expectedType);
 
             // Same Type possible
-            if (conversion.IsIdentity || conversion.IsReference || conversion.IsNullable)
+            if (conversion.IsIdentity || conversion.IsReference || conversion.IsNullable || conversion.IsBoxing || conversion.IsUnboxing)
                 return true;
 
             // Numeric conversion


### PR DESCRIPTION
```
object actual = 3;
Assert.That(actual, Is.EqualTo(3));
```

Fixed false positive in case above.