### PR TITLE
NonTestMethodAccessibilityLevelAnalyzer: #147: Should be private

### DIFF
--- a/documentation/NUnit1026.md
+++ b/documentation/NUnit1026.md
@@ -1,6 +1,6 @@
 # NUnit1026
 
-## The test method is not public.
+## The test or setup/teardown method is not public.
 
 | Topic    | Value
 | :--      | :--
@@ -12,7 +12,7 @@
 
 ## Description
 
-The test method is not public.
+The test or setup/teardown method is not public.
 
 ## Motivation
 
@@ -23,10 +23,18 @@ To prevent tests that will fail at runtime, as NUnit only runs public test metho
 ### Example Violation
 
 ```csharp
+private int Value;
+
+[SetUp]
+void NUnit1026SetUp()
+{
+    Value = 42;
+}
+
 [Test]
 void NUnit1026SampleTest()
 {
-    Assert.Pass();
+    Assert.That(Value, Is.GreaterThan(0));
 }
 
 [TestCase(1)]
@@ -47,10 +55,18 @@ NUnit only runs `public` methods, so neither test can be run.
 The analyzer comes with a code fix that will change the access modifier to `public`. So the tests above will be changed into.
 
 ```csharp
+private int Value;
+
+[SetUp]
+public void NUnit1026SetUp()
+{
+    Value = 42;
+}
+
 [Test]
 public void NUnit1026SampleTest()
 {
-    Assert.Pass();
+    Assert.That(Value, Is.GreaterThan(0));
 }
 
 [TestCase(1)]
@@ -70,22 +86,22 @@ Configure the severity per project, for more info see [MSDN](https://msdn.micros
 ### Via #pragma directive.
 
 ```csharp
-#pragma warning disable NUnit1026 // The test method is not public.
+#pragma warning disable NUnit1026 // The test or setup/teardown method is not public.
 Code violating the rule here
-#pragma warning restore NUnit1026 // The test method is not public.
+#pragma warning restore NUnit1026 // The test or setup/teardown method is not public.
 ```
 
 Or put this at the top of the file to disable all instances.
 
 ```csharp
-#pragma warning disable NUnit1026 // The test method is not public.
+#pragma warning disable NUnit1026 // The test or setup/teardown method is not public.
 ```
 
 ### Via attribute `[SuppressMessage]`.
 
 ```csharp
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Structure",
-    "NUnit1026:The test method is not public.",
+    "NUnit1026:The test or setup/teardown method is not public.",
     Justification = "Reason...")]
 ```
 <!-- end generated config severity -->

--- a/documentation/NUnit1028.md
+++ b/documentation/NUnit1028.md
@@ -1,0 +1,53 @@
+# NUnit1028
+
+## The non-test method is public.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1028
+| Severity | Warning
+| Enabled  | False
+| Category | Structure
+| Code     | [NonTestMethodAccessibilityLevelAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs)
+## Description
+
+A fixture should not contain any public non-test methods.
+
+## Motivation
+
+A fixture should be self-contained and not have methods callable by other classes.
+
+## How to fix violations
+
+If the methods are purely for this class, mark them as 'private'. If the methods are used by other classes move these 
+methods to a separate class used by the relevant test fixtures.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+
+```csharp
+#pragma warning disable NUnit1028 // The non-test method is public.
+Code violating the rule here
+#pragma warning restore NUnit1028 // The non-test method is public.
+```
+
+Or put this at the top of the file to disable all instances.
+
+```csharp
+#pragma warning disable NUnit1028 // The non-test method is public.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure",
+    "NUnit1028:The non-test method is public.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -27,6 +27,7 @@
 | [NUnit1025](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1025.md)| The ValueSource argument does not specify an existing member. | :white_check_mark: |
 | [NUnit1026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1026.md)| The test method is not public. | :white_check_mark: |
 | [NUnit1027](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1027.md)| The test method has parameters, but no arguments are supplied by attributes. | :white_check_mark: |
+| [NUnit1028](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1028.md)| The non-test method is public. | :x: |
 | [NUnit2001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2001.md)| Consider using Assert.That(expr, Is.False) instead of Assert.False(expr). | :white_check_mark: |
 | [NUnit2002](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2002.md)| Consider using Assert.That(expr, Is.False) instead of Assert.IsFalse(expr). | :white_check_mark: |
 | [NUnit2003](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2003.md)| Consider using Assert.That(expr, Is.True) instead of Assert.IsTrue(expr). | :white_check_mark: |

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -25,7 +25,7 @@
 | [NUnit1023](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1023.md)| The target method expects parameters which cannot be supplied by the ValueSource. | :white_check_mark: |
 | [NUnit1024](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1024.md)| The source specified by the ValueSource does not return an IEnumerable or a type that implements IEnumerable. | :white_check_mark: |
 | [NUnit1025](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1025.md)| The ValueSource argument does not specify an existing member. | :white_check_mark: |
-| [NUnit1026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1026.md)| The test method is not public. | :white_check_mark: |
+| [NUnit1026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1026.md)| The test or setup/teardown method is not public. | :white_check_mark: |
 | [NUnit1027](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1027.md)| The test method has parameters, but no arguments are supplied by attributes. | :white_check_mark: |
 | [NUnit1028](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1028.md)| The non-test method is public. | :x: |
 | [NUnit2001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2001.md)| Consider using Assert.That(expr, Is.False) instead of Assert.False(expr). | :white_check_mark: |

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -38,6 +38,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit1024.md = ..\documentation\NUnit1024.md
 		..\documentation\NUnit1025.md = ..\documentation\NUnit1025.md
 		..\documentation\NUnit1026.md = ..\documentation\NUnit1026.md
+		..\documentation\NUnit1027.md = ..\documentation\NUnit1027.md
 		..\documentation\NUnit1028.md = ..\documentation\NUnit1028.md
 		..\documentation\NUnit2001.md = ..\documentation\NUnit2001.md
 		..\documentation\NUnit2002.md = ..\documentation\NUnit2002.md

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -38,6 +38,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit1024.md = ..\documentation\NUnit1024.md
 		..\documentation\NUnit1025.md = ..\documentation\NUnit1025.md
 		..\documentation\NUnit1026.md = ..\documentation\NUnit1026.md
+		..\documentation\NUnit1028.md = ..\documentation\NUnit1028.md
 		..\documentation\NUnit2001.md = ..\documentation\NUnit2001.md
 		..\documentation\NUnit2002.md = ..\documentation\NUnit2002.md
 		..\documentation\NUnit2003.md = ..\documentation\NUnit2003.md

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.NonTestMethodAccessibilityLevel;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
+{
+    public class NonTestMethodAccessibilityLevelAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new NonTestMethodAccessibilityLevelAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.NonTestMethodIsPublic);
+
+        [Test]
+        public void AnalyzeWhenNonTestClassHasPublicMethod()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void AssertMethod() {{ }}");
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNonTestMethodIsNotPublic()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        [Test]
+        public void TestMethod() {{ AssertMethod(); }}
+        private void AssertMethod() {{ }}");
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNonTestMethodIsProtected()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        [Test]
+        public void TestMethod() {{ AssertMethod(); }}
+        protected virtual void AssertMethod() {{ }}");
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
+        [TestCaseSource(nameof(NonPrivateModifiers))]
+        public void AnalyzeWhenNonTestMethodIsPublicOrInternal(string modifiers)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        [TestCase(1)]
+        public void TestMethod(int i) {{ AssertMethod(); }}
+        {modifiers} void ↓AssertMethod() {{ }}");
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        private static IEnumerable<string> NonPrivateModifiers => new string[]
+        {
+            "public",
+            "internal",
+            "protected internal",
+
+            "static public",
+            "static internal",
+            "static protected internal",
+        };
+    }
+}

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
@@ -41,6 +41,17 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
             AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
         }
 
+        [TestCaseSource(nameof(TestMethodRelatedAttributes))]
+        public void AnalyzeWhenAuxiliaryTestMethodIsPublic(string attribute)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        [Test]
+        public void TestMethod() {{ }}
+        [{attribute}]
+        public void AuxiliaryMethod() {{ }}");
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
         [TestCaseSource(nameof(NonPrivateModifiers))]
         public void AnalyzeWhenNonTestMethodIsPublicOrInternal(string modifiers)
         {
@@ -50,6 +61,15 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         {modifiers} void ↓AssertMethod() {{ }}");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
+
+        private static IEnumerable<string> TestMethodRelatedAttributes => new string[]
+        {
+            "Test",
+            "OneTimeSetUp",
+            "OneTimeTearDown",
+            "SetUp",
+            "TearDown"
+        };
 
         private static IEnumerable<string> NonPrivateModifiers => new string[]
         {

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
@@ -1,0 +1,43 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.NonTestMethodAccessibilityLevel;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
+{
+    public class NonTestMethodAccessibilityLevelCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new NonTestMethodAccessibilityLevelAnalyzer();
+        private static readonly CodeFixProvider fix = new NonTestMethodAccessibilityLevelCodeFix();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.NonTestMethodIsPublic);
+
+        [TestCaseSource(nameof(NonPrivateModifiers))]
+        public void FixesPublicAccessModifiers(string modifiers, string modifiersAfter)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        [Test]
+        public void TestMethod() {{ AssertMethod(); }}
+        {modifiers} void ↓AssertMethod() {{ }}");
+
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        [Test]
+        public void TestMethod() {{ AssertMethod(); }}
+        {modifiersAfter} void AssertMethod() {{ }}");
+
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+        }
+
+        static readonly object[] NonPrivateModifiers =
+        {
+            new object [] { "public", "private" },
+            new object [] { "internal", "private" },
+            new object [] { "protected internal", "protected" },
+            new object [] { "static public", "static private" },
+            new object [] { "static internal", "static private" },
+            new object [] { "static protected internal", "static protected" },
+        };
+    }
+}

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             new object [] { "static protected", "static public" },
             new object [] { "static internal", "static public" },
             new object [] { "static protected internal", "static public" },
-            new object [] { "static private protected","static public" },
+            new object [] { "static private protected", "static public" },
 
             new object [] { "private static", "public static" },
             new object [] { "protected static", "public static" },

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -31,6 +31,7 @@ namespace NUnit.Analyzers.Constants
         internal const string ValueSourceIsMissing = "NUnit1025";
         internal const string TestMethodIsNotPublic = "NUnit1026";
         internal const string SimpleTestMethodHasParameters = "NUnit1027";
+        internal const string NonTestMethodIsPublic = "NUnit1028";
 
         #endregion Structure
 

--- a/src/nunit.analyzers/Constants/CodeFixConstants.cs
+++ b/src/nunit.analyzers/Constants/CodeFixConstants.cs
@@ -7,5 +7,6 @@ namespace NUnit.Analyzers.Constants
         internal const string UseConstraintDescriptionFormat = "Use {0} constraint";
         internal const string UsePropertyDescriptionFormat = "Use '{0}' property";
         internal const string MakeTestMethodPublic = "Make test method public";
+        internal const string MakeNonTestMethodPrivate = "Make non-test method private";
     }
 }

--- a/src/nunit.analyzers/Constants/NonTestMethodAccessibilityLevelConstants.cs
+++ b/src/nunit.analyzers/Constants/NonTestMethodAccessibilityLevelConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.Constants
+{
+    internal static class NonTestMethodAccessibilityLevelConstants
+    {
+        internal const string NonTestMethodIsPublicTitle = "The non-test method is public.";
+        internal const string NonTestMethodIsPublicMessage = "Only test methods should be public.";
+        internal const string NonTestMethodIsPublicDescription = "A fixture should not contain any public non-test methods.";
+    }
+}

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -83,6 +83,11 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfTypeValueSourceAttribute = "NUnit.Framework.ValueSourceAttribute";
         public const string FullNameOfTypeIParameterDataSource = "NUnit.Framework.Interfaces.IParameterDataSource";
 
+        public const string FullNameOfTypeOneTimeSetUpAttribute = "NUnit.Framework.OneTimeSetUpAttribute";
+        public const string FullNameOfTypeOneTimeTearDownAttribute = "NUnit.Framework.OneTimeTearDownAttribute";
+        public const string FullNameOfTypeSetUpAttribute = "NUnit.Framework.SetUpAttribute";
+        public const string FullNameOfTypeTearDownAttribute = "NUnit.Framework.TearDownAttribute";
+
         public const string NameOfConstraint = "Constraint";
 
         public const string FullNameOfSameAsConstraint = "NUnit.Framework.Constraints.SameAsConstraint";

--- a/src/nunit.analyzers/Constants/TestMethodAccessibilityLevelConstants.cs
+++ b/src/nunit.analyzers/Constants/TestMethodAccessibilityLevelConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class TestMethodAccessibilityLevelConstants
     {
-        internal const string TestMethodIsNotPublicTitle = "The test method is not public.";
-        internal const string TestMethodIsNotPublicMessage = "The test method is not public and cannot be run.";
-        internal const string TestMethodIsNotPublicDescription = "The test method is not public.";
+        internal const string TestMethodIsNotPublicTitle = "The test or setup/teardown method is not public.";
+        internal const string TestMethodIsNotPublicMessage = "The test or setup/teardown method is not public and cannot be run.";
+        internal const string TestMethodIsNotPublicDescription = "The test or setup/teardown method is not public.";
     }
 }

--- a/src/nunit.analyzers/DiagnosticDescriptorCreator.cs
+++ b/src/nunit.analyzers/DiagnosticDescriptorCreator.cs
@@ -11,13 +11,30 @@ namespace NUnit.Analyzers
             string category,
             DiagnosticSeverity defaultSeverity,
             string description) =>
-            new DiagnosticDescriptor(
+            Create(
                 id: id,
                 title: title,
                 messageFormat: messageFormat,
                 category: category,
                 defaultSeverity: defaultSeverity,
                 isEnabledByDefault: true,
+                description: description);
+
+        internal static DiagnosticDescriptor Create(
+            string id,
+            string title,
+            string messageFormat,
+            string category,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            string description) =>
+            new DiagnosticDescriptor(
+                id: id,
+                title: title,
+                messageFormat: messageFormat,
+                category: category,
+                defaultSeverity: defaultSeverity,
+                isEnabledByDefault: isEnabledByDefault,
                 description: description,
                 helpLinkUri: CreateLink(id),
                 customTags: new string[0]);

--- a/src/nunit.analyzers/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeSyntaxExtensions.cs
@@ -75,5 +75,30 @@ namespace NUnit.Analyzers.Extensions
             return attributeType.AllInterfaces.Any(i => i.Equals(interfaceType));
 
         }
+
+        internal static bool IsSetUpOrTearDownMethodAttribute(this AttributeSyntax attributeSyntax, SemanticModel semanticModel)
+        {
+            var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type;
+
+            if (attributeType == null)
+                return false;
+
+            switch (attributeType.ToString())
+            {
+                case NunitFrameworkConstants.FullNameOfTypeOneTimeSetUpAttribute:
+                case NunitFrameworkConstants.FullNameOfTypeOneTimeTearDownAttribute:
+                case NunitFrameworkConstants.FullNameOfTypeSetUpAttribute:
+                case NunitFrameworkConstants.FullNameOfTypeTearDownAttribute:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        internal static bool IsTestMethodAttribute(this AttributeSyntax attributeSyntax, SemanticModel semanticModel)
+        {
+            return attributeSyntax.DerivesFromITestBuilder(semanticModel) ||
+                   attributeSyntax.DerivesFromISimpleTestBuilder(semanticModel);
+        }
     }
 }

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class NonTestMethodAccessibilityLevelAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor nonTestMethodIsPublic = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.NonTestMethodIsPublic,
+            title: NonTestMethodAccessibilityLevelConstants.NonTestMethodIsPublicTitle,
+            messageFormat: NonTestMethodAccessibilityLevelConstants.NonTestMethodIsPublicMessage,
+            category: Categories.Structure,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: false,
+            description: NonTestMethodAccessibilityLevelConstants.NonTestMethodIsPublicDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(nonTestMethodIsPublic);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            var classNode = context.Node as ClassDeclarationSyntax;
+
+            if (classNode is null)
+            {
+                return;
+            }
+
+            // Is this even a TestFixture, i.e.: Does it has any test methods.
+            // If not public methods are fine.
+            bool hasTestMethods = false;
+
+            var publicNonTestMethods = new List<MethodDeclarationSyntax>();
+            foreach (var method in classNode.Members.OfType<MethodDeclarationSyntax>())
+            {
+                if (IsTestMethod(context.SemanticModel, method.AttributeLists))
+                    hasTestMethods = true;
+                else if (IsPublicOrInternalMethod(method))
+                    publicNonTestMethods.Add(method);
+            }
+
+            if (hasTestMethods)
+            {
+                foreach (var method in publicNonTestMethods)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        nonTestMethodIsPublic,
+                        method.Identifier.GetLocation()));
+                }
+            }
+        }
+
+        private static bool IsTestMethod(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        {
+            var allAttributes = attributeLists.SelectMany(al => al.Attributes);
+            return allAttributes.Any(a =>
+                a.DerivesFromITestBuilder(semanticModel) || a.DerivesFromISimpleTestBuilder(semanticModel));
+        }
+
+        private static bool IsPublicOrInternalMethod(MethodDeclarationSyntax method)
+        {
+            return method.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword) || m.IsKind(SyntaxKind.InternalKeyword));
+        }
+    }
+}

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
             var publicNonTestMethods = new List<MethodDeclarationSyntax>();
             foreach (var method in classNode.Members.OfType<MethodDeclarationSyntax>())
             {
-                if (IsTestMethod(context.SemanticModel, method.AttributeLists))
+                if (IsTestRelatedMethod(context.SemanticModel, method.AttributeLists))
                     hasTestMethods = true;
                 else if (IsPublicOrInternalMethod(method))
                     publicNonTestMethods.Add(method);
@@ -65,11 +65,11 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
             }
         }
 
-        private static bool IsTestMethod(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        private static bool IsTestRelatedMethod(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
         {
             var allAttributes = attributeLists.SelectMany(al => al.Attributes);
-            return allAttributes.Any(a =>
-                a.DerivesFromITestBuilder(semanticModel) || a.DerivesFromISimpleTestBuilder(semanticModel));
+            return allAttributes.Any(a => a.IsSetUpOrTearDownMethodAttribute(semanticModel) ||
+                                          a.IsTestMethodAttribute(semanticModel));
         }
 
         private static bool IsPublicOrInternalMethod(MethodDeclarationSyntax method)

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFix.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFix.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public class NonTestMethodAccessibilityLevelCodeFix : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(AnalyzerIdentifiers.NonTestMethodIsPublic);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            SyntaxNode node = root.FindNode(context.Span);
+
+            if (!(node is MethodDeclarationSyntax originalExpression))
+                return;
+
+            if (HasExplicitPublicAccessModifier(originalExpression))
+            {
+                SyntaxTokenList replacedModifiers = ReplaceModifiersWithPrivate(originalExpression);
+                MethodDeclarationSyntax newExpression = originalExpression.WithModifiers(replacedModifiers);
+
+                SyntaxNode newRoot = root.ReplaceNode(originalExpression, newExpression);
+
+                var codeAction = CodeAction.Create(
+                    CodeFixConstants.MakeNonTestMethodPrivate,
+                    _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
+                    CodeFixConstants.MakeNonTestMethodPrivate);
+
+                context.RegisterCodeFix(codeAction, context.Diagnostics);
+            }
+        }
+
+        private static SyntaxTokenList ReplaceModifiersWithPrivate(MethodDeclarationSyntax originalExpression)
+        {
+            var firstAccessModifier = true;
+            var isProtected = false;
+            var newSyntaxTokens = new List<SyntaxToken>();
+
+            foreach (var syntaxToken in originalExpression.Modifiers)
+            {
+                if (IsPublicAccessModifier(syntaxToken))
+                {
+                    if (firstAccessModifier && !isProtected)
+                    {
+                        firstAccessModifier = false;
+                        var newPrivateToken = SyntaxFactory.Token(
+                            syntaxToken.LeadingTrivia,
+                            SyntaxKind.PrivateKeyword,
+                            syntaxToken.TrailingTrivia);
+                        newSyntaxTokens.Add(newPrivateToken);
+                    }
+                }
+                else
+                {
+                    if (syntaxToken.IsKind(SyntaxKind.ProtectedKeyword))
+                        isProtected = true;
+
+                    newSyntaxTokens.Add(syntaxToken);
+                }
+            }
+
+            return new SyntaxTokenList(newSyntaxTokens);
+        }
+
+        private static bool HasExplicitPublicAccessModifier(MethodDeclarationSyntax methodDeclarationSyntax)
+        {
+            return methodDeclarationSyntax.Modifiers.Any(m => IsPublicAccessModifier(m));
+        }
+
+        private static bool IsPublicAccessModifier(SyntaxToken syntaxToken) =>
+            syntaxToken.IsKind(SyntaxKind.PublicKeyword) ||
+            syntaxToken.IsKind(SyntaxKind.InternalKeyword);
+    }
+}

--- a/src/nunit.analyzers/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzer.cs
@@ -36,12 +36,23 @@ namespace NUnit.Analyzers.TestMethodAccessibilityLevel
 
             if (methodNode != null && !methodNode.ContainsDiagnostics)
             {
-                if (IsTestMethod(context.SemanticModel, methodNode.AttributeLists) &&
-                    !methodNode.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))
+                if (IsTestMethod(context.SemanticModel, methodNode.AttributeLists))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        testMethodIsNotPublic,
-                        methodNode.Identifier.GetLocation()));
+                    if (!IsPublic(methodNode.Modifiers))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            testMethodIsNotPublic,
+                            methodNode.Identifier.GetLocation()));
+                    }
+                }
+                else if (IsSetUpTearDownMethod(context.SemanticModel, methodNode.AttributeLists))
+                {
+                    if (!IsPublicOrFamily(methodNode.Modifiers))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            testMethodIsNotPublic,
+                            methodNode.Identifier.GetLocation()));
+                    }
                 }
             }
         }
@@ -49,8 +60,42 @@ namespace NUnit.Analyzers.TestMethodAccessibilityLevel
         private static bool IsTestMethod(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
         {
             var allAttributes = attributeLists.SelectMany(al => al.Attributes);
-            return allAttributes.Any(a =>
-                a.DerivesFromITestBuilder(semanticModel) || a.DerivesFromISimpleTestBuilder(semanticModel));
+            return allAttributes.Any(a => a.IsTestMethodAttribute(semanticModel));
+        }
+
+        private static bool IsSetUpTearDownMethod(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        {
+            var allAttributes = attributeLists.SelectMany(al => al.Attributes);
+            return allAttributes.Any(a => a.IsSetUpOrTearDownMethodAttribute(semanticModel));
+        }
+
+        private static bool IsPublic(SyntaxTokenList modifiers)
+        {
+            return modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword));
+        }
+
+        // 'MethodInfo.IsFamily' which means protected, but neither 'protected internal' nor 'private protected'
+        // See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.isfamily?view=netcore-3.1
+        private static bool IsPublicOrFamily(SyntaxTokenList modifiers)
+        {
+            bool protectedSeen = false;
+            foreach (var modifier in modifiers)
+            {
+                if (modifier.IsKind(SyntaxKind.PublicKeyword))
+                {
+                    return true;
+                }
+                else if (modifier.IsKind(SyntaxKind.ProtectedKeyword))
+                {
+                    protectedSeen = true;
+                }
+                else if (modifier.IsKind(SyntaxKind.PrivateKeyword) || modifier.IsKind(SyntaxKind.InternalKeyword))
+                {
+                    return false;
+                }
+            }
+
+            return protectedSeen;
         }
     }
 }


### PR DESCRIPTION
Only allow private and protected methods.