### PR TITLE
TestCaseUsage - do not warn if type is unknown

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -199,13 +199,13 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void AnalyzeArgumentIsStringConvertedToEnum()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-    class AnalyzeArgumentIsIntConvertedToEnum
+    class AnalyzeArgumentIsStringConvertedToEnum
     {
         public enum TestEnum { A,B,C }
 
 
-        [TestCase(""A"")]
-        [TestCase(""B"")]
+        [TestCase(↓""A"")]
+        [TestCase(↓""B"")]
         public void Test(TestEnum e) { }
     }");
             AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(
@@ -217,12 +217,12 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void AnalyzeArgumentIsEnumConvertedToString()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-    class AnalyzeArgumentIsEnumConvertedToInt
+    class AnalyzeArgumentIsEnumConvertedToString
     {
         public enum TestEnum { A,B,C }
 
-        [TestCase(TestEnum.A)]
-        [TestCase(TestEnum.B)]
+        [TestCase(↓TestEnum.A)]
+        [TestCase(↓TestEnum.B)]
         public void Test(string e) { }
     }");
             AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -24,6 +24,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
                 yield return new TestCaseData("23:59:59", typeof(TimeSpan));
                 yield return new TestCaseData("2019-10-10", typeof(DateTimeOffset));
                 yield return new TestCaseData("2019-10-14T19:15:25+00:00", typeof(DateTimeOffset));
+                yield return new TestCaseData("https://github.com/nunit/", typeof(Uri));
             }
         }
 
@@ -192,6 +193,41 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int e) { }
     }");
             AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeArgumentIsStringConvertedToEnum()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    class AnalyzeArgumentIsIntConvertedToEnum
+    {
+        public enum TestEnum { A,B,C }
+
+
+        [TestCase(""A"")]
+        [TestCase(""B"")]
+        public void Test(TestEnum e) { }
+    }");
+            AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(
+                ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
+                testCode);
+        }
+
+        [Test]
+        public void AnalyzeArgumentIsEnumConvertedToString()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    class AnalyzeArgumentIsEnumConvertedToInt
+    {
+        public enum TestEnum { A,B,C }
+
+        [TestCase(TestEnum.A)]
+        [TestCase(TestEnum.B)]
+        public void Test(string e) { }
+    }");
+            AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(
+                ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
+                testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -156,7 +156,6 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     {
         public enum TestEnum { A,B,C }
 
-
         [TestCase(TestEnum.A)]
         [TestCase(TestEnum.B)]
         public void Test(TestEnum e) { }
@@ -171,7 +170,6 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     class AnalyzeArgumentIsIntConvertedToEnum
     {
         public enum TestEnum { A,B,C }
-
 
         [TestCase(0)]
         [TestCase(1)]
@@ -202,7 +200,6 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     class AnalyzeArgumentIsStringConvertedToEnum
     {
         public enum TestEnum { A,B,C }
-
 
         [TestCase(↓""A"")]
         [TestCase(↓""B"")]

--- a/src/nunit.analyzers/Extensions/AttributeArgumentSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentSyntaxExtensions.cs
@@ -78,20 +78,23 @@ namespace NUnit.Analyzers.Extensions
                     var reflectionTargetType = GetTargetReflectionType(targetType);
                     var reflectionArgumentType = GetTargetReflectionType(argumentType);
 
-                    if (reflectionTargetType != null && reflectionArgumentType != null)
+                    if (reflectionTargetType == null || reflectionArgumentType == null)
                     {
-                        TypeConverter converter = TypeDescriptor.GetConverter(reflectionTargetType);
-                        if (converter.CanConvertFrom(reflectionArgumentType))
+                        // Shouldn't report diagnostic if type is unknown for analyzer.
+                        return true;
+                    }
+
+                    TypeConverter converter = TypeDescriptor.GetConverter(reflectionTargetType);
+                    if (converter.CanConvertFrom(reflectionArgumentType))
+                    {
+                        try
                         {
-                            try
-                            {
-                                converter.ConvertFrom(null, CultureInfo.InvariantCulture, argumentValue);
-                                return true;
-                            }
-                            catch
-                            {
-                                return false;
-                            }
+                            converter.ConvertFrom(null, CultureInfo.InvariantCulture, argumentValue);
+                            return true;
+                        }
+                        catch
+                        {
+                            return false;
                         }
                     }
 


### PR DESCRIPTION
fixes #186 

Change is very simple - if type is unknown in runtime - do not show warnings.
We can add more supported cases, but I believe that this behavior (do not warn if don't know whether types can be converted) should remain anyway.

(Note - I added test case with Uri, but it does not reproduce issue itself, probably because of how we create test project) 