### PR TITLE
Add SomeItemsIncompatibleTypesAnalyzer

### DIFF
--- a/documentation/NUnit2026.md
+++ b/documentation/NUnit2026.md
@@ -1,5 +1,5 @@
 # NUnit2026
-## Wrong actual type used with SomeItemsConstraint.
+## Wrong actual type used with the SomeItemsConstraint with EqualConstraint.
 
 | Topic    | Value
 | :--      | :--
@@ -12,11 +12,11 @@
 
 ## Description
 
-The SomeItemsConstraint requires actual argument to be a collection with matching element type to the expected argument.
+The SomeItemsConstraint with EqualConstraint requires the actual argument to be a collection where the element type can match the type of the expected argument.
 
 ## Motivation
 
-Using SomeItemsConstraint with actual argument, which is either not a collection, or has wrong element type, leads to assertion error.
+Using Does.Contain or Contains.Item constraints with actual argument, which is either not a collection, or has wrong element type, leads to assertion error.
 
 ## How to fix violations
 
@@ -31,21 +31,21 @@ Configure the severity per project, for more info see [MSDN](https://msdn.micros
 
 ### Via #pragma directive.
 ```C#
-#pragma warning disable NUnit2026 // Wrong actual type used with SomeItemsConstraint.
+#pragma warning disable NUnit2026 // Wrong actual type used with the SomeItemsConstraint with EqualConstraint.
 Code violating the rule here
-#pragma warning restore NUnit2026 // Wrong actual type used with SomeItemsConstraint.
+#pragma warning restore NUnit2026 // Wrong actual type used with the SomeItemsConstraint with EqualConstraint.
 ```
 
 Or put this at the top of the file to disable all instances.
 ```C#
-#pragma warning disable NUnit2026 // Wrong actual type used with SomeItemsConstraint.
+#pragma warning disable NUnit2026 // Wrong actual type used with the SomeItemsConstraint with EqualConstraint.
 ```
 
 ### Via attribute `[SuppressMessage]`.
 
 ```C#
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
-    "NUnit2026:Wrong actual type used with SomeItemsConstraint.",
+    "NUnit2026:Wrong actual type used with the SomeItemsConstraint with EqualConstraint.",
     Justification = "Reason...")]
 ```
 <!-- end generated config severity -->

--- a/documentation/NUnit2026.md
+++ b/documentation/NUnit2026.md
@@ -1,0 +1,51 @@
+# NUnit2026
+## Wrong actual type used with SomeItemsConstraint.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2026
+| Severity | Warning
+| Enabled  | True
+| Category | Assertion
+| Code     | [SomeItemsIncompatibleTypesAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzer.cs)
+
+
+## Description
+
+The SomeItemsConstraint requires actual argument to be a collection with matching element type to the expected argument.
+
+## Motivation
+
+Using SomeItemsConstraint with actual argument, which is either not a collection, or has wrong element type, leads to assertion error.
+
+## How to fix violations
+
+Fix the actual value or use appropriate constraint.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable NUnit2026 // Wrong actual type used with SomeItemsConstraint.
+Code violating the rule here
+#pragma warning restore NUnit2026 // Wrong actual type used with SomeItemsConstraint.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable NUnit2026 // Wrong actual type used with SomeItemsConstraint.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion", 
+    "NUnit2026:Wrong actual type used with SomeItemsConstraint.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -46,3 +46,4 @@
 | [NUnit2022](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2022.md)| Missing property required for constraint. | :white_check_mark: |
 | [NUnit2023](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2023.md)| Invalid NullConstraint usage. | :white_check_mark: |
 | [NUnit2024](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2024.md)| Wrong actual type used with String Constraint. | :white_check_mark: |
+| [NUnit2026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2026.md)| Wrong actual type used with SomeItemsConstraint. | :white_check_mark: |

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -47,4 +47,4 @@
 | [NUnit2023](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2023.md)| Invalid NullConstraint usage. | :white_check_mark: |
 | [NUnit2024](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2024.md)| Wrong actual type used with String Constraint. | :white_check_mark: |
 | [NUnit2025](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2025.md)| Wrong actual type used with ContainsConstraint. | :white_check_mark: |
-| [NUnit2026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2026.md)| Wrong actual type used with SomeItemsConstraint. | :white_check_mark: |
+| [NUnit2026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2026.md)| Wrong actual type used with the SomeItemsConstraint with EqualConstraint. | :white_check_mark: |

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -56,6 +56,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2022.md = ..\documentation\NUnit2022.md
 		..\documentation\NUnit2023.md = ..\documentation\NUnit2023.md
 		..\documentation\NUnit2024.md = ..\documentation\NUnit2024.md
+		..\documentation\NUnit2026.md = ..\documentation\NUnit2026.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/Helpers/NUnitEqualityComparerHelperTests.cs
+++ b/src/nunit.analyzers.tests/Helpers/NUnitEqualityComparerHelperTests.cs
@@ -167,7 +167,7 @@ namespace NUnit.Analyzers.Tests.Helpers
         }
 
         [Test]
-        public void TrueWhenValueTuplesWithIncompatibleElementTypesProvided()
+        public void TrueWhenValueTuplesWithCompatibleElementTypesProvided()
         {
             var compilation = TestHelpers.CreateCompilation();
 

--- a/src/nunit.analyzers.tests/Helpers/NUnitEqualityComparerHelperTests.cs
+++ b/src/nunit.analyzers.tests/Helpers/NUnitEqualityComparerHelperTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using NUnit.Analyzers.Helpers;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Helpers
+{
+    public class NUnitEqualityComparerHelperTests
+    {
+        private static readonly Type[] NumericTypes = new[]
+        {
+            typeof(decimal), typeof(double), typeof(float), typeof(int), typeof(uint),
+            typeof(long), typeof(ulong), typeof(short), typeof(ushort)
+        };
+
+        [TestCase(typeof(string), typeof(int))]
+        [TestCase(typeof(string), typeof(bool))]
+        [TestCase(typeof(int), typeof(bool))]
+        [TestCase(typeof(decimal), typeof(bool))]
+        [TestCase(typeof(List<string>), typeof(List<int>), TestName = "FalseWhenCollectionsWithIncompatibleItemTypesProvided")]
+        [TestCase(typeof(Dictionary<string, string>), typeof(Dictionary<string, double>), TestName = "FalseWhenDictionariesWithIncompatibleValueTypesProvided")]
+        [TestCase(typeof(Dictionary<int, string>), typeof(Dictionary<double, string>), TestName = "FalseWhenDictionariesWithDifferentNumericKeyTypesProvided")]
+        [TestCase(typeof(Tuple<string, string>), typeof(Tuple<string, int>), TestName = "FalseWhenTuplesWithIncompatibleElementTypesProvided")]
+        public void FalseWhenIncompatibleTypesProvided(Type leftType, Type rightType)
+        {
+            var compilation = TestHelpers.CreateCompilation();
+            var leftTypeSymbol = GetTypeSymbol(compilation, leftType);
+            var rightTypeSymbol = GetTypeSymbol(compilation, rightType);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.False);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.False);
+        }
+
+        [Test]
+        public void FalseWhenValueTuplesWithIncompatibleElementTypesProvided()
+        {
+            var compilation = TestHelpers.CreateCompilation();
+
+            var intTypeSymbol = compilation.GetSpecialType(SpecialType.System_Int32);
+            var stringTypeSymbol = compilation.GetSpecialType(SpecialType.System_String);
+            var leftTypeSymbol = compilation.CreateTupleTypeSymbol(ImmutableArray.Create<ITypeSymbol>(intTypeSymbol, intTypeSymbol));
+            var rightTypeSymbol = compilation.CreateTupleTypeSymbol(ImmutableArray.Create<ITypeSymbol>(intTypeSymbol, stringTypeSymbol));
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.False);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.False);
+        }
+
+        [Test]
+        public void FalseWhenDifferentEnumsProvided()
+        {
+            var compilation = TestHelpers.CreateCompilation(@"
+                enum EnumOne { A, B, C }
+                enum EnumTwo { A, B, C }");
+            var leftTypeSymbol = compilation.GetTypeByMetadataName("EnumOne");
+            var rightTypeSymbol = compilation.GetTypeByMetadataName("EnumTwo");
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.False);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.False);
+        }
+
+        [Test]
+        public void FalseWhenDifferentNullableEnumsProvided()
+        {
+            var compilation = TestHelpers.CreateCompilation(@"
+                enum EnumOne { A, B, C }
+                enum EnumTwo { A, B, C }");
+            var nullableTypeSymbol = compilation.GetSpecialType(SpecialType.System_Nullable_T);
+            var leftTypeSymbol = nullableTypeSymbol.Construct(compilation.GetTypeByMetadataName("EnumOne"));
+            var rightTypeSymbol = compilation.GetTypeByMetadataName("EnumTwo");
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.False);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.False);
+        }
+
+        [Test]
+        public void FalseWhenIncompatibleTypesWithCyclicTypesProvided()
+        {
+            var compilation = TestHelpers.CreateCompilation(@"
+                class A : IEnumerable<A>
+                {
+                    public IEnumerator<A> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+
+                class B : IEnumerable<B>
+                {
+                    public IEnumerator<B> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }");
+            var leftTypeSymbol = compilation.GetTypeByMetadataName("A");
+            var rightTypeSymbol = compilation.GetTypeByMetadataName("B");
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.False);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.False);
+        }
+
+        [TestCase(typeof(FileStream), typeof(MemoryStream), TestName = "TrueForStreams")]
+        [TestCase(typeof(List<string>), typeof(string[]), TestName = "TrueForDifferentCollectionsWithSameType")]
+        [TestCase(typeof(List<string>), typeof(ArrayList), TestName = "TrueForNonGenericCollections")]
+        [TestCase(typeof(List<int>), typeof(double[]), TestName = "TrueForDifferentCollectionsWithNumerics")]
+        [TestCase(typeof(Dictionary<string, int>), typeof(Dictionary<string, decimal>), TestName = "TrueForDictionariesOfNumerics")]
+        [TestCase(typeof(KeyValuePair<string, int>), typeof(KeyValuePair<string, double>), TestName = "TrueForKeyValuePairsOfNumerics")]
+        [TestCase(typeof(Tuple<string, double>), typeof(Tuple<string, decimal>), TestName = "TrueForTuplesWithCompatibleElementTypes")]
+        public void TrueWhenCompatibleTypesProvided(Type leftType, Type rightType)
+        {
+            var compilation = TestHelpers.CreateCompilation();
+            var leftTypeSymbol = GetTypeSymbol(compilation, leftType);
+            var rightTypeSymbol = GetTypeSymbol(compilation, rightType);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [TestCase(typeof(string))]
+        [TestCase(typeof(int))]
+        [TestCase(typeof(bool))]
+        public void TrueWhenTypesAreSame(Type type)
+        {
+            var compilation = TestHelpers.CreateCompilation();
+            var typeSymbol = GetTypeSymbol(compilation, type);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(typeSymbol, typeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueWhenOneTypeInheritsAnother()
+        {
+            var compilation = TestHelpers.CreateCompilation(@"
+                class A { }
+                class B : A { }");
+            var leftTypeSymbol = compilation.GetTypeByMetadataName("A");
+            var rightTypeSymbol = compilation.GetTypeByMetadataName("B");
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueForNumericTypes(
+            [ValueSource(nameof(NumericTypes))] Type leftType,
+            [ValueSource(nameof(NumericTypes))] Type rightType)
+        {
+            var compilation = TestHelpers.CreateCompilation();
+            var leftTypeSymbol = GetTypeSymbol(compilation, leftType);
+            var rightTypeSymbol = GetTypeSymbol(compilation, rightType);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueWhenSameNullableEnumsProvided()
+        {
+            var compilation = TestHelpers.CreateCompilation(@"
+                enum EnumOne { A, B, C }");
+            var nullableTypeSymbol = compilation.GetSpecialType(SpecialType.System_Nullable_T);
+            var leftTypeSymbol = compilation.GetTypeByMetadataName("EnumOne");
+            var rightTypeSymbol = nullableTypeSymbol.Construct(leftTypeSymbol);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueWhenValueTuplesWithIncompatibleElementTypesProvided()
+        {
+            var compilation = TestHelpers.CreateCompilation();
+
+            var intTypeSymbol = compilation.GetSpecialType(SpecialType.System_Int32);
+            var doubleTypeSymbol = compilation.GetSpecialType(SpecialType.System_Double);
+            var leftTypeSymbol = compilation.CreateTupleTypeSymbol(ImmutableArray.Create<ITypeSymbol>(intTypeSymbol, intTypeSymbol));
+            var rightTypeSymbol = compilation.CreateTupleTypeSymbol(ImmutableArray.Create<ITypeSymbol>(intTypeSymbol, doubleTypeSymbol));
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueWhenActualHasIEquatableOfExpected()
+        {
+            var compilation = TestHelpers.CreateCompilation(@"
+                class A : System.IEquatable<B>
+                {
+                    public bool Equals(B other) => true;
+                }
+
+                class B { }");
+            var leftTypeSymbol = compilation.GetTypeByMetadataName("A");
+            var rightTypeSymbol = compilation.GetTypeByMetadataName("B");
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueForErrorType()
+        {
+            var compilation = TestHelpers.CreateCompilation();
+
+            var leftTypeSymbol = compilation.GetSpecialType(SpecialType.System_Int32);
+            var rightTypeSymbol = compilation.CreateErrorTypeSymbol(null, "ErrorType", 0);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        [Test]
+        public void TrueForArrayWithElementErrorType()
+        {
+            var compilation = TestHelpers.CreateCompilation();
+
+            var errorType = compilation.CreateErrorTypeSymbol(null, "ErrorType", 0);
+            var leftTypeSymbol = GetTypeSymbol(compilation, typeof(IEnumerable<int>));
+            var rightTypeSymbol = compilation.CreateArrayTypeSymbol(errorType);
+
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(leftTypeSymbol, rightTypeSymbol, compilation), Is.True);
+            Assert.That(NUnitEqualityComparerHelper.CanBeEqual(rightTypeSymbol, leftTypeSymbol, compilation), Is.True);
+        }
+
+        private static ITypeSymbol GetTypeSymbol(Compilation compilation, Type type)
+        {
+            if (type.IsArray)
+            {
+                var elementType = GetTypeSymbol(compilation, type.GetElementType());
+                return compilation.CreateArrayTypeSymbol(elementType);
+            }
+
+            if (type.IsConstructedGenericType)
+            {
+                var genericTypeDefinitionSymbol = compilation.GetTypeByMetadataName(type.GetGenericTypeDefinition().FullName);
+                var genericArgumentsSymbols = type.GetGenericArguments().Select(t => GetTypeSymbol(compilation, t)).ToArray();
+
+                return genericTypeDefinitionSymbol.Construct(genericArgumentsSymbols);
+            }
+
+            return compilation.GetTypeByMetadataName(type.FullName);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
@@ -1,0 +1,118 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.SomeItemsIncompatibleTypes;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
+{
+    [TestFixtureSource(nameof(ConstraintExpressions))]
+    public class SomeItemsIncompatibleTypesAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new SomeItemsIncompatibleTypesAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.SomeItemsIncompatibleTypes);
+
+        private static readonly string[] ConstraintExpressions = new[] { "Does.Contain", "Contains.Item" };
+
+        private readonly string constraint;
+
+        public SomeItemsIncompatibleTypesAnalyzerTests(string constraintExpession)
+        {
+            this.constraint = constraintExpession;
+        }
+
+        [Test]
+        public void AnalyzeWhenNonCollectionActualArgumentProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(123, ↓{this.constraint}(1));");
+
+            AnalyzerAssert.Diagnostics(analyzer,
+                expectedDiagnostic.WithMessage("The SomeItemsConstraint cannot be used with 'int' actual and 'int' expected arguments."),
+                testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenInvalidCollectionActualArgumentProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(new[] {{\"1\", \"2\"}}, ↓{this.constraint}(1));");
+
+            AnalyzerAssert.Diagnostics(analyzer,
+                expectedDiagnostic.WithMessage("The SomeItemsConstraint cannot be used with 'string[]' actual and 'int' expected arguments."),
+                testCode);
+        }
+
+        [Test]
+        public void ValidWhenCollectionIsProvidedAsActualWithMatchingExpectedType()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(new [] {{1, 2, 3}}, {this.constraint}(2));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenCollectionOfCollectionsIsProvidedAsActualAndCollectionAsExpected()
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                var actual = new List<IEnumerable<int>>
+                {{
+                    new [] {{ 1, 2 }},
+                    new List<int> {{ 2, 3 }},
+                    new [] {{ 3, 4 }}
+                }};
+                Assert.That(actual, {this.constraint}(new[] {{ 2, 3 }}));",
+                additionalUsings: "using System.Collections.Generic;");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenCollectionItemTypeAndExpectedTypeAreNumeric()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(new [] {{1.1, 2.0, 3.2}}, {this.constraint}(2));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenActualIsNonGenericCollection()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(new ArrayList {{ 1, 2, 3 }}, {this.constraint}(2));",
+                additionalUsings: "using System.Collections;");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenUsedWithAllOperator()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                "Assert.That(new[] { new[] { 1 }, new[] { 1, 2 } }, Has.All.Contain(1));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenActualIsCollectionTask()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(Task.FromResult(new[] {{1,2,3}}), {this.constraint}(1));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenActualIsCollectionDelegate()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(() => new[] {{1,2,3}}, {this.constraint}(1));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
                 $"Assert.That(123, ↓{this.constraint}(1));");
 
             AnalyzerAssert.Diagnostics(analyzer,
-                expectedDiagnostic.WithMessage("The SomeItemsConstraint cannot be used with 'int' actual and 'int' expected arguments."),
+                expectedDiagnostic.WithMessage($"'{this.constraint}' constraint cannot be used with actual argument of type 'int' and  expected argument of type 'int'."),
                 testCode);
         }
 
@@ -40,7 +40,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
                 $"Assert.That(new[] {{\"1\", \"2\"}}, ↓{this.constraint}(1));");
 
             AnalyzerAssert.Diagnostics(analyzer,
-                expectedDiagnostic.WithMessage("The SomeItemsConstraint cannot be used with 'string[]' actual and 'int' expected arguments."),
+                expectedDiagnostic.WithMessage($"'{this.constraint}' constraint cannot be used with actual argument of type 'string[]' and  expected argument of type 'int'."),
                 testCode);
         }
 

--- a/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
                 $"Assert.That(123, ↓{this.constraint}(1));");
 
             AnalyzerAssert.Diagnostics(analyzer,
-                expectedDiagnostic.WithMessage($"'{this.constraint}' constraint cannot be used with actual argument of type 'int' and  expected argument of type 'int'."),
+                expectedDiagnostic.WithMessage($"'{this.constraint}' constraint cannot be used with actual argument of type 'int' and expected argument of type 'int'."),
                 testCode);
         }
 
@@ -40,7 +40,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
                 $"Assert.That(new[] {{\"1\", \"2\"}}, ↓{this.constraint}(1));");
 
             AnalyzerAssert.Diagnostics(analyzer,
-                expectedDiagnostic.WithMessage($"'{this.constraint}' constraint cannot be used with actual argument of type 'string[]' and  expected argument of type 'int'."),
+                expectedDiagnostic.WithMessage($"'{this.constraint}' constraint cannot be used with actual argument of type 'string[]' and expected argument of type 'int'."),
                 testCode);
         }
 

--- a/src/nunit.analyzers.tests/TestHelpers.cs
+++ b/src/nunit.analyzers.tests/TestHelpers.cs
@@ -8,6 +8,21 @@ namespace NUnit.Analyzers.Tests
 {
     internal static class TestHelpers
     {
+        internal static Compilation CreateCompilation(string code = null)
+        {
+            var syntaxTrees = code is null
+                ? null
+                : new[] { CSharpSyntaxTree.ParseText(code) };
+
+            return CSharpCompilation.Create(Guid.NewGuid().ToString("N"),
+                syntaxTrees,
+                references: new[]
+                {
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location)
+                });
+        }
+
         internal static async Task<(SyntaxNode Node, SemanticModel Model)> GetRootAndModel(string code)
         {
             var tree = CSharpSyntaxTree.ParseText(code);

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -53,6 +53,7 @@ namespace NUnit.Analyzers.Constants
         internal const string MissingProperty = "NUnit2022";
         internal const string NullConstraintUsage = "NUnit2023";
         internal const string StringConstraintWrongActualType = "NUnit2024";
+        internal const string SomeItemsIncompatibleTypes = "NUnit2026";
 
         #endregion Assertion
     }

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -21,6 +21,9 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfIsSamePath = "SamePath";
         public const string NameOfNull = "Null";
 
+        public const string NameOfContains = "Contains";
+        public const string NameOfContainsItem = "Item";
+
         public const string NameOfDoes = "Does";
         public const string NameOfDoesNot = "Not";
         public const string NameOfDoesContain = "Contain";
@@ -60,6 +63,7 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfConstraint = "Constraint";
 
         public const string FullNameOfSameAsConstraint = "NUnit.Framework.Constraints.SameAsConstraint";
+        public const string FullNameOfSomeItemsConstraint = "NUnit.Framework.Constraints.SomeItemsConstraint";
         public const string FullNameOfEqualToConstraint = "NUnit.Framework.Constraints.EqualConstraint";
         public const string FullNameOfEndsWithConstraint = "NUnit.Framework.Constraints.EndsWithConstraint";
         public const string FullNameOfRegexConstraint = "NUnit.Framework.Constraints.RegexConstraint";

--- a/src/nunit.analyzers/Constants/SomeItemsIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SomeItemsIncompatibleTypesConstants.cs
@@ -3,7 +3,7 @@ namespace NUnit.Analyzers.Constants
     internal static class SomeItemsIncompatibleTypesConstants
     {
         public const string Title = "Wrong actual type used with the SomeItemsConstraint with EqualConstraint.";
-        public const string Message = "'{0}' constraint cannot be used with actual argument of type '{1}' and  expected argument of type '{2}'.";
+        public const string Message = "'{0}' constraint cannot be used with actual argument of type '{1}' and expected argument of type '{2}'.";
         public const string Description = "The SomeItemsConstraint with EqualConstraint requires the actual argument to be a collection where the element type can match the type of the expected argument.";
     }
 }

--- a/src/nunit.analyzers/Constants/SomeItemsIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SomeItemsIncompatibleTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class SomeItemsIncompatibleTypesConstants
     {
-        public const string Title = "Wrong actual type used with SomeItemsConstraint.";
-        public const string Message = "The SomeItemsConstraint cannot be used with '{0}' actual and '{1}' expected arguments.";
-        public const string Description = "The SomeItemsConstraint requires actual argument to be a collection with matching element type to the expected argument.";
+        public const string Title = "Wrong actual type used with the SomeItemsConstraint with EqualConstraint.";
+        public const string Message = "'{0}' constraint cannot be used with actual argument of type '{1}' and  expected argument of type '{2}'.";
+        public const string Description = "The SomeItemsConstraint with EqualConstraint requires the actual argument to be a collection where the element type can match the type of the expected argument.";
     }
 }

--- a/src/nunit.analyzers/Constants/SomeItemsIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SomeItemsIncompatibleTypesConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.Constants
+{
+    internal static class SomeItemsIncompatibleTypesConstants
+    {
+        public const string Title = "Wrong actual type used with SomeItemsConstraint.";
+        public const string Message = "The SomeItemsConstraint cannot be used with '{0}' actual and '{1}' expected arguments.";
+        public const string Description = "The SomeItemsConstraint requires actual argument to be a collection with matching element type to the expected argument.";
+    }
+}

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -67,7 +66,7 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
 
                 var expectedType = semanticModel.GetTypeInfo(expectedArgumentExpression, cancellationToken).Type;
 
-                if (!CanBeAssertedForEquality(actualType, expectedType, semanticModel))
+                if (!NUnitEqualityComparerHelper.CanBeEqual(actualType, expectedType, semanticModel.Compilation))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         descriptor,
@@ -87,181 +86,6 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
         private static bool HasCustomEqualityComparer(ConstraintPartExpression constraintPartExpression)
         {
             return constraintPartExpression.GetSuffixesNames().Any(s => s == NunitFrameworkConstants.NameOfUsing);
-        }
-
-        private static bool CanBeAssertedForEquality(
-            ITypeSymbol? actualType,
-            ITypeSymbol? expectedType,
-            SemanticModel semanticModel,
-            ImmutableHashSet<(ITypeSymbol, ITypeSymbol)>? checkedTypes = null)
-        {
-            if (actualType == null
-                || actualType.TypeKind == TypeKind.Error
-                || expectedType == null
-                || expectedType.TypeKind == TypeKind.Error)
-            {
-                // Can't tell anything specific if type is wrong.
-                return true;
-            }
-
-            if (actualType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
-                actualType = ((INamedTypeSymbol)actualType).TypeArguments[0];
-
-            if (expectedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
-                expectedType = ((INamedTypeSymbol)expectedType).TypeArguments[0];
-
-            var conversion = semanticModel.Compilation.ClassifyConversion(actualType, expectedType);
-
-            // Same Type possible
-            if (conversion.IsIdentity || conversion.IsReference || conversion.IsBoxing || conversion.IsUnboxing)
-            {
-                return true;
-            }
-
-            // Numeric conversion
-            if (conversion.IsNumeric)
-                return true;
-
-            // Protection against possible infinite recursion
-            if (checkedTypes == default(ImmutableHashSet<(ITypeSymbol, ITypeSymbol)>))
-                checkedTypes = ImmutableHashSet<(ITypeSymbol, ITypeSymbol)>.Empty;
-
-            if (checkedTypes.Contains((actualType, expectedType)))
-                return false;
-
-            checkedTypes = checkedTypes.Add((actualType, expectedType));
-
-            var actualFullName = actualType.GetFullMetadataName();
-            var expectedFullName = expectedType.GetFullMetadataName();
-
-            var namedActualType = actualType as INamedTypeSymbol;
-            var namedExpectedType = expectedType as INamedTypeSymbol;
-
-            if (namedActualType != null && namedExpectedType != null)
-            {
-                // Tuples
-                if (IsTuple(actualFullName) && IsTuple(expectedFullName))
-                {
-                    return namedActualType.TypeArguments.Length == namedExpectedType.TypeArguments.Length
-                        && Enumerable.Range(0, namedActualType.TypeArguments.Length).All(i =>
-                            CanBeAssertedForEquality(namedActualType.TypeArguments[i], namedExpectedType.TypeArguments[i],
-                                semanticModel, checkedTypes));
-                }
-
-                // ValueTuples
-                if (namedActualType.IsTupleType && namedExpectedType.IsTupleType)
-                {
-                    return namedActualType.TupleElements.Length == namedActualType.TupleElements.Length
-                        && Enumerable.Range(0, namedActualType.TupleElements.Length).All(i =>
-                            CanBeAssertedForEquality(namedActualType.TupleElements[i].Type, namedExpectedType.TupleElements[i].Type,
-                                semanticModel, checkedTypes));
-                }
-
-                // Dictionaries
-                if (IsDictionary(namedActualType, actualFullName, out var actualKeyType, out var actualValueType)
-                    && IsDictionary(namedExpectedType, expectedFullName, out var expectedKeyType, out var expectedValueType))
-                {
-                    // Unlike for KeyValuePairs, Dictionaries Keys should match exactly
-
-                    var keysConversion = semanticModel.Compilation.ClassifyConversion(actualKeyType, expectedKeyType);
-                    var keysMatching = keysConversion.IsIdentity || keysConversion.IsReference;
-
-                    return keysMatching && CanBeAssertedForEquality(actualValueType, expectedValueType, semanticModel, checkedTypes);
-                }
-
-                // KeyValuePairs
-                if (IsKeyValuePair(namedActualType, actualFullName, out actualKeyType, out actualValueType)
-                    && IsKeyValuePair(namedExpectedType, expectedFullName, out expectedKeyType, out expectedValueType))
-                {
-                    return CanBeAssertedForEquality(actualKeyType, expectedKeyType, semanticModel, checkedTypes)
-                        && CanBeAssertedForEquality(actualValueType, expectedValueType, semanticModel, checkedTypes);
-                }
-            }
-
-            // IEnumerables
-            if (actualType.IsIEnumerable(out var actualElementType) && expectedType.IsIEnumerable(out var expectedElementType))
-            {
-                if (actualElementType == null || expectedElementType == null)
-                {
-                    // If actual or expected values implement only non-generic IEnumerable, we cannot determine
-                    // whether types are suitable
-                    return true;
-                }
-                else
-                {
-                    return CanBeAssertedForEquality(actualElementType, expectedElementType, semanticModel, checkedTypes);
-                }
-            }
-
-            // Streams
-            if (IsStream(actualType, actualFullName) && IsStream(expectedType, expectedFullName))
-                return true;
-
-            // IEquatables
-            if (IsIEquatable(actualType, expectedType) || IsIEquatable(expectedType, actualType))
-                return true;
-
-            return false;
-        }
-
-        private static bool IsStream(ITypeSymbol typeSymbol, string fullName)
-        {
-            const string streamFullName = "System.IO.Stream";
-
-            return fullName == streamFullName
-                || typeSymbol.GetAllBaseTypes().Any(t => t.GetFullMetadataName() == streamFullName);
-        }
-
-        private static bool IsKeyValuePair(INamedTypeSymbol typeSymbol, string fullSymbolName,
-            [NotNullWhen(true)] out ITypeSymbol? keyType, [NotNullWhen(true)] out ITypeSymbol? valueType)
-        {
-            const string keyValuePairFullName = "System.Collections.Generic.KeyValuePair`2";
-
-            if (typeSymbol.TypeArguments.Length == 2
-                && fullSymbolName == keyValuePairFullName)
-            {
-                keyType = typeSymbol.TypeArguments[0];
-                valueType = typeSymbol.TypeArguments[1];
-                return true;
-            }
-            else
-            {
-                keyType = null;
-                valueType = null;
-                return false;
-            }
-        }
-
-        private static bool IsDictionary(INamedTypeSymbol typeSymbol, string fullSymbolName,
-            [NotNullWhen(true)] out ITypeSymbol? keyType, [NotNullWhen(true)] out ITypeSymbol? valueType)
-        {
-            const string dictionaryFullName = "System.Collections.Generic.Dictionary`2";
-
-            if (typeSymbol.TypeArguments.Length == 2
-                && fullSymbolName == dictionaryFullName)
-            {
-                keyType = typeSymbol.TypeArguments[0];
-                valueType = typeSymbol.TypeArguments[1];
-                return true;
-            }
-            else
-            {
-                keyType = null;
-                valueType = null;
-                return false;
-            }
-        }
-
-        private static bool IsTuple(string fullName)
-        {
-            return fullName.StartsWith("System.Tuple`");
-        }
-
-        private static bool IsIEquatable(ITypeSymbol typeSymbol, ITypeSymbol equatableTypeArguments)
-        {
-            return typeSymbol.AllInterfaces.Any(i => i.TypeArguments.Length == 1
-                && i.TypeArguments[0].Equals(equatableTypeArguments)
-                && i.GetFullMetadataName() == "System.IEquatable`1");
         }
     }
 }

--- a/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
+++ b/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.Helpers
+{
+    internal static class NUnitEqualityComparerHelper
+    {
+        /// <summary>
+        /// Returns true if it is possible that <see cref="NUnit.Framework.Constraints.NUnitEqualityComparer.AreEqual"/>
+        /// returns true for given argument types. 
+        /// False otherwise.
+        /// </summary>
+        public static bool CanBeEqual(
+            ITypeSymbol? actualType,
+            ITypeSymbol? expectedType,
+            Compilation compilation,
+            ImmutableHashSet<(ITypeSymbol, ITypeSymbol)>? checkedTypes = null)
+        {
+            if (actualType == null
+                || actualType.TypeKind == TypeKind.Error
+                || expectedType == null
+                || expectedType.TypeKind == TypeKind.Error)
+            {
+                // Can't tell anything specific if type is wrong.
+                return true;
+            }
+
+            if (actualType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+                actualType = ((INamedTypeSymbol)actualType).TypeArguments[0];
+
+            if (expectedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+                expectedType = ((INamedTypeSymbol)expectedType).TypeArguments[0];
+
+            var conversion = compilation.ClassifyConversion(actualType, expectedType);
+
+            // Same Type possible
+            if (conversion.IsIdentity || conversion.IsReference || conversion.IsBoxing || conversion.IsUnboxing)
+            {
+                return true;
+            }
+
+            // Numeric conversion
+            if (conversion.IsNumeric)
+                return true;
+
+            // Protection against possible infinite recursion
+            if (checkedTypes == default)
+                checkedTypes = ImmutableHashSet<(ITypeSymbol, ITypeSymbol)>.Empty;
+
+            if (checkedTypes.Contains((actualType, expectedType)))
+                return false;
+
+            checkedTypes = checkedTypes.Add((actualType, expectedType));
+
+            var actualFullName = actualType.GetFullMetadataName();
+            var expectedFullName = expectedType.GetFullMetadataName();
+
+
+            if (actualType is INamedTypeSymbol namedActualType
+                && expectedType is INamedTypeSymbol namedExpectedType)
+            {
+                // Tuples
+                if (IsTuple(actualFullName) && IsTuple(expectedFullName))
+                {
+                    return namedActualType.TypeArguments.Length == namedExpectedType.TypeArguments.Length
+                        && Enumerable.Range(0, namedActualType.TypeArguments.Length).All(i =>
+                            CanBeEqual(namedActualType.TypeArguments[i], namedExpectedType.TypeArguments[i],
+                                compilation, checkedTypes));
+                }
+
+                // ValueTuples
+                if (namedActualType.IsTupleType && namedExpectedType.IsTupleType)
+                {
+                    return namedActualType.TupleElements.Length == namedActualType.TupleElements.Length
+                        && Enumerable.Range(0, namedActualType.TupleElements.Length).All(i =>
+                            CanBeEqual(namedActualType.TupleElements[i].Type, namedExpectedType.TupleElements[i].Type,
+                                compilation, checkedTypes));
+                }
+
+                // Dictionaries
+                if (IsDictionary(namedActualType, actualFullName, out var actualKeyType, out var actualValueType)
+                    && IsDictionary(namedExpectedType, expectedFullName, out var expectedKeyType, out var expectedValueType))
+                {
+                    // Unlike for KeyValuePairs, Dictionaries Keys should match exactly
+
+                    var keysConversion = compilation.ClassifyConversion(actualKeyType, expectedKeyType);
+                    var keysMatching = keysConversion.IsIdentity || keysConversion.IsReference;
+
+                    return keysMatching && CanBeEqual(actualValueType, expectedValueType, compilation, checkedTypes);
+                }
+
+                // KeyValuePairs
+                if (IsKeyValuePair(namedActualType, actualFullName, out actualKeyType, out actualValueType)
+                    && IsKeyValuePair(namedExpectedType, expectedFullName, out expectedKeyType, out expectedValueType))
+                {
+                    return CanBeEqual(actualKeyType, expectedKeyType, compilation, checkedTypes)
+                        && CanBeEqual(actualValueType, expectedValueType, compilation, checkedTypes);
+                }
+            }
+
+            // IEnumerables
+            if (actualType.IsIEnumerable(out var actualElementType) && expectedType.IsIEnumerable(out var expectedElementType))
+            {
+                if (actualElementType == null || expectedElementType == null)
+                {
+                    // If actual or expected values implement only non-generic IEnumerable, we cannot determine
+                    // whether types are suitable
+                    return true;
+                }
+                else
+                {
+                    return CanBeEqual(actualElementType, expectedElementType, compilation, checkedTypes);
+                }
+            }
+
+            // Streams
+            if (IsStream(actualType, actualFullName) && IsStream(expectedType, expectedFullName))
+                return true;
+
+            // IEquatables
+            if (IsIEquatable(actualType, expectedType) || IsIEquatable(expectedType, actualType))
+                return true;
+
+            return false;
+        }
+
+        private static bool IsStream(ITypeSymbol typeSymbol, string fullName)
+        {
+            const string streamFullName = "System.IO.Stream";
+
+            return fullName == streamFullName
+                || typeSymbol.GetAllBaseTypes().Any(t => t.GetFullMetadataName() == streamFullName);
+        }
+
+        private static bool IsKeyValuePair(INamedTypeSymbol typeSymbol, string fullSymbolName,
+            [NotNullWhen(true)] out ITypeSymbol? keyType, [NotNullWhen(true)] out ITypeSymbol? valueType)
+        {
+            const string keyValuePairFullName = "System.Collections.Generic.KeyValuePair`2";
+
+            if (typeSymbol.TypeArguments.Length == 2
+                && fullSymbolName == keyValuePairFullName)
+            {
+                keyType = typeSymbol.TypeArguments[0];
+                valueType = typeSymbol.TypeArguments[1];
+                return true;
+            }
+            else
+            {
+                keyType = null;
+                valueType = null;
+                return false;
+            }
+        }
+
+        private static bool IsDictionary(INamedTypeSymbol typeSymbol, string fullSymbolName,
+            [NotNullWhen(true)] out ITypeSymbol? keyType, [NotNullWhen(true)] out ITypeSymbol? valueType)
+        {
+            const string dictionaryFullName = "System.Collections.Generic.Dictionary`2";
+
+            if (typeSymbol.TypeArguments.Length == 2
+                && fullSymbolName == dictionaryFullName)
+            {
+                keyType = typeSymbol.TypeArguments[0];
+                valueType = typeSymbol.TypeArguments[1];
+                return true;
+            }
+            else
+            {
+                keyType = null;
+                valueType = null;
+                return false;
+            }
+        }
+
+        private static bool IsTuple(string fullName)
+        {
+            return fullName.StartsWith("System.Tuple`");
+        }
+
+        private static bool IsIEquatable(ITypeSymbol typeSymbol, ITypeSymbol equatableTypeArguments)
+        {
+            return typeSymbol.AllInterfaces.Any(i => i.TypeArguments.Length == 1
+                && i.TypeArguments[0].Equals(equatableTypeArguments)
+                && i.GetFullMetadataName() == "System.IEquatable`1");
+        }
+    }
+}

--- a/src/nunit.analyzers/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzer.cs
@@ -1,0 +1,98 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Helpers;
+using NUnit.Analyzers.Syntax;
+
+namespace NUnit.Analyzers.SomeItemsIncompatibleTypes
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SomeItemsIncompatibleTypesAnalyzer : BaseAssertionAnalyzer
+    {
+        private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.SomeItemsIncompatibleTypes,
+            title: SomeItemsIncompatibleTypesConstants.Title,
+            messageFormat: SomeItemsIncompatibleTypesConstants.Message,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: SomeItemsIncompatibleTypesConstants.Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(descriptor);
+
+        protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
+        {
+            var cancellationToken = context.CancellationToken;
+            var semanticModel = context.SemanticModel;
+
+            if (!AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
+                out var actualExpression, out var constraintExpression))
+            {
+                return;
+            }
+
+            foreach (var constraintPart in constraintExpression.ConstraintParts)
+            {
+                if ((!IsDoesContain(constraintPart) && !IsContaintsItem(constraintPart))
+                    || constraintPart.GetConstraintTypeSymbol()?.GetFullMetadataName() != NunitFrameworkConstants.FullNameOfSomeItemsConstraint)
+                {
+                    continue;
+                }
+
+                if (HasIncompatibleOperators(constraintPart))
+                    return;
+
+                var expectedExpression = constraintPart.GetExpectedArgumentExpression();
+
+                if (expectedExpression == null)
+                    continue;
+
+                var expectedType = semanticModel.GetTypeInfo(expectedExpression, cancellationToken).Type;
+                var actualType = AssertHelper.GetUnwrappedActualType(actualExpression, semanticModel, cancellationToken);
+
+                if (actualType == null || expectedType == null)
+                    continue;
+
+                if (actualType.IsIEnumerable(out var elementType))
+                {
+                    // Cannot determine element type for non-generic IEnumerable, therefore consider valid.
+                    if (elementType == null)
+                        continue;
+
+                    // Valid, if collection element type matches expected type.
+                    if (NUnitEqualityComparerHelper.CanBeEqual(elementType, expectedType, semanticModel.Compilation))
+                        continue;
+                }
+
+                var actualTypeDisplay = actualType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                var expectedTypeDisplay = expectedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    descriptor,
+                    constraintPart.GetLocation(),
+                    actualTypeDisplay,
+                    expectedTypeDisplay));
+            }
+        }
+
+        private static bool IsDoesContain(ConstraintPartExpression constraintPart)
+        {
+            return constraintPart.GetConstraintName() == NunitFrameworkConstants.NameOfDoesContain;
+        }
+
+        private static bool IsContaintsItem(ConstraintPartExpression constraintPart)
+        {
+            return constraintPart.GetHelperClassName() == NunitFrameworkConstants.NameOfContains
+                && constraintPart.GetConstraintName() == NunitFrameworkConstants.NameOfContainsItem;
+        }
+
+        private static bool HasIncompatibleOperators(ConstraintPartExpression constraintPart)
+        {
+            return constraintPart.GetPrefixesNames().Any(p => p != NunitFrameworkConstants.NameOfDoesNot);
+        }
+    }
+}

--- a/src/nunit.analyzers/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzer.cs
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.SomeItemsIncompatibleTypes
 
             foreach (var constraintPart in constraintExpression.ConstraintParts)
             {
-                if ((!IsDoesContain(constraintPart) && !IsContaintsItem(constraintPart))
+                if ((!IsDoesContain(constraintPart) && !IsContainsItem(constraintPart))
                     || constraintPart.GetConstraintTypeSymbol()?.GetFullMetadataName() != NunitFrameworkConstants.FullNameOfSomeItemsConstraint)
                 {
                     continue;
@@ -74,6 +74,7 @@ namespace NUnit.Analyzers.SomeItemsIncompatibleTypes
                 context.ReportDiagnostic(Diagnostic.Create(
                     descriptor,
                     constraintPart.GetLocation(),
+                    ConstraintDiagnosticDescription(constraintPart),
                     actualTypeDisplay,
                     expectedTypeDisplay));
             }
@@ -84,7 +85,7 @@ namespace NUnit.Analyzers.SomeItemsIncompatibleTypes
             return constraintPart.GetConstraintName() == NunitFrameworkConstants.NameOfDoesContain;
         }
 
-        private static bool IsContaintsItem(ConstraintPartExpression constraintPart)
+        private static bool IsContainsItem(ConstraintPartExpression constraintPart)
         {
             return constraintPart.GetHelperClassName() == NunitFrameworkConstants.NameOfContains
                 && constraintPart.GetConstraintName() == NunitFrameworkConstants.NameOfContainsItem;
@@ -93,6 +94,13 @@ namespace NUnit.Analyzers.SomeItemsIncompatibleTypes
         private static bool HasIncompatibleOperators(ConstraintPartExpression constraintPart)
         {
             return constraintPart.GetPrefixesNames().Any(p => p != NunitFrameworkConstants.NameOfDoesNot);
+        }
+
+        private static string ConstraintDiagnosticDescription(ConstraintPartExpression constraintPart)
+        {
+            return constraintPart.GetHelperClassName() != null
+                ? $"{constraintPart.GetHelperClassName()}.{constraintPart.GetConstraintName()}"
+                : (constraintPart.GetConstraintName() ?? "");
         }
     }
 }


### PR DESCRIPTION
Related to #221 .

Examples:
```csharp
// The SomeItemsConstraint cannot be used with 'string[]' actual and 'int' expected arguments.
Assert.That(new[] {"1", "2"}, Does.Contain(1));

// The SomeItemsConstraint cannot be used with 'string[]' actual and 'int' expected arguments.
Assert.That(new[] {"1", "2"}, Contains.Item(1));
```

In order to re-use logic for types comparing, I moved method `CanBeEqual` from `EqualToIncompatibleTypesAnalyzer` to `NUnitEqualityComparerHelper`, and added tests for it.


I'd like to ask for advice about naming and messages. Technically it is for `SomeItemsConstraint` combined with `EqualConstraint`, which you get when you use `Does.Contain` or `Contains.Item` expressions.
So mentioning it as `SomeItemsConstraint` is not strictly correct. But I'm not sure how to name it better.