### PR TITLE
Tests fixes

### DIFF
--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
@@ -191,7 +191,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""bcd""));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -201,7 +201,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual.Contains(""bc""));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
@@ -80,7 +80,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new List<int> { 1, 2, 3 }.Remove(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(""1, 2, 3"".Contains(""1""));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -95,18 +95,18 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         [Test]
         public void ValidForUnsupportedStringMethods()
         {
-            var testCode = TestUtility.WrapInTestMethod(@"Assert.That(↓""abc"".IsNormalized());");
+            var testCode = TestUtility.WrapInTestMethod(@"Assert.That(""abc"".IsNormalized());");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
         public void ValidForNonStringMethods()
         {
             var testCode = TestUtility.WrapInTestMethod(
-                @"Assert.That(new List<string> { ""a"",""ab""}.Contains(""ab""));");
+                @"Assert.That(new System.Collections.Generic.List<string> { ""a"",""ab""}.Contains(""ab""));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.EqualToIncompatibleTypes);
 
         private static readonly string[] NumericTypes = new[] {
-            "decimal", "double", "float", "int", "unit", "long", "ulong", "short", "ushort"
+            "decimal", "double", "float", "int", "uint", "long", "ulong", "short", "ushort"
         };
 
         [Test]
@@ -323,7 +323,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -334,7 +334,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.Not.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -344,7 +344,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(() => """", Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -355,7 +355,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -366,7 +366,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -377,7 +377,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -398,7 +398,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -419,7 +419,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -432,7 +432,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 {expectedType} expected = 1;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -443,7 +443,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = (int)actual;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -463,7 +463,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -483,7 +483,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
 
@@ -495,7 +495,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = new System.IO.MemoryStream();
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -507,7 +507,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -519,7 +519,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -531,7 +531,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -540,9 +540,10 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = new KeyValuePair<string, int>(""a"", 1);
                 var expected = new KeyValuePair<string, double>(""a"", 1.0);
-                Assert.That(actual, Is.EqualTo(expected));");
+                Assert.That(actual, Is.EqualTo(expected));",
+                additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -553,7 +554,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = Tuple.Create(""1"", 2);
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -564,7 +565,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = (""1"", 2);
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -589,7 +590,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -614,7 +615,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -625,7 +626,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -636,7 +637,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 dynamic expected = 2;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -657,7 +658,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -678,7 +679,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -688,7 +689,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var actual = ""abc"";
             Assert.That(actual, Has.Property(""Length"").EqualTo(3));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -699,7 +700,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             int expected = 5;
             Assert.That(actual, Is.EqualTo(5));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -710,7 +711,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             int? expected = 5;
             Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -721,7 +722,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             double expected = 5.0;
             Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -731,7 +732,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             bool shouldBePresent = true;
             Assert.That(new[] { 1, 2, 3 }, (shouldBePresent ? Has.Some : Has.None).EqualTo(2));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -742,7 +743,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var constraintModifier = (shouldBePresent ? Has.Some : Has.None);
             Assert.That(new[] { 1, 2, 3 }, constraintModifier.EqualTo(2));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -752,7 +753,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 object actual = 3;
                 Assert.That(actual, Is.EqualTo(3));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
@@ -114,7 +114,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(""A"", Is.EqualTo(""a"").IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [TestCase(nameof(Is.EqualTo))]
@@ -128,7 +128,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = new[] {{""A"",""C"",""B""}};
                 Assert.That(actual, Is.{constraintMethod}(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 System.Collections.IEnumerable expected = new[] {""A"",""C"",""B""};
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 };
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = (""a"", 2, false);
                 Assert.That(actual, Is.EqualTo((""A"", 2, false)).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = System.Tuple.Create(1, ""A"");
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.Generic.KeyValuePair<string, int>(""A"", 1);
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.Generic.KeyValuePair<int, string>(1, ""A"");
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.DictionaryEntry(1, ""A"");
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -218,7 +218,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = (1, new[] { new[] { ""A"" } });
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SameActualExpectedValue/SameActualExpectedValueTests.cs
+++ b/src/nunit.analyzers.tests/SameActualExpectedValue/SameActualExpectedValueTests.cs
@@ -11,7 +11,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
         private static readonly DiagnosticAnalyzer analyzer = new SameActualExpectedValueAnalyzer();
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.SameActualExpectedValue);
-        
+
         [TestCase(nameof(Is.EqualTo))]
         [TestCase(nameof(Is.EquivalentTo))]
         public void AnalyzeWhenSameVariableProvided(string constraintMethod)
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 var str2 = ""test2"";
                 Assert.That(str1, Is.{constraintMethod}(str2));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -101,9 +101,9 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
         {
             var testCode = TestUtility.WrapInTestMethod($@"
                 var str = ""test"";
-                Assert.That(str.Trim(), Is.EqualTo(↓str.TrimEnd()));");
+                Assert.That(str.Trim(), Is.EqualTo(str.TrimEnd()));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
@@ -184,7 +184,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.Not.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -205,7 +205,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(() => """", Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -216,7 +216,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -238,7 +238,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -280,7 +280,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -291,7 +291,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -302,7 +302,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 dynamic expected = 2;
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -323,7 +323,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            AnalyzerAssert.Valid(analyzer, testCode);
         }
     }
 }


### PR DESCRIPTION
Replaced all `AnalyzerAssert.NoAnalyzerDiagnostics` usages with `AnalyzerAssert.Valid`, unless test is specifically for error case handling.

It revealed couple of errors in tests, which I fixed.