### PR TITLE
Add ContainsConstraintWrongActualTypeAnalyzer

### DIFF
--- a/documentation/NUnit2025.md
+++ b/documentation/NUnit2025.md
@@ -12,11 +12,11 @@
 
 ## Description
 
-The ContainsConstraint constraint requires actual argument to be either string, or collection of strings.
+The ContainsConstraint requires actual value to be either a string or a collection of strings.
 
 ## Motivation
 
-Using ContainsConstraint with actual argument, which is not a string and not a collection of strings, leads to assertion error.
+Using a ContainsConstraint with an actual argument, which is neither a string nor a collection of strings, leads to an assertion error.
 
 ## How to fix violations
 

--- a/documentation/NUnit2025.md
+++ b/documentation/NUnit2025.md
@@ -1,0 +1,51 @@
+# NUnit2025
+## Wrong actual type used with ContainsConstraint.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2025
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [ContainsConstraintWrongActualTypeAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzer.cs)
+
+
+## Description
+
+The ContainsConstraint constraint requires actual argument to be either string, or collection of strings.
+
+## Motivation
+
+Using ContainsConstraint with actual argument, which is not a string and not a collection of strings, leads to assertion error.
+
+## How to fix violations
+
+Fix the actual value or use appropriate constraint.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2025 // Wrong actual type used with ContainsConstraint.
+Code violating the rule here
+#pragma warning restore NUnit2025 // Wrong actual type used with ContainsConstraint.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2025 // Wrong actual type used with ContainsConstraint.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2025:Wrong actual type used with ContainsConstraint.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -46,3 +46,4 @@
 | [NUnit2022](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2022.md)| Missing property required for constraint. | :white_check_mark: |
 | [NUnit2023](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2023.md)| Invalid NullConstraint usage. | :white_check_mark: |
 | [NUnit2024](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2024.md)| Wrong actual type used with String Constraint. | :white_check_mark: |
+| [NUnit2025](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2025.md)| Wrong actual type used with ContainsConstraint. | :white_check_mark: |

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -56,6 +56,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2022.md = ..\documentation\NUnit2022.md
 		..\documentation\NUnit2023.md = ..\documentation\NUnit2023.md
 		..\documentation\NUnit2024.md = ..\documentation\NUnit2024.md
+		..\documentation\NUnit2025.md = ..\documentation\NUnit2025.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzerTests.cs
@@ -19,7 +19,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
                 "Assert.That(123, ↓Does.Contain(\"1\"));");
 
             AnalyzerAssert.Diagnostics(analyzer,
-                expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with 'int' actual argument."),
+                expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with an actual value of type 'int'."),
                 testCode);
         }
 
@@ -31,7 +31,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
                 Assert.That(actual, ↓Does.Contain(""1""));");
 
             AnalyzerAssert.Diagnostics(analyzer,
-                expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with 'int[]' actual argument."),
+                expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with an actual value of type 'int[]'."),
                 testCode);
         }
 

--- a/src/nunit.analyzers.tests/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzerTests.cs
@@ -1,0 +1,84 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.ContainsConstraintWrongActualType;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
+{
+    public class ContainsConstraintWrongActualTypeAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new ContainsConstraintWrongActualTypeAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.ContainsConstraintWrongActualType);
+
+        [Test]
+        public void AnalyzeWhenNonStringAndNonCollectionActualArgumentProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                "Assert.That(123, ↓Does.Contain(\"1\"));");
+
+            AnalyzerAssert.Diagnostics(analyzer,
+                expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with 'int' actual argument."),
+                testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNonStringCollectionActualArgumentProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] {1, 2, 3};
+                Assert.That(actual, ↓Does.Contain(""1""));");
+
+            AnalyzerAssert.Diagnostics(analyzer,
+                expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with 'int[]' actual argument."),
+                testCode);
+        }
+
+        [Test]
+        public void ValidWhenStringProvidedAsActual()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                "Assert.That(\"123\", Does.Contain(\"1\"));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenStringArrayProvidedAsActual()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[] {""1"", ""2"", ""3""};
+                Assert.That(actual, Does.Contain(""1""));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenUsedWithAllOperator()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                "Assert.That(new [] {\"Aa\", \"Ba\", \"Ca\"}, Has.All.Contains(\"a\"));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenActualIsStringTask()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                "Assert.That(Task.FromResult(\"1234\"), Does.Contain(\"1\"));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenActualIsStringDelegate()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                "Assert.That(() => \"1234\", Does.Contain(\"1\"));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -53,6 +53,7 @@ namespace NUnit.Analyzers.Constants
         internal const string MissingProperty = "NUnit2022";
         internal const string NullConstraintUsage = "NUnit2023";
         internal const string StringConstraintWrongActualType = "NUnit2024";
+        internal const string ContainsConstraintWrongActualType = "NUnit2025";
 
         #endregion Assertion
     }

--- a/src/nunit.analyzers/Constants/ContainsConstraintWrongActualTypeConstants.cs
+++ b/src/nunit.analyzers/Constants/ContainsConstraintWrongActualTypeConstants.cs
@@ -3,7 +3,7 @@ namespace NUnit.Analyzers.Constants
     internal static class ContainsConstraintWrongActualTypeConstants
     {
         public const string Title = "Wrong actual type used with ContainsConstraint.";
-        public const string Message = "The ContainsConstraint cannot be used with '{0}' actual argument.";
-        public const string Description = "The ContainsConstraint constraint requires actual argument to be either string, or collection of strings.";
+        public const string Message = "The ContainsConstraint cannot be used with an actual value of type '{0}'.";
+        public const string Description = "The ContainsConstraint requires actual value to be either a string or a collection of strings.";
     }
 }

--- a/src/nunit.analyzers/Constants/ContainsConstraintWrongActualTypeConstants.cs
+++ b/src/nunit.analyzers/Constants/ContainsConstraintWrongActualTypeConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.Constants
+{
+    internal static class ContainsConstraintWrongActualTypeConstants
+    {
+        public const string Title = "Wrong actual type used with ContainsConstraint.";
+        public const string Message = "The ContainsConstraint cannot be used with '{0}' actual argument.";
+        public const string Description = "The ContainsConstraint constraint requires actual argument to be either string, or collection of strings.";
+    }
+}

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -69,6 +69,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfStartsWithConstraint = "NUnit.Framework.Constraints.StartsWithConstraint";
         public const string FullNameOfSubPathConstraint = "NUnit.Framework.Constraints.SubPathConstraint";
         public const string FullNameOfSubstringConstraint = "NUnit.Framework.Constraints.SubstringConstraint";
+        public const string FullNameOfContainsConstraint = "NUnit.Framework.Constraints.ContainsConstraint";
 
         public const string NameOfTestCaseAttribute = "TestCaseAttribute";
         public const string NameOfTestCaseSourceAttribute = "TestCaseSourceAttribute";

--- a/src/nunit.analyzers/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzer.cs
+++ b/src/nunit.analyzers/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzer.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Helpers;
+
+namespace NUnit.Analyzers.ContainsConstraintWrongActualType
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ContainsConstraintWrongActualTypeAnalyzer : BaseAssertionAnalyzer
+    {
+        private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.ContainsConstraintWrongActualType,
+            title: ContainsConstraintWrongActualTypeConstants.Title,
+            messageFormat: ContainsConstraintWrongActualTypeConstants.Message,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: ContainsConstraintWrongActualTypeConstants.Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(descriptor);
+
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
+        {
+            var cancellationToken = context.CancellationToken;
+            var semanticModel = context.SemanticModel;
+
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
+                out var actualExpression, out var constraintExpression))
+            {
+                return;
+            }
+
+            foreach (var constraintPart in constraintExpression.ConstraintParts)
+            {
+                if (constraintPart.GetPrefixesNames().Any(p => p != NunitFrameworkConstants.NameOfIsNot))
+                    return;
+
+                if (constraintPart.GetConstraintName() != NunitFrameworkConstants.NameOfDoesContain
+                    || constraintPart.GetConstraintTypeSymbol()?.GetFullMetadataName() != NunitFrameworkConstants.FullNameOfContainsConstraint)
+                {
+                    continue;
+                }
+
+                var actualType = AssertHelper.GetUnwrappedActualType(actualExpression, semanticModel, cancellationToken);
+
+                // Valid if actualType is String
+                if (actualType == null
+                    || actualType.TypeKind == TypeKind.Error
+                    || actualType.TypeKind == TypeKind.Dynamic
+                    || actualType.SpecialType == SpecialType.System_String)
+                {
+                    continue;
+                }
+
+                // Valid if actualType is collection of Strings
+                if (actualType.IsIEnumerable(out var elementType)
+                     && (elementType == null || elementType.SpecialType == SpecialType.System_String))
+                {
+                    continue;
+                }
+
+                var actualTypeDisplay = actualType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    descriptor,
+                    constraintPart.GetLocation(),
+                    actualTypeDisplay));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #221 .

Examples:
```csharp
// The ContainsConstraint cannot be used with 'int' actual argument.
Assert.That(123, Does.Contain("1"));

// The ContainsConstraint cannot be used with 'int[]' actual argument.
Assert.That(new[] {1, 2, 3}, Does.Contain("1"));
```

Originally I thought that it is required to support collections with arbitrary element type, but it turned out that ContainsConstraint is used only with strings - `Does.Contain(object)` returns `SomeItemsConstraint` instead.