### PR TITLE
ClassicModelAssertUsageCodeFix: #280: Cast type to implicit type

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -88,5 +88,81 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyGreaterWithActualTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            ↓Assert.Greater(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            Assert.That((float)x, Is.GreaterThan(y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyGreaterWithExpectedTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            ↓Assert.Greater(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            Assert.That(x, Is.GreaterThan((float)y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -88,5 +88,81 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyGreaterOrEqualWithActualTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            ↓Assert.GreaterOrEqual(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            Assert.That((float)x, Is.GreaterThanOrEqualTo(y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyGreaterOrEqualWithExpectedTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            ↓Assert.GreaterOrEqual(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            Assert.That(x, Is.GreaterThanOrEqualTo((float)y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -84,5 +84,41 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyIsEmptyWithImplicitTypeConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyString
+        {
+            private readonly string _value;
+
+            public MyString(string value) => _value = value;
+
+            public static implicit operator string(MyString value) => value._value;
+            public static implicit operator MyString(string value) => new MyString(value);
+        }
+        public void TestMethod()
+        {
+            MyString s = string.Empty;
+            ↓Assert.IsEmpty(s);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyString
+        {
+            private readonly string _value;
+
+            public MyString(string value) => _value = value;
+
+            public static implicit operator string(MyString value) => value._value;
+            public static implicit operator MyString(string value) => new MyString(value);
+        }
+        public void TestMethod()
+        {
+            MyString s = string.Empty;
+            Assert.That((string)s, Is.Empty);
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -84,5 +84,41 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyIsNotEmptyWithImplicitTypeConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyString
+        {
+            private readonly string _value;
+
+            public MyString(string value) => _value = value;
+
+            public static implicit operator string(MyString value) => value._value;
+            public static implicit operator MyString(string value) => new MyString(value);
+        }
+        public void TestMethod()
+        {
+            MyString s = ""Hello NUnit"";
+            ↓Assert.IsNotEmpty(s);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyString
+        {
+            private readonly string _value;
+
+            public MyString(string value) => _value = value;
+
+            public static implicit operator string(MyString value) => value._value;
+            public static implicit operator MyString(string value) => new MyString(value);
+        }
+        public void TestMethod()
+        {
+            MyString s = ""Hello NUnit"";
+            Assert.That((string)s, Is.Not.Empty);
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -88,5 +88,81 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyLessWithActualTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            ↓Assert.Less(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            Assert.That((float)x, Is.LessThan(y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyLessWithExpectedTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            ↓Assert.Less(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            Assert.That(x, Is.LessThan((float)y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -88,5 +88,81 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyLessOrEqualWithActualTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            ↓Assert.LessOrEqual(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            float y = 2;
+            Assert.That((float)x, Is.LessThanOrEqualTo(y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyLessOrEqualWithExpectedTypeImplicitConversionFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            ↓Assert.LessOrEqual(x, y);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            float x = 1;
+            MyFloat y = 2;
+            Assert.That(x, Is.LessThanOrEqualTo((float)y));
+        }");
+            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
 using static NUnit.Analyzers.Constants.NunitFrameworkConstants;
 
 namespace NUnit.Analyzers.ClassicModelAssertUsage
@@ -203,7 +204,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             defaultSeverity: DiagnosticSeverity.Info,
             description: ClassicModelUsageAnalyzerConstants.IsNotInstanceOfDescription);
 
-        private static readonly ImmutableDictionary<string, DiagnosticDescriptor> name =
+        private static readonly ImmutableDictionary<string, DiagnosticDescriptor> NameToDescriptor =
           new Dictionary<string, DiagnosticDescriptor>
           {
               { NameOfAssertIsTrue, isTrueDescriptor },
@@ -232,15 +233,15 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
               { NameOfAssertIsNotInstanceOf, isNotInstanceOfDescriptor },
           }.ToImmutableDictionary();
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.name.Values.ToImmutableArray();
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ClassicModelAssertUsageAnalyzer.NameToDescriptor.Values.ToImmutableArray();
 
         protected override void AnalyzeAssertInvocation(SyntaxNodeAnalysisContext context,
             InvocationExpressionSyntax assertExpression, IMethodSymbol methodSymbol)
         {
-            if (ClassicModelAssertUsageAnalyzer.name.ContainsKey(methodSymbol.Name))
+            if (ClassicModelAssertUsageAnalyzer.NameToDescriptor.TryGetValue(methodSymbol.Name, out DiagnosticDescriptor? descriptor))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    ClassicModelAssertUsageAnalyzer.name[methodSymbol.Name],
+                    descriptor,
                     assertExpression.GetLocation(),
                     ClassicModelAssertUsageAnalyzer.GetProperties(methodSymbol)));
             }


### PR DESCRIPTION
When a specific classic assert overload is called.