### PR TITLE
Extra condensed CodeFix for Assert.IsTrue (Issues #273)

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Immutable;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.ClassicModelAssertUsage;
+using NUnit.Analyzers.Constants;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
+{
+    [TestFixture]
+    public sealed class IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new ClassicModelAssertUsageAnalyzer();
+        private static readonly CodeFixProvider fix = new IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix();
+
+        [Test]
+        public void VerifyGetFixableDiagnosticIds()
+        {
+            var fix = new IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix();
+            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+
+            Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsTrueUsage, AnalyzerIdentifiers.TrueUsage }));
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixes(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓Assert.{assertion}(true);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(true);
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: CodeFixConstants.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixesWithMessage(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓Assert.{assertion}(true, ""message"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(true, ""message"");
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: CodeFixConstants.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixesWithMessageAndParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓Assert.{assertion}(true, ""message"", Guid.NewGuid());
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(true, ""message"", Guid.NewGuid());
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: CodeFixConstants.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
+        }
+    }
+}

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -20,6 +20,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             return WellKnownFixAllProviders.BatchFixer;
         }
 
+        protected virtual string Title => CodeFixConstants.TransformToConstraintModelDescription;
+
         protected virtual void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments, TypeArgumentListSyntax typeArguments)
         {
             throw new InvalidOperationException($"Class must override {nameof(UpdateArguments)} accepting {nameof(TypeArgumentListSyntax)}");
@@ -90,9 +92,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    CodeFixConstants.TransformToConstraintModelDescription,
+                    this.Title,
                     _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
-                    CodeFixConstants.TransformToConstraintModelDescription), diagnostic);
+                    this.Title), diagnostic);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.ClassicModelAssertUsage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public sealed class IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix
+        : ClassicModelAssertUsageCodeFix
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+            AnalyzerIdentifiers.IsTrueUsage,
+            AnalyzerIdentifiers.TrueUsage);
+
+        public const string Suffix = " (condensed)";
+
+        protected override string Title => base.Title + Suffix;
+
+        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        {
+            // Nothing to do
+        }
+    }
+}


### PR DESCRIPTION
Uses Assert.That(expr) iso Assert.That(expr, Is.True)

Fixes #273 