### PR TITLE
Update .editorconfig to match overall code-style used.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ charset = utf-8
 indent_size = 2
 
 [*]
-# https://github.com/nunit/docs/wiki/Coding-Standards#namespace-class-structure-interface-enumeration-and-method-definitions
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#namespace-class-structure-interface-enumeration-and-method-definitions
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -26,7 +26,7 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-# https://github.com/nunit/docs/wiki/Coding-Standards#spaces
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#spaces
 csharp_space_after_cast = false
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_after_comma = true
@@ -50,27 +50,44 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-# https://github.com/nunit/docs/wiki/Coding-Standards#indentation
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#indentation
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#naming
 # Always use "this." and "Me." when applicable; let StyleCop Analyzers provide the warning and fix
-dotnet_style_qualification_for_field = true:suggestion
-dotnet_style_qualification_for_property = true:suggestion
-dotnet_style_qualification_for_method = true:suggestion
-dotnet_style_qualification_for_event = true:suggestion
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_property = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_event = true:warning
 
-# https://github.com/nunit/docs/wiki/Coding-Standards#naming
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_readonly_field = true:warning
 
-# Prefer "var" only where type is obvious; disable diagnostics since no firm policy is in place yet
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#use-of-the-var-keyword
+# Unfortunately var_for_built_in_types conflicts with var_when_type_is_apparent. https://github.com/dotnet/roslyn/issues/23714
+# Also 'apparent' does not mean the same for everyone.
+# Disable diagnostics since no firm policy is in place yet and the messages hide other violations.
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = false:none
+
+# Disabled rule as convention is not mentioned in https://docs.nunit.org/articles/developer-info/Coding-Standards.html
+# Mentioned is 'if braces are not used on a control float statements with a single line, a blank line should follow'
+# This is not something we can configure.
+# The document doesn't say that it should have braces for multi-line statements, but maybe that is implied.
+csharp_prefer_braces = when_multiline:warning
+
+# Rules to match the actual code style used
+csharp_prefer_simple_default_expression = false:suggestion
+csharp_style_deconstructed_variable_declaration = false:suggestion
+csharp_style_prefer_switch_expression = false:suggestion
+csharp_style_expression_bodied_local_functions = false:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = false:suggestion
 
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:none
@@ -79,7 +96,7 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 
-# https://github.com/nunit/docs/wiki/Coding-Standards#file-organization
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#file-organization
 dotnet_sort_system_directives_first = true
 
 # The first matching rule wins, more specific rules at the top

--- a/.editorconfig
+++ b/.editorconfig
@@ -76,10 +76,7 @@ csharp_style_var_for_built_in_types = true:none
 csharp_style_var_when_type_is_apparent = true:none
 csharp_style_var_elsewhere = false:none
 
-# Disabled rule as convention is not mentioned in https://docs.nunit.org/articles/developer-info/Coding-Standards.html
-# Mentioned is 'if braces are not used on a control float statements with a single line, a blank line should follow'
-# This is not something we can configure.
-# The document doesn't say that it should have braces for multi-line statements, but maybe that is implied.
+# This convention is not mentioned in https://docs.nunit.org/articles/developer-info/Coding-Standards.html
 csharp_prefer_braces = when_multiline:warning
 
 # Rules to match the actual code style used
@@ -121,4 +118,3 @@ dotnet_naming_rule.public_fields.style = pascal_case
 dotnet_naming_rule.parameters_and_locals.severity = suggestion
 dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
 dotnet_naming_rule.parameters_and_locals.style = camel_case
-

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
@@ -106,7 +106,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsTrue(true);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.True(true);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsFalse(false);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.False(false);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -170,7 +170,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreEqual(2, 2);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreEqual(2d, 2d, 0.0000001d);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreNotEqual(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -218,7 +218,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreSame(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -235,7 +235,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNull(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.Null(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -269,7 +269,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNotNull(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -286,7 +286,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.NotNull(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
@@ -20,13 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         private sealed class TestableClassicModelAssertUsageCodeFix : ClassicModelAssertUsageCodeFix
         {
-            public override ImmutableArray<string> FixableDiagnosticIds
-            {
-                get
-                {
-                    return new ImmutableArray<string>();
-                }
-            }
+            public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray<string>.Empty;
 
             protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments) { }
         }

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -110,10 +110,10 @@ namespace NUnit.Analyzers.Tests
         [TestCaseSource(nameof(DescriptorsWithDocs))]
         public void EnsureThatTableIsAsExpected(DescriptorInfo descriptorInfo)
         {
-            const string HeaderRow = "| Topic    | Value";
-            var expected = GetTable(descriptorInfo.Stub, HeaderRow);
+            const string headerRow = "| Topic    | Value";
+            var expected = GetTable(descriptorInfo.Stub, headerRow);
             DumpIfDebug(expected);
-            var actual = GetTable(descriptorInfo.DocumentationFile.AllText, HeaderRow);
+            var actual = GetTable(descriptorInfo.DocumentationFile.AllText, headerRow);
             CodeAssert.AreEqual(expected, actual);
         }
 
@@ -142,8 +142,8 @@ namespace NUnit.Analyzers.Tests
         public void EnsureThatIndexIsAsExpected()
         {
             var builder = new StringBuilder();
-            const string HeaderRow = "| Id       | Title       | Enabled by Default |";
-            builder.AppendLine(HeaderRow)
+            const string headerRow = "| Id       | Title       | Enabled by Default |";
+            builder.AppendLine(headerRow)
                    .AppendLine("| :--      | :--         | :--:               |");
 
             var descriptors = DescriptorsWithDocs.Select(x => x.Descriptor)
@@ -159,7 +159,7 @@ namespace NUnit.Analyzers.Tests
 
             var expected = builder.ToString();
             DumpIfDebug(expected);
-            var actual = GetTable(File.ReadAllText(Path.Combine(DocumentsDirectory.FullName, "index.md")), HeaderRow);
+            var actual = GetTable(File.ReadAllText(Path.Combine(DocumentsDirectory.FullName, "index.md")), headerRow);
             CodeAssert.AreEqual(expected, actual);
         }
 
@@ -248,7 +248,7 @@ namespace NUnit.Analyzers.Tests
 | Topic    | Value
 | :--      | :--
 | Id       | {descriptor.Id}
-| Severity | {descriptor.DefaultSeverity.ToString()}
+| Severity | {descriptor.DefaultSeverity}
 | Enabled  | {(descriptor.IsEnabledByDefault ? "True" : "False")}
 | Category | {descriptor.Category}
 | Code     | [<TYPENAME>](<URL>)

--- a/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ParallelizableUsage
         [Test]
         public void VerifySupportedDiagnostics()
         {
-            var diagnostics = analyzer.SupportedDiagnostics;
+            var diagnostics = this.analyzer.SupportedDiagnostics;
 
             var expectedIdentifiers = new List<string>
             {
@@ -76,7 +76,7 @@ using NUnit.Framework;
             var testCode = $@"
 using NUnit.Framework;
 [assembly: ↓Parallelizable(ParallelScope.Self)]";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -89,7 +89,7 @@ using NUnit.Framework;
             var testCode = $@"
 using NUnit.Framework;
 [assembly: ↓Parallelizable()]";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Theory]
@@ -140,7 +140,7 @@ using NUnit.Framework;
         {{
         }}
     }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -160,7 +160,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(ParallelScopesExceptFixtures))]
@@ -197,7 +197,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(ParallelScopesExceptFixtures))]
@@ -234,7 +234,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         private static IEnumerable<ParallelScope> ParallelScopesExceptFixtures =>

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     [TestFixture]
     public sealed class TestCaseUsageAnalyzerTests
     {
-        private DiagnosticAnalyzer analyzer = new TestCaseUsageAnalyzer();
+        private readonly DiagnosticAnalyzer analyzer = new TestCaseUsageAnalyzer();
 
         private static IEnumerable<TestCaseData> SpecialConversions
         {
@@ -244,7 +244,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                String.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "char"));
+                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "char"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenArgumentTypeIsIncorrect
@@ -252,7 +252,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓2)]
         public void Test(char a) { }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -260,7 +260,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                String.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "char"));
+                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "char"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenArgumentPassesNullToValueType
@@ -268,7 +268,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓null)]
         public void Test(char a) { }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -309,7 +309,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int a, char b) { }
     }");
             var message = "The TestCaseAttribute provided too few arguments. Expected '2', but got '1'.";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -326,7 +326,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int a) { }
     }");
             var message = "The TestCaseAttribute provided too many arguments. Expected '1', but got '2'.";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -343,7 +343,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int a, char b = 'c') { }
     }");
             var message = "The TestCaseAttribute provided too many arguments. Expected '2', but got '3'.";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -387,7 +387,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                String.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "string[]"));
+                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "string[]"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsIncorrect
@@ -395,7 +395,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓2)]
         public void Test(params string[] a) { }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -403,7 +403,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                String.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "int[]"));
+                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "int[]"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenMethodHasOnlyParamsAndArgumentPassesNullToValueType
@@ -411,7 +411,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓null)]
         public void Test(params int[] a) { }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
@@ -71,7 +71,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
 
-        static object[] NonPublicModifiers =
+        static readonly object[] NonPublicModifiers =
         {
             new object [] { "private", "public" },
             new object [] { "protected", "public" },

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     [TestFixture]
     public sealed class TestMethodUsageAnalyzerTests
     {
-        private static DiagnosticAnalyzer analyzer = new TestMethodUsageAnalyzer();
+        private static readonly DiagnosticAnalyzer analyzer = new TestMethodUsageAnalyzer();
 
         [Test]
         public void VerifySupportedDiagnostics()
@@ -109,7 +109,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
-                String.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
+                string.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenExpectedResultIsProvidedAndTypeIsIncorrect
@@ -125,7 +125,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
-                String.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
+                string.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenExpectedResultIsProvidedAndPassesNullToValueType

--- a/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
@@ -62,7 +62,9 @@ namespace NUnit.Analyzers.ParallelizableUsage
 
             if (parallelizableAttributeType.ContainingAssembly.Identity != attributeSymbol?.ContainingAssembly.Identity ||
                 NunitFrameworkConstants.NameOfParallelizableAttribute != attributeSymbol?.ContainingType.Name)
+            {
                 return;
+            }
 
             context.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -194,7 +194,9 @@ namespace NUnit.Analyzers.TestCaseUsage
 
                     if (argumentTypeMatchesElementType ||
                         (argumentTypeMatchesParameterType && (argumentType != null || !methodParameterParamsType.IsValueType)))
-                    continue;
+                    {
+                        continue;
+                    }
                 }
                 
                 context.ReportDiagnostic(Diagnostic.Create(parameterTypeMismatch,

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -165,7 +165,7 @@ namespace NUnit.Analyzers.TestCaseUsage
             var (_, attributeNamedArguments) = attributeNode.GetArguments();
 
             var expectedResultNamedArgument = attributeNamedArguments.SingleOrDefault(
-                _ => _.DescendantTokens().Any(__ => __.Text == NunitFrameworkConstants.NameOfExpectedResult));
+                _ => _.DescendantTokens().Any(_ => _.Text == NunitFrameworkConstants.NameOfExpectedResult));
 
             if (expectedResultNamedArgument != null)
             {


### PR DESCRIPTION
Fix two multi-line 'if' statements by adding braces.
Fix a few places that were not conforming to the overall code-style.

Fixes #261