### PR TITLE
feat: Handle type conversion conservatively without loading types

### DIFF
--- a/src/nunit.analyzers.tests/Extensions/AttributeArgumentSyntaxExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/AttributeArgumentSyntaxExtensionsTests.cs
@@ -25,8 +25,8 @@ namespace NUnit.Analyzers.Tests.Extensions
                 SetName("CanAssignToWhenArgumentIsNotNullableAndAssignable");
             yield return new TestCaseData("3", "int", "int?", Is.True).
                 SetName("CanAssignToWhenArgumentIsNullableAndAssignable");
-            yield return new TestCaseData("\"x\"", "Guid", "string", Is.False).
-                SetName("CanAssignToWhenArgumentIsNotAssignable");
+            yield return new TestCaseData("\"a084f0aa-6fe6-4211-9def-3d294dbdaf01\"", "Guid", "string", Is.True).
+                SetName("CanAssignToWhenArgumentIsConvertibleFromString");
             yield return new TestCaseData("3", "short", "int", Is.True).
                 SetName("CanAssignToWhenParameterIsInt16AndArgumentIsInt32");
             yield return new TestCaseData("3", "byte", "int", Is.True).
@@ -38,25 +38,17 @@ namespace NUnit.Analyzers.Tests.Extensions
             yield return new TestCaseData("3d", "decimal", "double", Is.True).
                 SetName("CanAssignToWhenParameterIsDecimalAndArgumentIsDouble");
             yield return new TestCaseData("\"3\"", "decimal", "string", Is.True).
-                SetName("CanAssignToWhenParameterIsDecimalAndArgumentIsValidString");
-            yield return new TestCaseData("\"x\"", "decimal", "string", Is.False).
-                SetName("CanAssignToWhenParameterIsDecimalAndArgumentIsInvalidString");
+                SetName("CanAssignToWhenParameterIsDecimal");
             yield return new TestCaseData("3", "decimal", "int", Is.True).
                 SetName("CanAssignToWhenParameterIsDecimalAndArgumentIsInt32");
             yield return new TestCaseData("3", "long?", "int", Is.True).
                 SetName("CanAssignToWhenParameterIsNullableInt64AndArgumentIsInt32");
             yield return new TestCaseData("\"1/1/2000\"", "DateTime", "string", Is.True).
-                SetName("CanAssignToWhenParameterIsDateTimeAndArgumentIsValidString");
-            yield return new TestCaseData("\"x\"", "DateTime", "string", Is.False).
-                SetName("CanAssignToWhenParameterIsDateTimeAndArgumentIsInvalidString");
+                SetName("CanAssignToWhenParameterIsDateTime");
             yield return new TestCaseData("\"00:03:00\"", "TimeSpan", "string", Is.True).
-                SetName("CanAssignToWhenParameterIsTimeSpanAndArgumentIsValidString");
-            yield return new TestCaseData("\"x\"", "TimeSpan", "string", Is.False).
-                SetName("CanAssignToWhenParameterIsTimeSpanAndArgumentIsInvalidString");
+                SetName("CanAssignToWhenParameterIsTimeSpan");
             yield return new TestCaseData("\"2019-10-14T21:11:10+00:00\"", "DateTimeOffset", "string", Is.True).
-                SetName("CanAssignToWhenParameterIsDateTimeOffsetAndArgumentIsValidString");
-            yield return new TestCaseData("\"x\"", "DateTimeOffset", "string", Is.False).
-                SetName("CanAssignToWhenParameterIsDateTimeOffsetAndArgumentIsInvalidString");
+                SetName("CanAssignToWhenParameterIsDateTimeOffset");
             yield return new TestCaseData("new[] { \"a\", \"b\", \"c\" }", "string[]", "string[]", Is.True).
                 SetName("CanAssignToWhenArgumentIsImplicitlyTypedArrayAndAssignable");
             yield return new TestCaseData("new[] { \"a\", \"b\", \"c\" }", "int[]", "string[]", Is.False).

--- a/src/nunit.analyzers.tests/TestHelpers.cs
+++ b/src/nunit.analyzers.tests/TestHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using NUnit.Framework;
@@ -14,11 +15,7 @@ namespace NUnit.Analyzers.Tests
 
             var compilation = CSharpCompilation.Create(Guid.NewGuid().ToString("N"),
                 syntaxTrees: new[] { tree },
-                references: new[]
-                {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location)
-                });
+                references: MetadataReferences.Transitive(typeof(Assert)));
 
             var model = compilation.GetSemanticModel(tree);
             var root = await tree.GetRootAsync().ConfigureAwait(false);


### PR DESCRIPTION
Fixes #196 

A consequence of this is that we cannot determine the result from `Convert.ChangeType`, so we will assume that it is always successful.