### PR TITLE
Fix EqualTo diagnostic when errors present

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -770,8 +770,19 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         public void NoDiagnosticWhenActualIsErrorType()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
-                var actual = 3;
-                var expected = HaveNoIdea();
+                var actual = HaveNoIdea();
+                var expected = 3;
+                Assert.That(actual, Is.EqualTo(expected));");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticWhenActualIsErrorTypeArray()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] { HaveNoIdea() };
+                var expected = new[] { 3 };
                 Assert.That(actual, Is.EqualTo(expected));");
 
             AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);

--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -754,5 +754,38 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
 
             AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
+
+        [Test]
+        public void NoDiagnosticWhenExpectedIsErrorType()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = 3;
+                var expected = HaveNoIdea();
+                Assert.That(actual, Is.EqualTo(expected));");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticWhenActualIsErrorType()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = 3;
+                var expected = HaveNoIdea();
+                Assert.That(actual, Is.EqualTo(expected));");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticWhenExpectedIsErrorTypeArray()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] { 3 };
+                var expected = HaveNoIdea();
+                Assert.That(actual, Is.EqualTo(new[] { expected }));");
+
+            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -23,8 +23,5 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Don't show incompatible types diagnostic when type info is missing.

This validation was already present, but didn't work for recursive checks (e.g. when we have array or list with unknown element type).