### PR TITLE
Fix EqualToIncompatibleTypesAnalyzer false positive

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -798,5 +798,15 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
 
             AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
+
+        [Test]
+        public void NoDiagnosticWhenCombinedConstraintAndUseAllOperator()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] { 1,2,2,1 };
+                Assert.That(actual, Has.All.EqualTo(1).Or.EqualTo(2));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -42,7 +42,9 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
                 if (HasIncompatiblePrefixes(constraintPartExpression)
                     || HasCustomEqualityComparer(constraintPartExpression)
                     || constraintPartExpression.HasUnknownExpressions())
-                    continue;
+                {
+                    return;
+                }
 
                 var constraintMethod = constraintPartExpression.GetConstraintMethod();
 


### PR DESCRIPTION
```
var actual = new[] { 1,2,2,1 };
Assert.That(actual, Has.All.EqualTo(1).Or.EqualTo(2));
```
Currently it shows warning for `EqualTo(2)`. 

Caused by #218 . I haven't figured out how to fix that issue properly so far, so adding this micro fix to analyzer itself.