### PR TITLE
Rework attribute analyzers to symbol analyzers

### DIFF
--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -6,10 +6,10 @@ using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
-using NUnit.Analyzers.TestCaseUsage;
+using NUnit.Analyzers.TestMethodUsage;
 using NUnit.Framework;
 
-namespace NUnit.Analyzers.Tests.TestCaseUsage
+namespace NUnit.Analyzers.Tests.TestMethodUsage
 {
     [TestFixture]
     public sealed class TestMethodUsageAnalyzerTests
@@ -510,6 +510,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
 
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
     [↓Test]
+    [Category(""Test"")]
     public void M(int p)
     {
         Assert.That(p, Is.EqualTo(42));

--- a/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
@@ -5,11 +5,10 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace NUnit.Analyzers.Extensions
 {
-    internal static class AttributeArgumentSyntaxExtensions
+    internal static class AttributeArgumentTypedConstantExtensions
     {
         private static readonly IReadOnlyList<Type> ConvertibleTypes = new List<Type>
         {
@@ -52,21 +51,16 @@ namespace NUnit.Analyzers.Extensions
                 (typeof(Version), null),
             };
 
-        internal static bool CanAssignTo(this AttributeArgumentSyntax @this, ITypeSymbol target, SemanticModel model,
+        internal static bool CanAssignTo(this TypedConstant @this, ITypeSymbol target, Compilation compilation,
             bool allowImplicitConversion = false,
             bool allowEnumToUnderlyingTypeConversion = false)
         {
             //See https://github.com/nunit/nunit/blob/f16d12d6fa9e5c879601ad57b4b24ec805c66054/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs#L396
             //for the reasoning behind this implementation.
-            Optional<object> possibleConstantValue = model.GetConstantValue(@this.Expression);
-            object? argumentValue = null;
-            if (possibleConstantValue.HasValue)
-            {
-                argumentValue = possibleConstantValue.Value;
-            }
 
-            TypeInfo sourceTypeInfo = model.GetTypeInfo(@this.Expression);
-            ITypeSymbol? argumentType = sourceTypeInfo.Type;
+            object? argumentValue = GetValue(@this);
+
+            ITypeSymbol? argumentType = @this.Type;
             ITypeSymbol? targetType = GetTargetType(target);
 
             if (allowEnumToUnderlyingTypeConversion && targetType?.TypeKind == TypeKind.Enum)
@@ -75,7 +69,7 @@ namespace NUnit.Analyzers.Extensions
             if (targetType == null)
                 return false;
 
-            if (argumentType == null)
+            if (argumentValue == null)
             {
                 if (target.IsReferenceType ||
                     target.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
@@ -92,7 +86,7 @@ namespace NUnit.Analyzers.Extensions
                     return false;
 
                 if (targetType.IsAssignableFrom(argumentType)
-                    || (allowImplicitConversion && HasBuiltInImplicitConversion(argumentType, targetType, model)))
+                    || (allowImplicitConversion && HasBuiltInImplicitConversion(argumentType, targetType, compilation)))
                 {
                     return true;
                 }
@@ -121,13 +115,23 @@ namespace NUnit.Analyzers.Extensions
 
                         if (canConvert)
                         {
-                            return AttributeArgumentSyntaxExtensions.TryChangeType(targetType, argumentValue);
+                            return AttributeArgumentTypedConstantExtensions.TryChangeType(targetType, argumentValue);
                         }
                     }
                 }
             }
 
-            return CanBeTranslatedByTypeConverter(targetType, argumentValue, model.Compilation);
+            return CanBeTranslatedByTypeConverter(targetType, argumentValue, compilation);
+        }
+
+        private static object? GetValue(TypedConstant typedConstant)
+        {
+            if (typedConstant.IsNull)
+                return null;
+
+            return typedConstant.Kind == TypedConstantKind.Array
+                ? typedConstant.Values
+                : typedConstant.Value;
         }
 
         private static ITypeSymbol GetTargetType(ITypeSymbol target)
@@ -170,9 +174,9 @@ namespace NUnit.Analyzers.Extensions
             }
         }
 
-        private static bool HasBuiltInImplicitConversion(ITypeSymbol argumentType, ITypeSymbol targetType, SemanticModel model)
+        private static bool HasBuiltInImplicitConversion(ITypeSymbol argumentType, ITypeSymbol targetType, Compilation compilation)
         {
-            var conversion = model.Compilation.ClassifyConversion(argumentType, targetType);
+            var conversion = compilation.ClassifyConversion(argumentType, targetType);
             return conversion.IsImplicit && !conversion.IsUserDefined;
         }
 

--- a/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
@@ -2,11 +2,26 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
 
 namespace NUnit.Analyzers.Extensions
 {
     internal static class AttributeDataExtensions
     {
+        public static bool DerivesFromISimpleTestBuilder(this AttributeData @this, Compilation compilation)
+        {
+            return DerivesFromInterface(compilation, @this, NunitFrameworkConstants.FullNameOfTypeISimpleTestBuilder);
+        }
+
+        public static bool DerivesFromITestBuilder(this AttributeData @this, Compilation compilation)
+        {
+            return DerivesFromInterface(compilation, @this, NunitFrameworkConstants.FullNameOfTypeITestBuilder);
+        }
+        public static bool DerivesFromIParameterDataSource(this AttributeData @this, Compilation compilation)
+        {
+            return DerivesFromInterface(compilation, @this, NunitFrameworkConstants.FullNameOfTypeIParameterDataSource);
+        }
+
         public static AttributeArgumentSyntax? GetConstructorArgumentSyntax(this AttributeData @this, int position,
             CancellationToken cancellationToken = default)
         {
@@ -26,6 +41,14 @@ namespace NUnit.Analyzers.Extensions
 
             return attributeSyntax.ArgumentList.Arguments
                 .FirstOrDefault(a => a.NameEquals?.Name.Identifier.Text == name);
+        }
+
+        private static bool DerivesFromInterface(Compilation compilation, AttributeData attributeData, string interfaceTypeFullName)
+        {
+            var interfaceType = compilation.GetTypeByMetadataName(interfaceTypeFullName);
+
+            return attributeData.AttributeClass != null
+                && attributeData.AttributeClass.AllInterfaces.Any(i => i.Equals(interfaceType));
         }
     }
 }

--- a/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace NUnit.Analyzers.Extensions
+{
+    internal static class AttributeDataExtensions
+    {
+        public static AttributeArgumentSyntax? GetConstructorArgumentSyntax(this AttributeData @this, int position,
+            CancellationToken cancellationToken = default)
+        {
+            if (!(@this.ApplicationSyntaxReference.GetSyntax(cancellationToken) is AttributeSyntax attributeSyntax))
+                return null;
+
+            return attributeSyntax.ArgumentList.Arguments
+                .Where(a => a.NameEquals == null)
+                .ElementAtOrDefault(position);
+        }
+
+        public static AttributeArgumentSyntax? GetNamedArgumentSyntax(this AttributeData @this, string name,
+            CancellationToken cancellationToken = default)
+        {
+            if (!(@this.ApplicationSyntaxReference.GetSyntax(cancellationToken) is AttributeSyntax attributeSyntax))
+                return null;
+
+            return attributeSyntax.ArgumentList.Arguments
+                .FirstOrDefault(a => a.NameEquals?.Name.Identifier.Text == name);
+        }
+    }
+}

--- a/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
@@ -17,9 +17,29 @@ namespace NUnit.Analyzers.Extensions
         {
             return DerivesFromInterface(compilation, @this, NunitFrameworkConstants.FullNameOfTypeITestBuilder);
         }
+
         public static bool DerivesFromIParameterDataSource(this AttributeData @this, Compilation compilation)
         {
             return DerivesFromInterface(compilation, @this, NunitFrameworkConstants.FullNameOfTypeIParameterDataSource);
+        }
+
+        public static bool IsTestMethodAttribute(this AttributeData @this, Compilation compilation)
+        {
+            return @this.DerivesFromITestBuilder(compilation) ||
+                   @this.DerivesFromISimpleTestBuilder(compilation);
+        }
+
+        public static bool IsSetUpOrTearDownMethodAttribute(this AttributeData @this, Compilation compilation)
+        {
+            var attributeType = @this.AttributeClass;
+
+            if (attributeType == null)
+                return false;
+
+            return attributeType.IsType(NunitFrameworkConstants.FullNameOfTypeOneTimeSetUpAttribute, compilation)
+                || attributeType.IsType(NunitFrameworkConstants.FullNameOfTypeOneTimeTearDownAttribute, compilation)
+                || attributeType.IsType(NunitFrameworkConstants.FullNameOfTypeSetUpAttribute, compilation)
+                || attributeType.IsType(NunitFrameworkConstants.FullNameOfTypeTearDownAttribute, compilation);
         }
 
         public static AttributeArgumentSyntax? GetConstructorArgumentSyntax(this AttributeData @this, int position,

--- a/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
@@ -65,10 +65,15 @@ namespace NUnit.Analyzers.Extensions
 
         private static bool DerivesFromInterface(Compilation compilation, AttributeData attributeData, string interfaceTypeFullName)
         {
+            if (attributeData.AttributeClass is null)
+                return false;
+
             var interfaceType = compilation.GetTypeByMetadataName(interfaceTypeFullName);
 
-            return attributeData.AttributeClass != null
-                && attributeData.AttributeClass.AllInterfaces.Any(i => i.Equals(interfaceType));
+            if (interfaceType is null)
+                return false;
+
+            return attributeData.AttributeClass.AllInterfaces.Any(i => i.Equals(interfaceType));
         }
     }
 }

--- a/src/nunit.analyzers/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeSyntaxExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using NUnit.Analyzers.Constants;
 
 namespace NUnit.Analyzers.Extensions
 {
@@ -40,65 +39,6 @@ namespace NUnit.Analyzers.Extensions
             }
 
             return (positionalArguments.ToImmutableArray(), namedArguments.ToImmutableArray());
-        }
-
-        internal static bool DerivesFromISimpleTestBuilder(this AttributeSyntax @this, SemanticModel semanticModel)
-        {
-            return DerivesFromInterface(semanticModel, @this, NunitFrameworkConstants.FullNameOfTypeISimpleTestBuilder);
-        }
-
-        internal static bool DerivesFromITestBuilder(this AttributeSyntax @this, SemanticModel semanticModel)
-        {
-            return DerivesFromInterface(semanticModel, @this, NunitFrameworkConstants.FullNameOfTypeITestBuilder);
-        }
-
-        internal static bool DerivesFromIParameterDataSource(this AttributeSyntax @this, SemanticModel semanticModel)
-        {
-            return DerivesFromInterface(semanticModel, @this, NunitFrameworkConstants.FullNameOfTypeIParameterDataSource);
-        }
-
-        private static bool DerivesFromInterface(
-            SemanticModel semanticModel,
-            AttributeSyntax attributeSyntax,
-            string interfaceTypeFullName)
-        {
-            var interfaceType = semanticModel.Compilation.GetTypeByMetadataName(interfaceTypeFullName);
-
-            if (interfaceType == null)
-                return false;
-
-            var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type;
-
-            if (attributeType == null)
-                return false;
-
-            return attributeType.AllInterfaces.Any(i => i.Equals(interfaceType));
-
-        }
-
-        internal static bool IsSetUpOrTearDownMethodAttribute(this AttributeSyntax attributeSyntax, SemanticModel semanticModel)
-        {
-            var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type;
-
-            if (attributeType == null)
-                return false;
-
-            switch (attributeType.ToString())
-            {
-                case NunitFrameworkConstants.FullNameOfTypeOneTimeSetUpAttribute:
-                case NunitFrameworkConstants.FullNameOfTypeOneTimeTearDownAttribute:
-                case NunitFrameworkConstants.FullNameOfTypeSetUpAttribute:
-                case NunitFrameworkConstants.FullNameOfTypeTearDownAttribute:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        internal static bool IsTestMethodAttribute(this AttributeSyntax attributeSyntax, SemanticModel semanticModel)
-        {
-            return attributeSyntax.DerivesFromITestBuilder(semanticModel) ||
-                   attributeSyntax.DerivesFromISimpleTestBuilder(semanticModel);
         }
     }
 }

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -33,6 +33,13 @@ namespace NUnit.Analyzers.Extensions
                     && NunitFrameworkConstants.NUnitFrameworkAssemblyName == @this.ContainingAssembly.Name);
         }
 
+        internal static bool IsType([NotNullWhen(true)] this ITypeSymbol? @this, string fullMetadataName, Compilation compilation)
+        {
+            var typeSymbol = compilation.GetTypeByMetadataName(fullMetadataName);
+
+            return typeSymbol != null && typeSymbol.Equals(@this);
+        }
+
         internal static string GetFullMetadataName(this ITypeSymbol @this)
         {
             // e.g. System.Collections.Generic.IEnumerable`1

--- a/src/nunit.analyzers/Extensions/ImmutableArrayExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ImmutableArrayExtensions.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NUnit.Analyzers.Extensions
 {
     public static class ImmutableArrayExtensions
     {
-        public static bool TryGetValue<TKey, TValue>(this ImmutableArray<KeyValuePair<TKey, TValue>> @this, TKey key, out TValue value)
+        public static bool TryGetValue<TKey, TValue>(this ImmutableArray<KeyValuePair<TKey, TValue>> @this,
+            TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             foreach (var keyValue in @this)
             {
@@ -16,7 +18,7 @@ namespace NUnit.Analyzers.Extensions
                 }
             }
 
-            value = default!;
+            value = default;
             return false;
         }
     }

--- a/src/nunit.analyzers/Extensions/ImmutableArrayExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ImmutableArrayExtensions.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace NUnit.Analyzers.Extensions
+{
+    public static class ImmutableArrayExtensions
+    {
+        public static bool TryGetValue<TKey, TValue>(this ImmutableArray<KeyValuePair<TKey, TValue>> @this, TKey key, out TValue value)
+        {
+            foreach (var keyValue in @this)
+            {
+                if (Equals(keyValue.Key, key))
+                {
+                    value = keyValue.Value;
+                    return true;
+                }
+            }
+
+            value = default!;
+            return false;
+        }
+    }
+}

--- a/src/nunit.analyzers/Extensions/SyntaxReferenceExtensions.cs
+++ b/src/nunit.analyzers/Extensions/SyntaxReferenceExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.CodeAnalysis;
+
+namespace NUnit.Analyzers.Extensions
+{
+    internal static class SyntaxReferenceExtensions
+    {
+        public static Location GetLocation(this SyntaxReference @this)
+        {
+            return @this.SyntaxTree.GetLocation(@this.Span);
+        }
+    }
+}

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
@@ -68,7 +68,7 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
 
         private static bool IsPublicOrInternalMethod(IMethodSymbol method)
         {
-            switch(method.DeclaredAccessibility)
+            switch (method.DeclaredAccessibility)
             {
                 case Accessibility.Public:
                 case Accessibility.Internal:

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
@@ -29,26 +27,23 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
         {
             context.EnableConcurrentExecution();
 
-            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.ClassDeclaration);
+            context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
         }
 
-        private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeType(SymbolAnalysisContext context)
         {
-            var classNode = context.Node as ClassDeclarationSyntax;
-
-            if (classNode is null)
-            {
-                return;
-            }
+            var typeSymbol = (INamedTypeSymbol)context.Symbol;
 
             // Is this even a TestFixture, i.e.: Does it has any test methods.
             // If not public methods are fine.
             bool hasTestMethods = false;
 
-            var publicNonTestMethods = new List<MethodDeclarationSyntax>();
-            foreach (var method in classNode.Members.OfType<MethodDeclarationSyntax>())
+            var publicNonTestMethods = new List<IMethodSymbol>();
+
+            var methods = typeSymbol.GetMembers().OfType<IMethodSymbol>().Where(m => m.MethodKind == MethodKind.Ordinary);
+            foreach (var method in methods)
             {
-                if (IsTestRelatedMethod(context.SemanticModel, method.AttributeLists))
+                if (IsTestRelatedMethod(context.Compilation, method))
                     hasTestMethods = true;
                 else if (IsPublicOrInternalMethod(method))
                     publicNonTestMethods.Add(method);
@@ -60,21 +55,29 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         nonTestMethodIsPublic,
-                        method.Identifier.GetLocation()));
+                        method.Locations[0]));
                 }
             }
         }
 
-        private static bool IsTestRelatedMethod(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        private static bool IsTestRelatedMethod(Compilation compilation, IMethodSymbol methodSymbol)
         {
-            var allAttributes = attributeLists.SelectMany(al => al.Attributes);
-            return allAttributes.Any(a => a.IsSetUpOrTearDownMethodAttribute(semanticModel) ||
-                                          a.IsTestMethodAttribute(semanticModel));
+            return methodSymbol.GetAttributes().Any(
+                a => a.IsSetUpOrTearDownMethodAttribute(compilation) || a.IsTestMethodAttribute(compilation));
         }
 
-        private static bool IsPublicOrInternalMethod(MethodDeclarationSyntax method)
+        private static bool IsPublicOrInternalMethod(IMethodSymbol method)
         {
-            return method.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword) || m.IsKind(SyntaxKind.InternalKeyword));
+            switch(method.DeclaredAccessibility)
+            {
+                case Accessibility.Public:
+                case Accessibility.Internal:
+                case Accessibility.ProtectedOrInternal:
+                    return true;
+
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
@@ -1,8 +1,7 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
@@ -12,8 +11,6 @@ namespace NUnit.Analyzers.ParallelizableUsage
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ParallelizableUsageAnalyzer : DiagnosticAnalyzer
     {
-        internal const string AssemblyAttributeTargetSpecifier = "assembly";
-
         private static readonly DiagnosticDescriptor scopeSelfNoEffectOnAssemblyUsage = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.ParallelScopeSelfNoEffectOnAssemblyUsage,
             title: ParallelizableUsageAnalyzerConstants.ParallelScopeSelfNoEffectOnAssemblyTitle,
@@ -46,70 +43,85 @@ namespace NUnit.Analyzers.ParallelizableUsage
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
-
-            context.RegisterSyntaxNodeAction(ParallelizableUsageAnalyzer.AnalyzeAttribute, SyntaxKind.Attribute);
+            context.RegisterCompilationAction(AnalyzeCompilation);
+            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
         }
 
-        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationAnalysisContext context)
         {
-            var parallelizableAttributeType = context.SemanticModel.Compilation.GetTypeByMetadataName(
-                NunitFrameworkConstants.FullNameOfTypeParallelizableAttribute);
-            if (parallelizableAttributeType == null)
-                return;
-
-            var attributeNode = (AttributeSyntax)context.Node;
-            var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
-
-            if (parallelizableAttributeType.ContainingAssembly.Identity != attributeSymbol?.ContainingAssembly.Identity ||
-                NunitFrameworkConstants.NameOfParallelizableAttribute != attributeSymbol?.ContainingType.Name)
+            if (!TryGetAttributeEnumValue(context.Compilation, context.Compilation.Assembly,
+                out int enumValue,
+                out var attributeData))
             {
                 return;
             }
-
-            context.CancellationToken.ThrowIfCancellationRequested();
-
-            var possibleEnumValue = GetOptionalEnumValue(context, attributeNode);
-            if (possibleEnumValue == null)
-                return;
-
-            int enumValue = possibleEnumValue.Value;
-            var attributeListSyntax = attributeNode.Parent as AttributeListSyntax;
-            if (attributeListSyntax == null)
-                return;
 
             if (HasExactFlag(enumValue, ParallelizableUsageAnalyzerConstants.ParallelScope.Self))
             {
                 // Specifying ParallelScope.Self on an assembly level attribute has no effect
-                var atAssemblyLevel = attributeListSyntax.Target?.Identifier.ValueText == AssemblyAttributeTargetSpecifier;
-                if (atAssemblyLevel)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(scopeSelfNoEffectOnAssemblyUsage,
-                        attributeNode.GetLocation()));
-                }
+                context.ReportDiagnostic(Diagnostic.Create(
+                    scopeSelfNoEffectOnAssemblyUsage,
+                    attributeData.ApplicationSyntaxReference.GetLocation()));
             }
-            else if (HasFlag(enumValue, ParallelizableUsageAnalyzerConstants.ParallelScope.Children))
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
+        {
+            if (!TryGetAttributeEnumValue(context.Compilation, context.Symbol,
+                out int enumValue,
+                out var attributeData))
+            {
+                return;
+            }
+
+            var methodSymbol = (IMethodSymbol)context.Symbol;
+
+            if (HasFlag(enumValue, ParallelizableUsageAnalyzerConstants.ParallelScope.Children))
             {
                 // One may not specify ParallelScope.Children on a non-parameterized test method
-                if (IsNonParameterizedTestMethod(context, attributeListSyntax.Parent as MethodDeclarationSyntax))
+                if (IsNonParameterizedTestMethod(context, methodSymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(scopeChildrenOnNonParameterizedTest,
-                        attributeNode.GetLocation()));
+                        attributeData.ApplicationSyntaxReference.GetLocation()));
                 }
             }
             else if (HasFlag(enumValue, ParallelizableUsageAnalyzerConstants.ParallelScope.Fixtures))
             {
                 // One may not specify ParallelScope.Fixtures on a test method
-                if (attributeListSyntax.Parent is MethodDeclarationSyntax)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(scopeFixturesOnTest,
-                        attributeNode.GetLocation()));
-                }
+                context.ReportDiagnostic(Diagnostic.Create(scopeFixturesOnTest,
+                    attributeData.ApplicationSyntaxReference.GetLocation()));
             }
         }
 
-        private static int? GetOptionalEnumValue(SyntaxNodeAnalysisContext context, AttributeSyntax attributeNode)
+        private static bool TryGetAttributeEnumValue(Compilation compilation, ISymbol symbol,
+            out int enumValue,
+            [NotNullWhen(true)] out AttributeData? attributeData)
         {
-            var (attributePositionalArguments, _) = attributeNode.GetArguments();
+            enumValue = 0;
+            attributeData = null;
+
+            var parallelizableAttributeType = compilation.GetTypeByMetadataName(
+                NunitFrameworkConstants.FullNameOfTypeParallelizableAttribute);
+            if (parallelizableAttributeType == null)
+                return false;
+
+            attributeData = symbol.GetAttributes()
+                .FirstOrDefault(a => a.AttributeClass?.Equals(parallelizableAttributeType) == true);
+
+            if (attributeData?.ApplicationSyntaxReference is null)
+                return false;
+
+            var optionalEnumValue = GetOptionalEnumValue(attributeData);
+            if (optionalEnumValue == null)
+                return false;
+
+            enumValue = optionalEnumValue.Value;
+            return true;
+        }
+
+        private static int? GetOptionalEnumValue(AttributeData attributeData)
+        {
+            var attributePositionalArguments = attributeData.ConstructorArguments;
             var noExplicitEnumArgument = attributePositionalArguments.Length == 0;
             if (noExplicitEnumArgument)
             {
@@ -118,30 +130,19 @@ namespace NUnit.Analyzers.ParallelizableUsage
             else
             {
                 var arg = attributePositionalArguments[0];
-                var constantValue = context.SemanticModel.GetConstantValue(arg.Expression);
-                if (constantValue.HasValue)
-                {
-                    return constantValue.Value as int?;
-                }
+                return arg.Value as int?;
             }
-
-            return null;
         }
 
-        private static bool IsNonParameterizedTestMethod(SyntaxNodeAnalysisContext context,
-            MethodDeclarationSyntax? methodDeclarationSyntax)
+        private static bool IsNonParameterizedTestMethod(SymbolAnalysisContext context, IMethodSymbol methodSymbol)
         {
-            if (methodDeclarationSyntax == null)
-                return false;
-
             // The method is only a parametric method if (see DefaultTestCaseBuilder.BuildFrom)
             // * it has parameters
             // * is marked with one or more attributes deriving from ITestBuilder
             // * the attributes defines tests (difficult to access without evaluating the code)
-            bool noParameters = methodDeclarationSyntax.ParameterList.Parameters.Count == 0;
+            bool noParameters = methodSymbol.Parameters.IsEmpty;
+            bool noITestBuilders = !methodSymbol.GetAttributes().Any(a => a.DerivesFromITestBuilder(context.Compilation));
 
-            var allAttributes = methodDeclarationSyntax.AttributeLists.SelectMany(al => al.Attributes);
-            bool noITestBuilders = !allAttributes.Any(a => a.DerivesFromITestBuilder(context.SemanticModel));
             return noParameters && noITestBuilders;
         }
 

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
@@ -46,76 +43,97 @@ namespace NUnit.Analyzers.TestCaseUsage
         {
             context.EnableConcurrentExecution();
 
-            context.RegisterSyntaxNodeAction(TestCaseUsageAnalyzer.AnalyzeAttribute, SyntaxKind.Attribute);
+            context.RegisterSymbolAction(TestCaseUsageAnalyzer.AnalyzeMethod, SymbolKind.Method);
         }
 
-        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
         {
-            var methodNode = context.Node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+            var methodSymbol = (IMethodSymbol)context.Symbol;
 
-            if (methodNode != null)
+            var attributes = methodSymbol.GetAttributes();
+            if (attributes.Length == 0)
+                return;
+
+            var testCaseType = context.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
+            if (testCaseType == null)
+                return;
+
+            var testCaseAttributes = methodSymbol.GetAttributes()
+                .Where(a => a.ApplicationSyntaxReference != null
+                    && a.AttributeClass != null
+                    && a.AttributeClass.Equals(testCaseType));
+
+            foreach (var attribute in testCaseAttributes)
             {
-                if (!methodNode.ContainsDiagnostics)
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                var (methodRequiredParameters, methodOptionalParameters, methodParamsParameters) =
+                    methodSymbol.GetParameterCounts();
+
+                var attributePositionalArguments = AdjustArguments(attribute.ConstructorArguments);
+
+                // From NUnit.Framework.TestCaseAttribute.GetParametersForTestCase
+                // Special handling when sole method parameter is an object[].
+                // If more than one argument - or one of a different type - is provided
+                // then the argument is wrapped within a object[], as the only element,
+                // hence the resulting code will always be valid.
+                if (IsSoleParameterAnObjectArray(methodSymbol))
                 {
-                    var testCaseType = context.SemanticModel.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
-                    if (testCaseType == null)
-                        return;
-
-                    var attributeNode = (AttributeSyntax)context.Node;
-                    var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
-
-                    if (testCaseType.ContainingAssembly.Identity == attributeSymbol?.ContainingAssembly.Identity &&
-                        NunitFrameworkConstants.NameOfTestCaseAttribute == attributeSymbol?.ContainingType.Name)
+                    if (attributePositionalArguments.Length > 1 ||
+                        (attributePositionalArguments.Length == 1 && !IsTypeAnObjectArray(attributePositionalArguments[0].Type)))
                     {
-                        context.CancellationToken.ThrowIfCancellationRequested();
-
-                        var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodNode);
-                        var (methodRequiredParameters, methodOptionalParameters, methodParamsParameters) =
-                            methodSymbol.GetParameterCounts();
-
-                        var (attributePositionalArguments, _) = attributeNode.GetArguments();
-
-                        // From NUnit.Framework.TestCaseAttribute.GetParametersForTestCase
-                        // Special handling when sole method parameter is an object[].
-                        // If more than one argument - or one of a different type - is provided
-                        // then the argument is wrapped within a object[], as the only element,
-                        // hence the resulting code will always be valid.
-                        if (IsSoleParameterAnObjectArray(methodSymbol))
-                        {
-                            if (attributePositionalArguments.Length > 1 ||
-                                (attributePositionalArguments.Length == 1 &&
-                                IsExpressionNotAnObjectArray(context, attributePositionalArguments[0].Expression)))
-                            {
-                                return;
-                            }
-                        }
-
-                        if (attributePositionalArguments.Length < methodRequiredParameters)
-                        {
-                            context.ReportDiagnostic(Diagnostic.Create(
-                                notEnoughArguments,
-                                attributeNode.GetLocation(),
-                                methodRequiredParameters,
-                                attributePositionalArguments.Length));
-                        }
-                        else if (methodParamsParameters == 0 &&
-                            attributePositionalArguments.Length > methodRequiredParameters + methodOptionalParameters)
-                        {
-                            context.ReportDiagnostic(Diagnostic.Create(
-                                tooManyArguments,
-                                attributeNode.GetLocation(),
-                                methodRequiredParameters + methodOptionalParameters,
-                                attributePositionalArguments.Length));
-                        }
-                        else
-                        {
-                            context.CancellationToken.ThrowIfCancellationRequested();
-                            TestCaseUsageAnalyzer.AnalyzePositionalArgumentsAndParameters(context,
-                                attributePositionalArguments, methodSymbol.Parameters);
-                        }
+                        return;
                     }
                 }
+
+                if (attributePositionalArguments.Length < methodRequiredParameters)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        notEnoughArguments,
+                        attribute.ApplicationSyntaxReference.GetLocation(),
+                        methodRequiredParameters,
+                        attributePositionalArguments.Length));
+                }
+                else if (methodParamsParameters == 0 &&
+                    attributePositionalArguments.Length > methodRequiredParameters + methodOptionalParameters)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        tooManyArguments,
+                        attribute.ApplicationSyntaxReference.GetLocation(),
+                        methodRequiredParameters + methodOptionalParameters,
+                        attributePositionalArguments.Length));
+                }
+                else
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+                    TestCaseUsageAnalyzer.AnalyzePositionalArgumentsAndParameters(
+                        context,
+                        attribute,
+                        attributePositionalArguments,
+                        methodSymbol.Parameters);
+                }
             }
+        }
+
+        private static ImmutableArray<TypedConstant> AdjustArguments(ImmutableArray<TypedConstant> attributePositionalArguments)
+        {
+            if (attributePositionalArguments.Length == 1
+                && attributePositionalArguments[0] is { Kind: TypedConstantKind.Array } arrayArgument)
+            {
+                // params overload, need to check array values instead
+
+                if (arrayArgument.IsNull)
+                {
+                    // If null is provided - analyze it as single null value, not as null array
+                    return ImmutableArray.Create(default(TypedConstant));
+                }
+                else
+                {
+                    return arrayArgument.Values;
+                }
+            }
+
+            return attributePositionalArguments;
         }
 
         private static bool IsSoleParameterAnObjectArray(IMethodSymbol methodSymbol)
@@ -125,12 +143,6 @@ namespace NUnit.Analyzers.TestCaseUsage
 
             var parameterType = methodSymbol.Parameters[0].Type;
             return IsTypeAnObjectArray(parameterType);
-        }
-
-        private static bool IsExpressionNotAnObjectArray(SyntaxNodeAnalysisContext context, ExpressionSyntax expressionSyntax)
-        {
-            TypeInfo typeInfo = context.SemanticModel.GetTypeInfo(expressionSyntax);
-            return !IsTypeAnObjectArray(typeInfo.Type);
         }
 
         private static bool IsTypeAnObjectArray(ITypeSymbol typeSymbol)
@@ -157,12 +169,12 @@ namespace NUnit.Analyzers.TestCaseUsage
             return (type, symbol.Name, paramsType);
         }
 
-        private static void AnalyzePositionalArgumentsAndParameters(SyntaxNodeAnalysisContext context,
-            ImmutableArray<AttributeArgumentSyntax> attributePositionalArguments,
+        private static void AnalyzePositionalArgumentsAndParameters(
+            SymbolAnalysisContext context,
+            AttributeData attribute,
+            ImmutableArray<TypedConstant> attributePositionalArguments,
             ImmutableArray<IParameterSymbol> methodParameters)
         {
-            var model = context.SemanticModel;
-
             for (var i = 0; i < attributePositionalArguments.Length; i++)
             {
                 var attributeArgument = attributePositionalArguments[i];
@@ -172,12 +184,11 @@ namespace NUnit.Analyzers.TestCaseUsage
                 if (methodParameterType.IsTypeParameterAndDeclaredOnMethod())
                     continue;
 
-                TypeInfo sourceTypeInfo = model.GetTypeInfo(attributeArgument.Expression);
-                ITypeSymbol argumentType = sourceTypeInfo.Type;
+                ITypeSymbol? argumentType = attributeArgument.Type;
 
                 var argumentTypeMatchesParameterType = attributeArgument.CanAssignTo(
                     methodParameterType,
-                    model,
+                    context.Compilation,
                     allowImplicitConversion: true,
                     allowEnumToUnderlyingTypeConversion: true);
 
@@ -188,7 +199,7 @@ namespace NUnit.Analyzers.TestCaseUsage
                 {
                     var argumentTypeMatchesElementType = attributeArgument.CanAssignTo(
                         methodParameterParamsType,
-                        model,
+                        context.Compilation,
                         allowImplicitConversion: true,
                         allowEnumToUnderlyingTypeConversion: true);
 
@@ -198,9 +209,14 @@ namespace NUnit.Analyzers.TestCaseUsage
                         continue;
                     }
                 }
-                
+
+                var attributeArgumentSyntax = attribute.GetConstructorArgumentSyntax(i, context.CancellationToken);
+
+                if (attributeArgumentSyntax is null)
+                    continue;
+
                 context.ReportDiagnostic(Diagnostic.Create(parameterTypeMismatch,
-                    attributeArgument.GetLocation(),
+                    attributeArgumentSyntax.GetLocation(),
                     i,
                     argumentType?.ToDisplayString() ?? "<null>",
                     methodParameterName,

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -1,13 +1,11 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
 
-namespace NUnit.Analyzers.TestCaseUsage
+namespace NUnit.Analyzers.TestMethodUsage
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class TestMethodUsageAnalyzer : DiagnosticAnalyzer
@@ -27,7 +25,6 @@ namespace NUnit.Analyzers.TestCaseUsage
             category: Categories.Structure,
             defaultSeverity: DiagnosticSeverity.Error,
             description: TestMethodUsageAnalyzerConstants.SpecifiedExpectedResultForVoidMethodDescription);
-
 
         private static readonly DiagnosticDescriptor noExpectedResultButNonVoidReturnType = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.TestMethodNoExpectedResultButNonVoidReturnType,
@@ -81,107 +78,89 @@ namespace NUnit.Analyzers.TestCaseUsage
         {
             context.EnableConcurrentExecution();
 
-            context.RegisterSyntaxNodeAction(
-                TestMethodUsageAnalyzer.AnalyzeAttribute, SyntaxKind.Attribute);
+            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
         }
 
-        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
         {
-            var declarationNode = context.Node.Parent?.Parent;
-            if (declarationNode is MethodDeclarationSyntax methodNode)
+            var methodSymbol = (IMethodSymbol)context.Symbol;
+
+            var testCaseType = context.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
+            var testType = context.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestAttribute);
+
+            if (testCaseType == null || testType == null)
+                return;
+
+            var methodAttributes = methodSymbol.GetAttributes();
+
+            foreach (var attribute in methodAttributes)
             {
-                if (!methodNode.ContainsDiagnostics)
+                if (attribute.AttributeClass is null)
+                    continue;
+
+                var isTestCaseAttribute = attribute.AttributeClass.Equals(testCaseType);
+                var isTestAttribute = attribute.AttributeClass.Equals(testType);
+
+                if (isTestCaseAttribute || isTestAttribute && !HasITestBuilderAttribute(context.Compilation, methodAttributes))
                 {
-                    var testCaseType = context.SemanticModel.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
-                    var testType = context.SemanticModel.Compilation.GetTypeByMetadataName(NunitFrameworkConstants.FullNameOfTypeTestAttribute);
+                    context.CancellationToken.ThrowIfCancellationRequested();
 
-                    if (testCaseType == null || testType == null)
-                        return;
+                    AnalyzeExpectedResult(context, attribute, methodSymbol);
+                }
 
-                    var attributeNode = (AttributeSyntax)context.Node;
-                    var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
+                var isSimpleTestBulderAttribute = attribute.DerivesFromISimpleTestBuilder(context.Compilation);
 
-                    var isTestCaseAttribute = IsAttribute(testCaseType, NunitFrameworkConstants.NameOfTestCaseAttribute, attributeSymbol);
-                    var isTestAttribute = IsAttribute(testType, NunitFrameworkConstants.NameOfTestAttribute, attributeSymbol);
-
-                    if (isTestCaseAttribute || (isTestAttribute && !HasITestBuilderAttribute(context.SemanticModel, methodNode.AttributeLists)))
-                    {
-                        context.CancellationToken.ThrowIfCancellationRequested();
-
-                        var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodNode);
-
-                        context.CancellationToken.ThrowIfCancellationRequested();
-                        TestMethodUsageAnalyzer.AnalyzeExpectedResult(context, attributeNode, methodSymbol);
-                    }
-
-                    var parameters = methodNode.ParameterList.Parameters;
-                    var testMethodParameters = parameters.Count;
-                    var hasISimpleTestBuilderAttribute = HasISimpleTestBuilderAttribute(context.SemanticModel, methodNode.AttributeLists);
-                    var hasITestBuilderAttribute = HasITestBuilderAttribute(context.SemanticModel, methodNode.AttributeLists);
+                if (isSimpleTestBulderAttribute)
+                {
+                    var parameters = methodSymbol.Parameters;
+                    var testMethodParameters = parameters.Length;
+                    var hasITestBuilderAttribute = HasITestBuilderAttribute(context.Compilation, methodAttributes);
                     var parametersMarkedWithIParameterDataSourceAttribute =
-                        parameters.Count(p => HasIParameterDataSourceAttribute(context.SemanticModel, p.AttributeLists));
+                        parameters.Count(p => HasIParameterDataSourceAttribute(context.Compilation, p.GetAttributes()));
 
                     if (testMethodParameters > 0 &&
-                        hasISimpleTestBuilderAttribute &&
                         !hasITestBuilderAttribute &&
                         parametersMarkedWithIParameterDataSourceAttribute < testMethodParameters)
                     {
-                        context.ReportDiagnostic(
-                            Diagnostic.Create(
-                                simpleTestHasParameters,
-                                attributeNode.GetLocation(),
-                                testMethodParameters,
-                                parametersMarkedWithIParameterDataSourceAttribute));
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            simpleTestHasParameters,
+                            attribute.ApplicationSyntaxReference.GetLocation(),
+                            testMethodParameters,
+                            parametersMarkedWithIParameterDataSourceAttribute));
                     }
                 }
             }
         }
 
-        private static bool IsAttribute(INamedTypeSymbol nunitType, string nunitTypeName, ISymbol attributeSymbol) =>
-            nunitType.ContainingAssembly.Identity == attributeSymbol?.ContainingAssembly.Identity &&
-            nunitTypeName == attributeSymbol?.ContainingType.Name;
-
-        private static bool HasITestBuilderAttribute(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        private static bool HasITestBuilderAttribute(Compilation compilation, ImmutableArray<AttributeData> attributes)
         {
-            var allAttributes = attributeLists.SelectMany(al => al.Attributes);
-            return allAttributes.Any(a => a.DerivesFromITestBuilder(semanticModel));
+            return attributes.Any(a => a.DerivesFromITestBuilder(compilation));
         }
 
-        private static bool HasISimpleTestBuilderAttribute(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        private static bool HasIParameterDataSourceAttribute(Compilation compilation, ImmutableArray<AttributeData> attributes)
         {
-            var allAttributes = attributeLists.SelectMany(al => al.Attributes);
-            return allAttributes.Any(a => a.DerivesFromISimpleTestBuilder(semanticModel));
+            return attributes.Any(a => a.DerivesFromIParameterDataSource(compilation));
         }
 
-        private static bool HasIParameterDataSourceAttribute(SemanticModel semanticModel, SyntaxList<AttributeListSyntax> attributeLists)
+        private static void AnalyzeExpectedResult(SymbolAnalysisContext context,
+            AttributeData attribute, IMethodSymbol methodSymbol)
         {
-            var allAttributes = attributeLists.SelectMany(al => al.Attributes);
-            return allAttributes.Any(a => a.DerivesFromIParameterDataSource(semanticModel));
-        }
-
-        private static void AnalyzeExpectedResult(SyntaxNodeAnalysisContext context,
-            AttributeSyntax attributeNode, IMethodSymbol methodSymbol)
-        {
-            var (_, attributeNamedArguments) = attributeNode.GetArguments();
-
-            var expectedResultNamedArgument = attributeNamedArguments.SingleOrDefault(
-                _ => _.DescendantTokens().Any(_ => _.Text == NunitFrameworkConstants.NameOfExpectedResult));
-
-            if (expectedResultNamedArgument != null)
+            if (attribute.NamedArguments.TryGetValue(NunitFrameworkConstants.NameOfExpectedResult,
+                out var expectedResultNamedArgument))
             {
-                ExpectedResultSupplied(context, methodSymbol, attributeNode, expectedResultNamedArgument);
+                ExpectedResultSupplied(context, methodSymbol, attribute, expectedResultNamedArgument);
             }
             else
             {
-                NoExpectedResultSupplied(context, methodSymbol, attributeNode);
+                NoExpectedResultSupplied(context, methodSymbol, attribute);
             }
         }
 
         private static void ExpectedResultSupplied(
-            SyntaxNodeAnalysisContext context,
+            SymbolAnalysisContext context,
             IMethodSymbol methodSymbol,
-            AttributeSyntax attributeNode,
-            AttributeArgumentSyntax expectedResultNamedArgument)
+            AttributeData attributeData,
+            TypedConstant expectedResultNamedArgument)
         {
             var methodReturnValueType = methodSymbol.ReturnType;
 
@@ -189,73 +168,100 @@ namespace NUnit.Analyzers.TestCaseUsage
             {
                 if (awaitReturnType.SpecialType == SpecialType.System_Void)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(asyncExpectedResultButReturnTypeNotGenericTask,
-                        attributeNode.GetLocation(), methodReturnValueType.ToDisplayString()));
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        asyncExpectedResultButReturnTypeNotGenericTask,
+                        attributeData.ApplicationSyntaxReference.GetLocation(),
+                        methodReturnValueType.ToDisplayString()));
                 }
                 else
                 {
                     ReportIfExpectedResultTypeCannotBeAssignedToReturnType(
-                        ref context, expectedResultNamedArgument, awaitReturnType);
+                        ref context, attributeData, expectedResultNamedArgument, awaitReturnType);
                 }
             }
             else
             {
                 if (methodReturnValueType.SpecialType == SpecialType.System_Void)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(specifiedExpectedResultForVoid,
-                        expectedResultNamedArgument.GetLocation()));
+                    var expectedResultLocation = GetExpectedArgumentLocation(attributeData);
+
+                    if (expectedResultLocation != null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            specifiedExpectedResultForVoid,
+                            expectedResultLocation));
+                    }
                 }
                 else
                 {
                     ReportIfExpectedResultTypeCannotBeAssignedToReturnType(
-                        ref context, expectedResultNamedArgument, methodReturnValueType);
+                        ref context, attributeData, expectedResultNamedArgument, methodReturnValueType);
                 }
             }
         }
 
         private static void ReportIfExpectedResultTypeCannotBeAssignedToReturnType(
-            ref SyntaxNodeAnalysisContext context,
-            AttributeArgumentSyntax expectedResultNamedArgument,
+            ref SymbolAnalysisContext context,
+            AttributeData attributeData,
+            TypedConstant expectedResultNamedArgument,
             ITypeSymbol typeSymbol)
         {
             if (typeSymbol.IsTypeParameterAndDeclaredOnMethod())
                 return;
 
-            if (!expectedResultNamedArgument.CanAssignTo(typeSymbol, context.SemanticModel))
+            if (!expectedResultNamedArgument.CanAssignTo(typeSymbol, context.Compilation))
             {
-                context.ReportDiagnostic(Diagnostic.Create(expectedResultTypeMismatch,
-                    expectedResultNamedArgument.GetLocation(), typeSymbol.MetadataName));
+                var location = GetExpectedArgumentLocation(attributeData);
+
+                if (location != null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        expectedResultTypeMismatch,
+                        location,
+                        typeSymbol.MetadataName));
+                }
             }
         }
 
         private static void NoExpectedResultSupplied(
-            SyntaxNodeAnalysisContext context,
+            SymbolAnalysisContext context,
             IMethodSymbol methodSymbol,
-            AttributeSyntax attributeNode)
+            AttributeData attributeData)
         {
             var methodReturnValueType = methodSymbol.ReturnType;
 
             if (methodSymbol.IsAsync
                 && methodReturnValueType.SpecialType == SpecialType.System_Void)
             {
-                context.ReportDiagnostic(Diagnostic.Create(asyncNoExpectedResultAndVoidReturnType, attributeNode.GetLocation()));
+                context.ReportDiagnostic(Diagnostic.Create(
+                    asyncNoExpectedResultAndVoidReturnType,
+                    attributeData.ApplicationSyntaxReference.GetLocation()));
             }
             else if (methodReturnValueType.IsAwaitable(out var awaitReturnType))
             {
                 if (awaitReturnType.SpecialType != SpecialType.System_Void)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(asyncNoExpectedResultAndNonTaskReturnType,
-                        attributeNode.GetLocation(), methodReturnValueType.ToDisplayString()));
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        asyncNoExpectedResultAndNonTaskReturnType,
+                        attributeData.ApplicationSyntaxReference.GetLocation(),
+                        methodReturnValueType.ToDisplayString()));
                 }
             }
             else
             {
                 if (methodReturnValueType.SpecialType != SpecialType.System_Void)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(noExpectedResultButNonVoidReturnType,
-                        attributeNode.GetLocation(), methodReturnValueType.ToDisplayString()));
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        noExpectedResultButNonVoidReturnType,
+                        attributeData.ApplicationSyntaxReference.GetLocation(),
+                        methodReturnValueType.ToDisplayString()));
                 }
             }
+        }
+
+        private static Location? GetExpectedArgumentLocation(AttributeData attributeData)
+        {
+            return attributeData.GetNamedArgumentSyntax(NunitFrameworkConstants.NameOfExpectedResult)?.GetLocation();
         }
     }
 }


### PR DESCRIPTION
Contributes to #270 .

The following analyzers are reworked as symbol analyzers:

- TestCaseUsageAnalyzer
- TestMethodUsage
- ParallelizableUsageAnalyzer 
- NonTestMethodAccessibilityLevelAnalyzer 
- TestMethodAccessibilityLevelAnalyzer 

The easiest would be to review commit-by-commit, ignoring spaces.