### PR TITLE
Fix for NUnit2021 firing on Action delegates. #274

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -811,6 +811,17 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
+        public void NoDiagnosticWhenComparingDelegate()
+        {
+            var testCode = TestUtility.WrapInAsyncTestMethod(@"
+                Action x = () => {};
+                var y = x;
+                Assert.That(y, Is.EqualTo(x));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void NoDiagnosticWhenComparingTask()
         {
             var testCode = TestUtility.WrapInAsyncTestMethod(@"

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -45,10 +45,13 @@ namespace NUnit.Analyzers.Helpers
         {
             if (actualType is INamedTypeSymbol namedType && namedType.DelegateInvokeMethod != null)
             {
-                actualType = namedType.DelegateInvokeMethod.ReturnType;
+                ITypeSymbol returnType = namedType.DelegateInvokeMethod.ReturnType;
 
-                if (actualType.IsAwaitable(out var awaitReturnType) && awaitReturnType.SpecialType != SpecialType.System_Void)
-                    actualType = awaitReturnType;
+                if (returnType.IsAwaitable(out ITypeSymbol? awaitReturnType))
+                    returnType = awaitReturnType;
+
+                if (returnType.SpecialType != SpecialType.System_Void)
+                    actualType = returnType;
             }
 
             return actualType;


### PR DESCRIPTION
The previous fix for #258 solved ignoring void return type from Task. This extends it to Delegates (Action).

Fixes #274 