### PR TITLE
Target both .NET Framework (4.6.1) and .NET Core (2.1) for testing.

### DIFF
--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -351,6 +351,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
+#if !NET461
         [Test]
         public void AnalyzeWhenTestMethodHasValueTaskReturnTypeAndExpectedResult()
         {
@@ -380,6 +381,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
 
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
+#endif
 
         [Test]
         public void AnalyzeWhenAsyncTestMethodHasTaskReturnTypeAndExpectedResult()

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Analyzers.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>


### PR DESCRIPTION
Addresses issue #191 