### PR TITLE
fix: Replace invalid tokens in suffix

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -76,7 +76,7 @@ Setup(context =>
                 else if (AppVeyor.Environment.Repository.Branch.StartsWith("release", StringComparison.OrdinalIgnoreCase))
                     suffix += "-pre-" + buildNumber;
                 else
-                    suffix += "-" + branch;
+                    suffix += "-" + System.Text.RegularExpressions.Regex.Replace(branch, "[^0-9A-Za-z-]+", "-");
 
                 // Nuget limits "special version part" to 20 chars. Add one for the hyphen.
                 if (suffix.Length > 21)


### PR DESCRIPTION
Otherwise pack can fail with NU5010, as the version string specified is invalid.