### PR TITLE
Fix StringConstraintAnalyzer false positive for delegate/task

### DIFF
--- a/src/nunit.analyzers.tests/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzerTests.cs
@@ -48,6 +48,26 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
         }
 
         [Test]
+        public void ValidWhenStringTaskValueProvided([ValueSource(nameof(StringConstraints))] string stringConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                var actual = Task.FromResult(""1234"");
+                Assert.That(actual, {stringConstraint});");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenStringDelegateProvided([ValueSource(nameof(StringConstraints))] string stringConstraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                var actual = ""1234"";
+                Assert.That(() => actual, {stringConstraint});");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenValueConvertedToStringProvided([ValueSource(nameof(StringConstraints))] string stringConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"

--- a/src/nunit.analyzers/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzer.cs
+++ b/src/nunit.analyzers/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzer.cs
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.StringConstraintWrongActualType
                 return;
             }
 
-            var actualType = semanticModel.GetTypeInfo(actualExpression, cancellationToken).Type;
+            var actualType = AssertHelper.GetUnwrappedActualType(actualExpression, semanticModel, cancellationToken);
 
             // Allow 'object' and 'dynamic' to avoid lots of false positives
             if (actualType == null
@@ -68,11 +68,13 @@ namespace NUnit.Analyzers.StringConstraintWrongActualType
 
                 if (constraintType != null && SupportedConstraints.Contains(constraintType.GetFullMetadataName()))
                 {
+                    var actualTypeDisplay = actualType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+
                     context.ReportDiagnostic(Diagnostic.Create(
                         descriptor,
                         constraintPart.GetLocation(),
                         constraintType.Name,
-                        actualType.Name));
+                        actualTypeDisplay));
                 }
             }
         }


### PR DESCRIPTION
```
Assert.That(Task.FromResult("1234"), Does.Contain("1"));
Assert.That(() => "1234", Does.Contain("1"));
```

No diagnostics expected for cases above.