### PR TITLE
ConstActualValueUsageAnalyzer: #256: Allow Assert on Enum.Member

### DIFF
--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -97,7 +97,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void AnalyzeWhenConstFieldArgumentIsProvidedForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string actual = ""act"";
 
@@ -115,7 +115,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void AnalyzeWhenConstFieldArgumentIsProvidedForAssertThat()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string actual = ""act"";
 
@@ -159,7 +159,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenNonConstValueIsProvidedAsActualArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string expected = ""exp"";
 
@@ -177,7 +177,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenConstValueIsProvidedAsActualAndExpectedArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string expected = ""exp"";
 
@@ -195,7 +195,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenNonConstValueIsProvidedAsActualNamedArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string expected = ""exp"";
 
@@ -213,7 +213,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenConstValueIsProvidedAsActualAndExpectedNamedArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string expected = ""exp"";
 
@@ -231,7 +231,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenNonConstValueIsProvidedAsActualArgumentForAssertThat()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string expected = ""exp"";
 
@@ -249,7 +249,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenConstValueIsProvidedAsActualAndExpectedArgumentForAssertThat()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string expected = ""exp"";
 
@@ -267,7 +267,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenCheckingEnumerationValueForAssertThat()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private enum Answer { No = 0, Yes = 1 };
 
@@ -284,7 +284,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         public void ValidWhenCheckingAgainstStringEmptyAssertThat()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-            public class TestFixure
+            public class TestFixture
             {
                 private const string actual = ""act"";
 

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -130,6 +130,32 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         }
 
         [Test]
+        public void AnalyzeWhenStringEmptyArgumentIsProvidedForAreEqual()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string actual = ""act"";
+                    Assert.AreEqual(actual, string.Empty);
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenStringEmptyArgumentIsProvidedForAssertThat()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string actual = ""act"";
+                    Assert.That(string.Empty, Is.EqualTo(actual));
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
         public void ValidWhenNonConstValueIsProvidedAsActualArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
@@ -248,6 +274,23 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     Assert.That(Answer.Yes, Is.EqualTo(1));
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenCheckingAgainstStringEmptyAssertThat()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string actual = ""act"";
+
+                public void Test()
+                {
+                    Assert.That(actual, Is.Not.EqualTo(string.Empty));
                 }
             }");
 

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -44,7 +44,8 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
                 public void Test()
                 {
-                    Assert.That(↓true, Is.False);
+                    Assert.That(↓-1, Is.Positive);
+                    Assert.That(↓(2 + 3) * 1024, Is.Positive);
                 }");
 
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
                 public void Test()
                 {
-                    Assert.That(↓true, Is.EqualTo(false));
+                    Assert.That(↓true, Is.False);
                 }");
 
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
@@ -147,6 +147,24 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
         }
 
         [Test]
+        public void ValidWhenConstValueIsProvidedAsActualAndExpectedArgumentForAreEqual()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    Assert.AreEqual(expected, actual);
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenNonConstValueIsProvidedAsActualNamedArgumentForAreEqual()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
@@ -157,6 +175,24 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     string actual = ""act"";
+                    Assert.AreEqual(actual: actual, expected: expected);
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenConstValueIsProvidedAsActualAndExpectedNamedArgumentForAreEqual()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    const string actual = ""act"";
                     Assert.AreEqual(actual: actual, expected: expected);
                 }
             }");
@@ -176,6 +212,41 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 {
                     string actual = ""act"";
                     Assert.That(actual, Is.EqualTo(expected));
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenConstValueIsProvidedAsActualAndExpectedArgumentForAssertThat()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    Assert.That(actual, Is.EqualTo(expected));
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenCheckingEnumerationValueForAssertThat()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixure
+            {
+                private enum Answer { No = 0, Yes = 1 };
+
+                public void Test()
+                {
+                    Assert.That(Answer.Yes, Is.EqualTo(1));
                 }
             }");
 

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -296,5 +296,20 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
 
             AnalyzerAssert.Valid(analyzer, testCode);
         }
+
+        [Test]
+        public void ValidWhenCheckingEmptyAgainstNullAssertThat()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixture
+            {
+                public void Test()
+                {
+                    Assert.That(string.Empty, Is.Not.Null);
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -1,10 +1,12 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Helpers;
 
 namespace NUnit.Analyzers.ConstActualValueUsage
 {
@@ -24,16 +26,56 @@ namespace NUnit.Analyzers.ConstActualValueUsage
         protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
             InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
         {
+            bool IsConstant(ExpressionSyntax expression)
+            {
+                if (expression is LiteralExpressionSyntax)
+                    return true;
+
+                var argumentSymbol = context.SemanticModel.GetSymbolInfo(expression).Symbol;
+
+                return (argumentSymbol is ILocalSymbol localSymbol && localSymbol.IsConst) ||
+                       (argumentSymbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst);
+            }
+
+            void Report(ExpressionSyntax expression)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    descriptor,
+                    expression.GetLocation()));
+            }
+
             var actualExpression = assertExpression.GetArgumentExpression(methodSymbol, NunitFrameworkConstants.NameOfActualParameter);
 
             if (actualExpression == null)
                 return;
 
-            var argumentSymbol = context.SemanticModel.GetSymbolInfo(actualExpression).Symbol;
+            if (!IsConstant(actualExpression))
+                return; // Standard use case
 
-            if (actualExpression is LiteralExpressionSyntax
-                || (argumentSymbol is ILocalSymbol localSymbol && localSymbol.IsConst)
-                || (argumentSymbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst))
+            if (actualExpression is LiteralExpressionSyntax)
+            {
+                // Classic error case
+                Report(actualExpression);
+                return;
+            }
+
+            // The actual expression is a constant field, check if expected is also constant
+            var expectedExpression = assertExpression.GetArgumentExpression(methodSymbol, NunitFrameworkConstants.NameOfExpectedParameter);
+
+            if (expectedExpression == null)
+            {
+                // Check for Assert.That
+                if (AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, context.SemanticModel,
+                    out _, out var constraintExpression))
+                {
+                    expectedExpression = constraintExpression.ConstraintParts
+                        .Select(part => part.GetExpectedArgumentExpression())
+                        .Where(e => e != null)
+                        .FirstOrDefault();
+                }
+            }
+
+            if (expectedExpression == null || !IsConstant(expectedExpression))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     descriptor,

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -64,15 +64,8 @@ namespace NUnit.Analyzers.ConstActualValueUsage
 
             if (expectedExpression == null)
             {
-                // Check for Assert.That
-                if (AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, context.SemanticModel,
-                    out _, out var constraintExpression))
-                {
-                    expectedExpression = constraintExpression.ConstraintParts
-                        .Select(part => part.GetExpectedArgumentExpression())
-                        .Where(e => e != null)
-                        .FirstOrDefault();
-                }
+                // Check for Assert.That IsEqualTo constraint
+                expectedExpression = this.GetExpectedExpression(assertExpression, context.SemanticModel);
             }
 
             if (expectedExpression == null || !IsConstant(expectedExpression))
@@ -81,6 +74,20 @@ namespace NUnit.Analyzers.ConstActualValueUsage
                     descriptor,
                     actualExpression.GetLocation()));
             }
+        }
+
+        private ExpressionSyntax? GetExpectedExpression(InvocationExpressionSyntax assertExpression, SemanticModel semanticModel)
+        {
+            if (AssertHelper.TryGetActualAndConstraintExpressions(assertExpression, semanticModel,
+                out _, out var constraintExpression))
+            {
+                return constraintExpression.ConstraintParts
+                        .Select(part => part.GetExpectedArgumentExpression())
+                        .Where(e => e != null)
+                        .FirstOrDefault();
+            }
+
+            return null;
         }
     }
 }

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -81,7 +81,7 @@ namespace NUnit.Analyzers.ConstActualValueUsage
             }
 
             if (!IsConstant(actualExpression) && !IsStringEmpty(actualExpression))
-                return; // Standard use case
+                return;
 
             // The actual expression is a constant field, check if expected is also constant
             var expectedExpression = this.GetExpectedExpression(assertExpression, methodSymbol, context.SemanticModel);

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -76,7 +76,6 @@ namespace NUnit.Analyzers.ConstActualValueUsage
 
             if (IsLiteralExpression(actualExpression))
             {
-                // Classic error case
                 Report(actualExpression);
                 return;
             }

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -72,14 +72,14 @@ namespace NUnit.Analyzers.ConstActualValueUsage
             if (actualExpression == null)
                 return;
 
-            if (IsLiteralExpression(actualExpression) || IsEmpty(actualExpression))
+            if (IsLiteralExpression(actualExpression))
             {
                 // Classic error case
                 Report(actualExpression);
                 return;
             }
 
-            if (!IsConstant(actualExpression))
+            if (!IsConstant(actualExpression) && !IsEmpty(actualExpression))
                 return; // Standard use case
 
             // The actual expression is a constant field, check if expected is also constant
@@ -91,7 +91,7 @@ namespace NUnit.Analyzers.ConstActualValueUsage
                 expectedExpression = this.GetExpectedExpression(assertExpression, context.SemanticModel);
             }
 
-            if (expectedExpression == null || (!IsConstant(expectedExpression) && !IsEmpty(expectedExpression)))
+            if (expectedExpression != null && !IsConstant(expectedExpression) && !IsEmpty(expectedExpression))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     descriptor,

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -89,9 +89,7 @@ namespace NUnit.Analyzers.ConstActualValueUsage
 
             if (expectedExpression != null && !IsConstant(expectedExpression) && !IsStringEmpty(expectedExpression))
             {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    descriptor,
-                    actualExpression.GetLocation()));
+                Report(actualExpression);
             }
         }
 


### PR DESCRIPTION
This fixes #256 
It will always fire if actual is a literal as that is the classic error case.
It will however not fire if actual is a constant field and expected is also a constant.
This allows validating values of named enumeration values and constants.