### PR TITLE
Fix Property analyzer for inherited interfaces

### DIFF
--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
@@ -86,6 +86,17 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         }
 
         [Test]
+        public void ValidWhenHasCountIsUsedForIList()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                IList<int> actual = new [] {1, 2, 3}.Where(i => i > 1).ToList();
+                Assert.That(actual, Has.Count.EqualTo(2));",
+                additionalUsings: "using System.Linq; using System.Collections.Generic;");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenHasLengthIsUsedForArray()
         {
             var testCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -65,7 +65,11 @@ namespace NUnit.Analyzers.Extensions
 
         internal static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol @this)
         {
-            return @this.GetMembers().Concat(@this.GetAllBaseTypes().SelectMany(t => t.GetMembers()));
+            var inheritedMembers = @this.TypeKind == TypeKind.Interface
+                ? @this.AllInterfaces.SelectMany(i => i.GetMembers())
+                : @this.GetAllBaseTypes().SelectMany(t => t.GetMembers());
+
+            return @this.GetMembers().Concat(inheritedMembers);
         }
 
         internal static bool IsTypeParameterAndDeclaredOnMethod(this ITypeSymbol typeSymbol)


### PR DESCRIPTION
Fix `MissingPropertyAnalyzer` not accounting for inherited interfaces. 
E.g. if we have `IList<int>`, property `Count` is inherited from `ICollection<int>`.