### PR TITLE
Fix EqualToIncompatibleTypes for nullable enums

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -85,6 +85,48 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
+        public void AnalyzeWhenDifferentEnumsProvided()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+                enum EnumOne { A, B, C }
+                enum EnumTwo { A, B, C }
+
+                class TestClass
+                {
+                    [Test]
+                    public void EnumTest()
+                    {
+                        var actual = EnumOne.B;
+                        var expected = EnumTwo.B;
+                        Assert.That(actual, Is.EqualTo(↓expected));
+                    }
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenDifferentNullableEnumsProvided()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+                enum EnumOne { A, B, C }
+                enum EnumTwo { A, B, C }
+
+                class TestClass
+                {
+                    [Test]
+                    public void EnumTest()
+                    {
+                        EnumOne? actual = EnumOne.B;
+                        EnumTwo expected = EnumTwo.B;
+                        Assert.That(actual, Is.EqualTo(↓expected));
+                    }
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenIncompatibleTypesWithCyclicTypesProvided()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
@@ -403,6 +445,47 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
 
             AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
+
+        [Test]
+        public void NoDiagnosticWhenSameEnumsProvided()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+                enum EnumOne { A, B, C }
+
+                class TestClass
+                {
+                    [Test]
+                    public void EnumTest()
+                    {
+                        var actual = EnumOne.B;
+                        var expected = EnumOne.B;
+                        Assert.That(actual, Is.EqualTo(expected));
+                    }
+                }");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticWhenSameNullableEnumsProvided()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+                enum EnumOne { A, B, C }
+
+                class TestClass
+                {
+                    [Test]
+                    public void EnumTest()
+                    {
+                        EnumOne? actual = EnumOne.B;
+                        EnumOne expected = EnumOne.B;
+                        Assert.That(actual, Is.EqualTo(expected));
+                    }
+                }");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
 
         [Test]
         public void NoDiagnosticForStreams()

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -95,11 +95,19 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
             SemanticModel semanticModel,
             ImmutableHashSet<(ITypeSymbol, ITypeSymbol)> checkedTypes = default(ImmutableHashSet<(ITypeSymbol, ITypeSymbol)>))
         {
+            if (actualType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+                actualType = ((INamedTypeSymbol)actualType).TypeArguments[0];
+
+            if (expectedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+                expectedType = ((INamedTypeSymbol)expectedType).TypeArguments[0];
+
             var conversion = semanticModel.Compilation.ClassifyConversion(actualType, expectedType);
 
             // Same Type possible
-            if (conversion.IsIdentity || conversion.IsReference || conversion.IsNullable || conversion.IsBoxing || conversion.IsUnboxing)
+            if (conversion.IsIdentity || conversion.IsReference || conversion.IsBoxing || conversion.IsUnboxing)
+            {
                 return true;
+            }
 
             // Numeric conversion
             if (conversion.IsNumeric)


### PR DESCRIPTION
Fixes #179 

Another small one :)

Problem that I've encountered was specifically about nullable enums.

Thing is that conversion from `EnumOne?` to `EnumTwo?` exists and it is `NullableExplicit`.
But it is same `NullableExplcit` for nullable to non-nullable type, e.g. `EnumOne?` -> `EnumOne`.

Therefore we cannot rely solely on conversion information, so I handle nullability case separately.