### PR TITLE
Add StyleCop to project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -153,9 +153,6 @@ dotnet_diagnostic.SA1311.severity = none
 # SA1316: Tuple element names should use correct casing
 dotnet_diagnostic.SA1316.severity = none
 
-# SA1401: Fields should be private
-dotnet_diagnostic.SA1401.severity = none
-
 # SA1413: Use trailing comma in multi-line initializers
 dotnet_diagnostic.SA1413.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -57,6 +57,10 @@ csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
+# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#file-organization
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
 # https://docs.nunit.org/articles/developer-info/Coding-Standards.html#naming
 # Always use "this." and "Me." when applicable; let StyleCop Analyzers provide the warning and fix
 dotnet_style_qualification_for_field = true:warning
@@ -139,9 +143,6 @@ dotnet_diagnostic.SA1124.severity = none
 
 # SA1118: Parameter should not span multiple lines
 dotnet_diagnostic.SA1118.severity = none
-
-# SA1200: Using directives should be placed correctly
-dotnet_diagnostic.SA1200.severity = none
 
 # SA1201: Elements should appear in the correct order
 dotnet_diagnostic.SA1201.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -168,9 +168,6 @@ dotnet_diagnostic.SA1516.severity = none
 # SA1600: Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
 
-# SA1623: Property summary documentation should match accessors
-dotnet_diagnostic.SA1623.severity = none
-
 # SA1615: Element return value should be documented
 dotnet_diagnostic.SA1615.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -144,9 +144,6 @@ dotnet_diagnostic.SA1124.severity = none
 # SA1118: Parameter should not span multiple lines
 dotnet_diagnostic.SA1118.severity = none
 
-# SA1201: Elements should appear in the correct order
-dotnet_diagnostic.SA1201.severity = none
-
 # SA1202: Elements should be ordered by access
 dotnet_diagnostic.SA1202.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -144,9 +144,6 @@ dotnet_diagnostic.SA1124.severity = none
 # SA1118: Parameter should not span multiple lines
 dotnet_diagnostic.SA1118.severity = none
 
-# SA1202: Elements should be ordered by access
-dotnet_diagnostic.SA1202.severity = none
-
 # SA1204: Static elements should appear before instance elements
 dotnet_diagnostic.SA1204.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -60,6 +60,7 @@ csharp_indent_labels = flush_left
 # https://docs.nunit.org/articles/developer-info/Coding-Standards.html#file-organization
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:warning
 
 # https://docs.nunit.org/articles/developer-info/Coding-Standards.html#naming
 # Always use "this." and "Me." when applicable; let StyleCop Analyzers provide the warning and fix

--- a/.editorconfig
+++ b/.editorconfig
@@ -118,3 +118,75 @@ dotnet_naming_rule.public_fields.style = pascal_case
 dotnet_naming_rule.parameters_and_locals.severity = suggestion
 dotnet_naming_rule.parameters_and_locals.symbols = parameters_and_locals
 dotnet_naming_rule.parameters_and_locals.style = camel_case
+
+# SA0001: Xml comment analysis disabled
+dotnet_diagnostic.SA0001.severity = none
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1116: Split parameters should start on line after declaration
+dotnet_diagnostic.SA1116.severity = none
+
+# SA1117: Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = none
+
+# SA1122: Use string.Empty for empty strings
+dotnet_diagnostic.SA1122.severity = none
+
+# SA1124: Do not use regions
+dotnet_diagnostic.SA1124.severity = none
+
+# SA1118: Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = none
+
+# SA1200: Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = none
+
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = none
+
+# SA1202: Elements should be ordered by access
+dotnet_diagnostic.SA1202.severity = none
+
+# SA1204: Static elements should appear before instance elements
+dotnet_diagnostic.SA1204.severity = none
+
+# SA1311: Static readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1311.severity = none
+
+# SA1316: Tuple element names should use correct casing
+dotnet_diagnostic.SA1316.severity = none
+
+# SA1401: Fields should be private
+dotnet_diagnostic.SA1401.severity = none
+
+# SA1413: Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = none
+
+# SA1503: Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = none
+
+# SA1512: Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = none
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1623: Property summary documentation should match accessors
+dotnet_diagnostic.SA1623.severity = none
+
+# SA1615: Element return value should be documented
+dotnet_diagnostic.SA1615.severity = none
+
+# SA1611: Element parameters should be documented
+dotnet_diagnostic.SA1611.severity = none
+
+# SA1612: Element parameter documentation should match element parameters
+dotnet_diagnostic.SA1612.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -98,9 +98,6 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 
-# https://docs.nunit.org/articles/developer-info/Coding-Standards.html#file-organization
-dotnet_sort_system_directives_first = true
-
 # The first matching rule wins, more specific rules at the top
 
 # dotnet_naming_rule.*.symbols does not yet support a comma-separated list https://github.com/dotnet/roslyn/issues/20891

--- a/.gitignore
+++ b/.gitignore
@@ -171,7 +171,6 @@ AppPackages/
 
 # Others
 ClientBin/
-[Ss]tyle[Cc]op.*
 ~$*
 *~
 *.dbmdl

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -87,6 +87,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6BFAB271-DF3C-4685-A0E0-8966C9C8832F}"
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
+		..\stylecop.json = ..\stylecop.json
 	EndProjectSection
 EndProject
 Global

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -83,6 +83,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6BFAB271-DF3C-4685-A0E0-8966C9C8832F}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
@@ -22,7 +22,9 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray<string>.Empty;
 
-            protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments) { }
+            protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+            {
+            }
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -111,7 +111,6 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
-
         [Test]
         public void VerifyIsNotInstanceOfSingleNestedGenericFix()
         {

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
@@ -174,7 +174,6 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.IsFalse(actual.Equals(""bcd""));");
 
-
             var fixedCode = TestUtility.WrapInTestMethod(@"
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
@@ -203,7 +202,6 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual.Equals(""abc""), Is.True, ""Assertion message"");");
 
-
             var fixedCode = TestUtility.WrapInTestMethod(@"
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""), ""Assertion message"");");
@@ -218,7 +216,6 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.True(actual.Equals(""abc""), ""Assertion message"");");
 
-
             var fixedCode = TestUtility.WrapInTestMethod(@"
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""), ""Assertion message"");");
@@ -232,7 +229,6 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var code = TestUtility.WrapInTestMethod(@"
                 var actual = ""abc"";
                 Assert.False(actual.Equals(""bcd""), ""Assertion message"");");
-
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
                 var actual = ""abc"";

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
@@ -25,6 +25,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
+
         [Test]
         public void AnalyzeWhenListContainsUsed_AssertIsTrue()
         {
@@ -54,6 +55,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
+
         [Test]
         public void AnalyzeWhenLinqContainsUsed_AssertIsTrue()
         {
@@ -63,6 +65,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
+
         [Test]
         public void AnalyzeWhenLinqContainsUsed_AssertIsFalse()
         {

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
@@ -32,6 +32,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
+
         [Test]
         public void AnalyzeWhenListContainsUsed_AssertIsTrue()
         {
@@ -73,6 +74,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
+
         [Test]
         public void AnalyzeWhenLinqContainsUsed_AssertIsTrue()
         {
@@ -86,6 +88,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
+
         [Test]
         public void AnalyzeWhenLinqContainsUsed_AssertIsFalse()
         {

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -10,16 +10,18 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
     {
         private static readonly DiagnosticAnalyzer analyzer = new StringConstraintUsageAnalyzer();
 
-        private static readonly object[] PositiveAssertData = new[] {
-            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain" },
-            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith" },
-            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith" }
+        private static readonly object[] PositiveAssertData = new[]
+        {
+            new[] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain" },
+            new[] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith" },
+            new[] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith" }
         };
 
-        private static readonly object[] NegativeAssertData = new[] {
-            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain" },
-            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith" },
-            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith" }
+        private static readonly object[] NegativeAssertData = new[]
+        {
+            new[] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain" },
+            new[] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith" },
+            new[] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith" }
         };
 
         [TestCaseSource(nameof(PositiveAssertData))]

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -12,16 +12,18 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         private static readonly DiagnosticAnalyzer analyzer = new StringConstraintUsageAnalyzer();
         private static readonly CodeFixProvider fix = new StringConstraintUsageCodeFix();
 
-        private static readonly object[] PositiveAssertData = new[] {
-            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain" },
-            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith" },
-            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith" }
+        private static readonly object[] PositiveAssertData = new[]
+        {
+            new[] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Contain" },
+            new[] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.StartWith" },
+            new[] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.EndWith" }
         };
 
-        private static readonly object[] NegativeAssertData = new[] {
-            new [] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain" },
-            new [] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith" },
-            new [] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith" }
+        private static readonly object[] NegativeAssertData = new[]
+        {
+            new[] { nameof(string.Contains), AnalyzerIdentifiers.StringContainsConstraintUsage, "Does.Not.Contain" },
+            new[] { nameof(string.StartsWith), AnalyzerIdentifiers.StringStartsWithConstraintUsage, "Does.Not.StartWith" },
+            new[] { nameof(string.EndsWith), AnalyzerIdentifiers.StringEndsWithConstraintUsage, "Does.Not.EndWith" }
         };
 
         [TestCaseSource(nameof(PositiveAssertData))]

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -152,10 +152,9 @@ namespace NUnit.Analyzers.Tests
                                                  .OrderBy(x => x.Id);
             foreach (var descriptor in descriptors)
             {
-                var enabledEmoji  = descriptor.IsEnabledByDefault ? ":white_check_mark:" : ":x:";
+                var enabledEmoji = descriptor.IsEnabledByDefault ? ":white_check_mark:" : ":x:";
                 builder.Append($"| [{descriptor.Id}]({descriptor.HelpLinkUri})")
-                       .AppendLine($"| {descriptor.Title.EscapeTags()} | {enabledEmoji} |");
-
+                       .AppendLine($"| {EscapeTags(descriptor.Title)} | {enabledEmoji} |");
             }
 
             var expected = builder.ToString();
@@ -202,6 +201,9 @@ namespace NUnit.Analyzers.Tests
             Console.WriteLine();
         }
 
+        private static string EscapeTags(LocalizableString str)
+            => str.ToString(CultureInfo.InvariantCulture).Replace("<", @"\<");
+
         public class DescriptorInfo
         {
             private DescriptorInfo(DiagnosticAnalyzer analyzer, DiagnosticDescriptor descriptor)
@@ -245,7 +247,7 @@ namespace NUnit.Analyzers.Tests
                 var text = builder.ToString();
                 var stub = $@"# {descriptor.Id}
 
-## {descriptor.Title.EscapeTags()}
+## {EscapeTags(descriptor.Title)}
 
 | Topic    | Value
 | :--      | :--
@@ -257,7 +259,7 @@ namespace NUnit.Analyzers.Tests
 
 ## Description
 
-{descriptor.Description.EscapeTags()}
+{EscapeTags(descriptor.Description)}
 
 ## Motivation
 
@@ -326,7 +328,7 @@ Or put this at the top of the file to disable all instances.
 
         public class CodeFile
         {
-            private const string repoOnMaster = "https://github.com/nunit/nunit.analyzers/blob/master";
+            private const string RepoOnMaster = "https://github.com/nunit/nunit.analyzers/blob/master";
 
             private static readonly ConcurrentDictionary<Type, CodeFile> cache =
                 new ConcurrentDictionary<Type, CodeFile>();
@@ -338,7 +340,7 @@ Or put this at the top of the file to disable all instances.
 
             public string Name { get; }
 
-            public string Uri => repoOnMaster + this.Name.Substring(RepositoryDirectory.FullName.Length).Replace("\\", "/");
+            public string Uri => RepoOnMaster + this.Name.Substring(RepositoryDirectory.FullName.Length).Replace("\\", "/");
 
             public static CodeFile Find(Type type)
             {
@@ -357,11 +359,5 @@ Or put this at the top of the file to disable all instances.
                 return new CodeFile(fileName);
             }
         }
-    }
-
-    public static class LocalizableStringExtensions
-    {
-        public static string EscapeTags(this LocalizableString @this)
-            => @this.ToString(CultureInfo.InvariantCulture).Replace("<", @"\<");
     }
 }

--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -12,7 +12,8 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.EqualToIncompatibleTypes);
 
-        private static readonly string[] NumericTypes = new[] {
+        private static readonly string[] NumericTypes = new[]
+        {
             "decimal", "double", "float", "int", "uint", "long", "ulong", "short", "ushort"
         };
 
@@ -36,7 +37,6 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
 
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
-
 
         [Test]
         public void AnalyzeWhenDictionariesWithIncompatibleValueTypesProvided()
@@ -485,7 +485,6 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
 
             AnalyzerAssert.Valid(analyzer, testCode);
         }
-
 
         [Test]
         public void NoDiagnosticForStreams()

--- a/src/nunit.analyzers.tests/Extensions/AttributeArgumentSyntaxExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/AttributeArgumentSyntaxExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.Analyzers.Tests.Extensions
     [TestFixture]
     public sealed class AttributeArgumentSyntaxExtensionsTests
     {
-        static IEnumerable<TestCaseData> GetTestData()
+        private static IEnumerable<TestCaseData> GetTestData()
         {
             yield return new TestCaseData("null", "object", "object", Is.True).
                 SetName("CanAssignToWhenArgumentIsNullAndTargetIsReferenceType");
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
             Assert.That(values.Syntax.CanAssignTo(values.TypeSymbol, values.Model), expectedResult);
         }
 
-        private async static Task<(AttributeArgumentSyntax Syntax, ITypeSymbol TypeSymbol, SemanticModel Model)> GetAttributeSyntaxAsync(string code)
+        private static async Task<(AttributeArgumentSyntax Syntax, ITypeSymbol TypeSymbol, SemanticModel Model)> GetAttributeSyntaxAsync(string code)
         {
             var rootAndModel = await TestHelpers.GetRootAndModel(code);
 

--- a/src/nunit.analyzers.tests/Extensions/AttributeSyntaxExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/AttributeSyntaxExtensionsTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
             Assert.That(namedArguments.Length, Is.EqualTo(0), nameof(namedArguments));
         }
 
-        private async static Task<AttributeSyntax> GetAttributeSyntaxAsync(string code, string typeName)
+        private static async Task<AttributeSyntax> GetAttributeSyntaxAsync(string code, string typeName)
         {
             var rootAndModel = await TestHelpers.GetRootAndModel(code);
 

--- a/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
@@ -121,7 +121,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
                 {
                     "IsAssignableFromWhenOtherIsNotASubclassA",
                     "IsAssignableFromWhenOtherIsNotASubclassB"
-              });
+                });
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.False);
         }

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
@@ -13,6 +13,26 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.NonTestMethodIsPublic);
 
+        private static IEnumerable<string> TestMethodRelatedAttributes => new string[]
+        {
+            "Test",
+            "OneTimeSetUp",
+            "OneTimeTearDown",
+            "SetUp",
+            "TearDown"
+        };
+
+        private static IEnumerable<string> NonPrivateModifiers => new string[]
+        {
+            "public",
+            "internal",
+            "protected internal",
+
+            "static public",
+            "static internal",
+            "static protected internal",
+        };
+
         [Test]
         public void AnalyzeWhenNonTestClassHasPublicMethod()
         {
@@ -61,25 +81,5 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         {modifiers} void ↓AssertMethod() {{ }}");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
-
-        private static IEnumerable<string> TestMethodRelatedAttributes => new string[]
-        {
-            "Test",
-            "OneTimeSetUp",
-            "OneTimeTearDown",
-            "SetUp",
-            "TearDown"
-        };
-
-        private static IEnumerable<string> NonPrivateModifiers => new string[]
-        {
-            "public",
-            "internal",
-            "protected internal",
-
-            "static public",
-            "static internal",
-            "static protected internal",
-        };
     }
 }

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
@@ -14,6 +14,16 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.NonTestMethodIsPublic);
 
+        private static readonly object[] NonPrivateModifiers =
+        {
+            new object[] { "public", "private" },
+            new object[] { "internal", "private" },
+            new object[] { "protected internal", "protected" },
+            new object[] { "static public", "static private" },
+            new object[] { "static internal", "static private" },
+            new object[] { "static protected internal", "static protected" },
+        };
+
         [TestCaseSource(nameof(NonPrivateModifiers))]
         public void FixesPublicAccessModifiers(string modifiers, string modifiersAfter)
         {
@@ -29,15 +39,5 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
-
-        private static readonly object[] NonPrivateModifiers =
-        {
-            new object[] { "public", "private" },
-            new object[] { "internal", "private" },
-            new object[] { "protected internal", "protected" },
-            new object[] { "static public", "static private" },
-            new object[] { "static internal", "static private" },
-            new object[] { "static protected internal", "static protected" },
-        };
     }
 }

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
@@ -30,14 +30,14 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
 
-        static readonly object[] NonPrivateModifiers =
+        private static readonly object[] NonPrivateModifiers =
         {
-            new object [] { "public", "private" },
-            new object [] { "internal", "private" },
-            new object [] { "protected internal", "protected" },
-            new object [] { "static public", "static private" },
-            new object [] { "static internal", "static private" },
-            new object [] { "static protected internal", "static protected" },
+            new object[] { "public", "private" },
+            new object[] { "internal", "private" },
+            new object[] { "protected internal", "protected" },
+            new object[] { "static public", "static private" },
+            new object[] { "static internal", "static private" },
+            new object[] { "static protected internal", "static protected" },
         };
     }
 }

--- a/src/nunit.analyzers.tests/Operations/ConstraintExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Operations/ConstraintExpressionTests.cs
@@ -57,10 +57,14 @@ namespace NUnit.Analyzers.Tests.Operations
                 "Is.Not.Empty & Is.EqualTo(new [] { \"1\" }).IgnoreCase.Or.EquivalentTo(new[] { \"1\", \"2\" })");
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
-            Assert.That(constraintParts, Is.EqualTo(new[]
+
+            var expectedParts = new[]
             {
-                "Is.Not.Empty", "Is.EqualTo(new [] { \"1\" }).IgnoreCase", "EquivalentTo(new[] { \"1\", \"2\" })"
-            }));
+                "Is.Not.Empty",
+                "Is.EqualTo(new [] { \"1\" }).IgnoreCase",
+                "EquivalentTo(new[] { \"1\", \"2\" })"
+            };
+            Assert.That(constraintParts, Is.EqualTo(expectedParts));
         }
 
         [Test]
@@ -70,10 +74,9 @@ namespace NUnit.Analyzers.Tests.Operations
                 "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")");
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
-            Assert.That(constraintParts, Is.EqualTo(new[]
-            {
-                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")"
-            }));
+
+            Assert.That(constraintParts, Is.EqualTo(
+                new[] { "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")" }));
         }
 
         private static async Task<ConstraintExpression> CreateConstraintExpression(string expressionString)

--- a/src/nunit.analyzers.tests/Operations/ConstraintExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Operations/ConstraintExpressionTests.cs
@@ -57,8 +57,10 @@ namespace NUnit.Analyzers.Tests.Operations
                 "Is.Not.Empty & Is.EqualTo(new [] { \"1\" }).IgnoreCase.Or.EquivalentTo(new[] { \"1\", \"2\" })");
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
-            Assert.That(constraintParts, Is.EqualTo(new[] {
-                "Is.Not.Empty", "Is.EqualTo(new [] { \"1\" }).IgnoreCase", "EquivalentTo(new[] { \"1\", \"2\" })" }));
+            Assert.That(constraintParts, Is.EqualTo(new[]
+            {
+                "Is.Not.Empty", "Is.EqualTo(new [] { \"1\" }).IgnoreCase", "EquivalentTo(new[] { \"1\", \"2\" })"
+            }));
         }
 
         [Test]
@@ -68,8 +70,10 @@ namespace NUnit.Analyzers.Tests.Operations
                 "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")");
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
-            Assert.That(constraintParts, Is.EqualTo(new[] {
-                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")" }));
+            Assert.That(constraintParts, Is.EqualTo(new[]
+            {
+                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")"
+            }));
         }
 
         private static async Task<ConstraintExpression> CreateConstraintExpression(string expressionString)

--- a/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
@@ -15,6 +15,9 @@ namespace NUnit.Analyzers.Tests.ParallelizableUsage
     {
         private readonly DiagnosticAnalyzer analyzer = new ParallelizableUsageAnalyzer();
 
+        private static IEnumerable<ParallelScope> ParallelScopesExceptFixtures =>
+            new ParallelScope[] { ParallelScope.All, ParallelScope.Children, ParallelScope.Self };
+
         [Test]
         public void VerifySupportedDiagnostics()
         {
@@ -236,8 +239,5 @@ using NUnit.Framework;
     }");
             AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
-
-        private static IEnumerable<ParallelScope> ParallelScopesExceptFixtures =>
-            new ParallelScope[] { ParallelScope.All, ParallelScope.Children, ParallelScope.Self };
     }
 }

--- a/src/nunit.analyzers.tests/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -13,7 +12,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.StringConstraintWrongActualType);
 
-        public static readonly string[] StringConstraints = new[]
+        private static readonly string[] StringConstraints = new[]
         {
             "Does.StartWith(\"12\")",
             "Does.EndWith(\"34\")",

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
@@ -13,6 +13,61 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestMethodIsNotPublic);
 
+        private static IEnumerable<string> SetUpTearDownMethodRelatedAttributes => new string[]
+        {
+            "OneTimeSetUp",
+            "OneTimeTearDown",
+            "SetUp",
+            "TearDown"
+        };
+
+        private static IEnumerable<string> NonPublicModifiers => new string[]
+        {
+            "",
+            "private",
+            "protected",
+            "internal",
+            "protected internal",
+            "private protected",
+
+            "static private",
+            "static protected",
+            "static internal",
+            "static protected internal",
+            "static private protected",
+
+            "private static",
+            "protected static",
+            "internal static",
+            "protected internal static",
+            "private protected static ",
+
+            "protected static internal",
+            "private static protected",
+        };
+
+        private static IEnumerable<string> NonPublicOrFamilyModifiers => new string[]
+        {
+            "",
+            "private",
+            "internal",
+            "protected internal",
+            "private protected",
+
+            "static private",
+            "static internal",
+            "static protected internal",
+            "static private protected",
+
+            "private static",
+            "internal static",
+            "protected internal static",
+            "private protected static ",
+
+            "protected static internal",
+            "private static protected",
+        };
+
         [TestCaseSource(nameof(SetUpTearDownMethodRelatedAttributes))]
         public void AnalyzeWhenSetUpTearDownMethodIsPublic(string attribute)
         {
@@ -93,60 +148,5 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         {modifiers} async Task ↓TestMethod(int i) {{ }}");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
-
-        private static IEnumerable<string> SetUpTearDownMethodRelatedAttributes => new string[]
-        {
-            "OneTimeSetUp",
-            "OneTimeTearDown",
-            "SetUp",
-            "TearDown"
-        };
-
-        private static IEnumerable<string> NonPublicModifiers => new string[]
-        {
-            "",
-            "private",
-            "protected",
-            "internal",
-            "protected internal",
-            "private protected",
-
-            "static private",
-            "static protected",
-            "static internal",
-            "static protected internal",
-            "static private protected",
-
-            "private static",
-            "protected static",
-            "internal static",
-            "protected internal static",
-            "private protected static ",
-
-            "protected static internal",
-            "private static protected",
-        };
-
-        private static IEnumerable<string> NonPublicOrFamilyModifiers => new string[]
-        {
-            "",
-            "private",
-            "internal",
-            "protected internal",
-            "private protected",
-
-            "static private",
-            "static internal",
-            "static protected internal",
-            "static private protected",
-
-            "private static",
-            "internal static",
-            "protected internal static",
-            "private protected static ",
-
-            "protected static internal",
-            "private static protected",
-        };
     }
 }

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
@@ -102,7 +102,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             "TearDown"
         };
 
-        static IEnumerable<string> NonPublicModifiers => new string[]
+        private static IEnumerable<string> NonPublicModifiers => new string[]
         {
             "",
             "private",
@@ -127,7 +127,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             "private static protected",
         };
 
-        static IEnumerable<string> NonPublicOrFamilyModifiers => new string[]
+        private static IEnumerable<string> NonPublicOrFamilyModifiers => new string[]
         {
             "",
             "private",

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
@@ -15,6 +15,30 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestMethodIsNotPublic);
 
+        private static readonly object[] NonPublicModifiers =
+        {
+            new object[] { "private", "public" },
+            new object[] { "protected", "public" },
+            new object[] { "internal", "public" },
+            new object[] { "protected internal", "public" },
+            new object[] { "private protected", "public" },
+
+            new object[] { "static private", "static public" },
+            new object[] { "static protected", "static public" },
+            new object[] { "static internal", "static public" },
+            new object[] { "static protected internal", "static public" },
+            new object[] { "static private protected", "static public" },
+
+            new object[] { "private static", "public static" },
+            new object[] { "protected static", "public static" },
+            new object[] { "internal static", "public static" },
+            new object[] { "protected internal static", "public static" },
+            new object[] { "private protected static", "public static" },
+
+            new object[] { "protected static internal", "public static" },
+            new object[] { "private static protected", "public static" },
+        };
+
         [TestCaseSource(nameof(NonPublicModifiers))]
         public void FixesNonPublicAccessModifiers(string modifiers, string modifiersAfter)
         {
@@ -70,29 +94,5 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
-
-        private static readonly object[] NonPublicModifiers =
-        {
-            new object[] { "private", "public" },
-            new object[] { "protected", "public" },
-            new object[] { "internal", "public" },
-            new object[] { "protected internal", "public" },
-            new object[] { "private protected", "public" },
-
-            new object[] { "static private", "static public" },
-            new object[] { "static protected", "static public" },
-            new object[] { "static internal", "static public" },
-            new object[] { "static protected internal", "static public" },
-            new object[] { "static private protected", "static public" },
-
-            new object[] { "private static", "public static" },
-            new object[] { "protected static", "public static" },
-            new object[] { "internal static", "public static" },
-            new object[] { "protected internal static", "public static" },
-            new object[] { "private protected static", "public static" },
-
-            new object[] { "protected static internal", "public static" },
-            new object[] { "private static protected", "public static" },
-        };
     }
 }

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
@@ -71,28 +71,28 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
 
-        static readonly object[] NonPublicModifiers =
+        private static readonly object[] NonPublicModifiers =
         {
-            new object [] { "private", "public" },
-            new object [] { "protected", "public" },
-            new object [] { "internal", "public" },
-            new object [] { "protected internal", "public" },
-            new object [] { "private protected", "public" },
+            new object[] { "private", "public" },
+            new object[] { "protected", "public" },
+            new object[] { "internal", "public" },
+            new object[] { "protected internal", "public" },
+            new object[] { "private protected", "public" },
 
-            new object [] { "static private", "static public" },
-            new object [] { "static protected", "static public" },
-            new object [] { "static internal", "static public" },
-            new object [] { "static protected internal", "static public" },
-            new object [] { "static private protected", "static public" },
+            new object[] { "static private", "static public" },
+            new object[] { "static protected", "static public" },
+            new object[] { "static internal", "static public" },
+            new object[] { "static protected internal", "static public" },
+            new object[] { "static private protected", "static public" },
 
-            new object [] { "private static", "public static" },
-            new object [] { "protected static", "public static" },
-            new object [] { "internal static", "public static" },
-            new object [] { "protected internal static", "public static" },
-            new object [] { "private protected static", "public static" },
+            new object[] { "private static", "public static" },
+            new object[] { "protected static", "public static" },
+            new object[] { "internal static", "public static" },
+            new object[] { "protected internal static", "public static" },
+            new object[] { "private protected static", "public static" },
 
-            new object [] { "protected static internal", "public static" },
-            new object [] { "private static protected", "public static" },
+            new object[] { "protected static internal", "public static" },
+            new object[] { "private static protected", "public static" },
         };
     }
 }

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -16,6 +16,17 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
     {
         private static readonly DiagnosticAnalyzer analyzer = new TestMethodUsageAnalyzer();
 
+        private static IEnumerable<TestCaseData> SpecialConversions
+        {
+            get
+            {
+                yield return new TestCaseData("2019-10-10", typeof(DateTime));
+                yield return new TestCaseData("23:59:59", typeof(TimeSpan));
+                yield return new TestCaseData("2019-10-10", typeof(DateTimeOffset));
+                yield return new TestCaseData("2019-10-14T19:15:25+00:00", typeof(DateTimeOffset));
+            }
+        }
+
         [Test]
         public void VerifySupportedDiagnostics()
         {
@@ -50,17 +61,6 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
                 $"{TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage} is missing.");
             Assert.That(diagnosticMessage, Contains.Item(TestMethodUsageAnalyzerConstants.SpecifiedExpectedResultForVoidMethodMessage),
                 $"{TestMethodUsageAnalyzerConstants.SpecifiedExpectedResultForVoidMethodMessage} is missing.");
-        }
-
-        private static IEnumerable<TestCaseData> SpecialConversions
-        {
-            get
-            {
-                yield return new TestCaseData("2019-10-10", typeof(DateTime));
-                yield return new TestCaseData("23:59:59", typeof(TimeSpan));
-                yield return new TestCaseData("2019-10-10", typeof(DateTimeOffset));
-                yield return new TestCaseData("2019-10-14T19:15:25+00:00", typeof(DateTimeOffset));
-            }
         }
 
         [TestCaseSource(nameof(SpecialConversions))]

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -52,7 +52,6 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
                 $"{TestMethodUsageAnalyzerConstants.SpecifiedExpectedResultForVoidMethodMessage} is missing.");
         }
 
-
         private static IEnumerable<TestCaseData> SpecialConversions
         {
             get

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\nunit.analyzers\nunit.analyzers.csproj" />
   </ItemGroup>
@@ -27,5 +27,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
 </Project>

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\nunit.analyzers\nunit.analyzers.csproj" />
   </ItemGroup>

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="NUnit" Version="3.12" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.205">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/nunit.analyzers/BaseAssertionAnalyzer.cs
+++ b/src/nunit.analyzers/BaseAssertionAnalyzer.cs
@@ -13,6 +13,8 @@ namespace NUnit.Analyzers
             context.RegisterOperationAction(this.AnalyzeInvocation, OperationKind.Invocation);
         }
 
+        protected abstract void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation);
+
         private void AnalyzeInvocation(OperationAnalysisContext context)
         {
             if (!(context.Operation is IInvocationOperation invocationOperation))
@@ -27,7 +29,5 @@ namespace NUnit.Analyzers
 
             this.AnalyzeAssertInvocation(context, invocationOperation);
         }
-
-        protected abstract void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation);
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -253,10 +253,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             return new Dictionary<string, string>
             {
                 { AnalyzerPropertyKeys.ModelName, invocationSymbol.Name },
-                { AnalyzerPropertyKeys.HasToleranceValue,
+                {
+                    AnalyzerPropertyKeys.HasToleranceValue,
                     (invocationSymbol.Name == NameOfAssertAreEqual &&
                         invocationSymbol.Parameters.Length >= 3 &&
-                        invocationSymbol.Parameters[2].Type.SpecialType == SpecialType.System_Double).ToString() },
+                        invocationSymbol.Parameters[2].Type.SpecialType == SpecialType.System_Double).ToString()
+                },
                 { AnalyzerPropertyKeys.IsGenericMethod, invocationSymbol.IsGenericMethod.ToString() },
             }.ToImmutableDictionary();
         }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -15,12 +15,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     public abstract class ClassicModelAssertUsageCodeFix
         : CodeFixProvider
     {
+        protected virtual string Title => CodeFixConstants.TransformToConstraintModelDescription;
+
         public sealed override FixAllProvider GetFixAllProvider()
         {
             return WellKnownFixAllProviders.BatchFixer;
         }
-
-        protected virtual string Title => CodeFixConstants.TransformToConstraintModelDescription;
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -22,16 +22,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 
         protected virtual string Title => CodeFixConstants.TransformToConstraintModelDescription;
 
-        protected virtual void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments, TypeArgumentListSyntax typeArguments)
-        {
-            throw new InvalidOperationException($"Class must override {nameof(UpdateArguments)} accepting {nameof(TypeArgumentListSyntax)}");
-        }
-
-        protected virtual void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
-        {
-            throw new InvalidOperationException($"Class must override {nameof(UpdateArguments)}");
-        }
-
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -131,6 +121,16 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                     this.Title,
                     _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
                     this.Title), diagnostic);
+        }
+
+        protected virtual void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments, TypeArgumentListSyntax typeArguments)
+        {
+            throw new InvalidOperationException($"Class must override {nameof(UpdateArguments)} accepting {nameof(TypeArgumentListSyntax)}");
+        }
+
+        protected virtual void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        {
+            throw new InvalidOperationException($"Class must override {nameof(UpdateArguments)}");
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
@@ -13,11 +13,11 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     public sealed class IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix
         : ClassicModelAssertUsageCodeFix
     {
+        public const string Suffix = " (condensed)";
+
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             AnalyzerIdentifiers.IsTrueUsage,
             AnalyzerIdentifiers.TrueUsage);
-
-        public const string Suffix = " (condensed)";
 
         protected override string Title => base.Title + Suffix;
 

--- a/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
+++ b/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
@@ -14,6 +14,12 @@ namespace NUnit.Analyzers.ComparableTypes
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class ComparableTypesAnalyzer : BaseAssertionAnalyzer
     {
+        private static readonly ImmutableHashSet<string> SupportedConstraints = ImmutableHashSet.Create(
+            NunitFrameworkConstants.NameOfIsLessThan,
+            NunitFrameworkConstants.NameOfIsLessThanOrEqualTo,
+            NunitFrameworkConstants.NameOfIsGreaterThan,
+            NunitFrameworkConstants.NameOfIsGreaterThanOrEqualTo);
+
         private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.ComparableTypes,
             title: ComparableTypesConstants.Title,
@@ -23,12 +29,6 @@ namespace NUnit.Analyzers.ComparableTypes
             description: ComparableTypesConstants.Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
-
-        private static readonly ImmutableHashSet<string> SupportedConstraints = ImmutableHashSet.Create(
-            NunitFrameworkConstants.NameOfIsLessThan,
-            NunitFrameworkConstants.NameOfIsLessThanOrEqualTo,
-            NunitFrameworkConstants.NameOfIsGreaterThan,
-            NunitFrameworkConstants.NameOfIsGreaterThanOrEqualTo);
 
         protected override void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation)
         {

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageCodeFix.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageCodeFix.cs
@@ -16,14 +16,16 @@ namespace NUnit.Analyzers.ConstActualValueUsage
     [Shared]
     public class ConstActualValueUsageCodeFix : CodeFixProvider
     {
-        private static readonly string[] SupportedClassicAsserts = new[] {
+        private static readonly string[] SupportedClassicAsserts = new[]
+        {
             NunitFrameworkConstants.NameOfAssertAreEqual,
             NunitFrameworkConstants.NameOfAssertAreNotEqual,
             NunitFrameworkConstants.NameOfAssertAreSame,
             NunitFrameworkConstants.NameOfAssertAreNotSame
         };
 
-        private static readonly string[] SupportedIsConstraints = new[] {
+        private static readonly string[] SupportedIsConstraints = new[]
+        {
             NunitFrameworkConstants.NameOfIsEqualTo,
             NunitFrameworkConstants.NameOfIsSameAs,
             NunitFrameworkConstants.NameOfIsSamePath

--- a/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class AnalyzerPropertyKeys
     {
-        internal static readonly string HasToleranceValue = nameof(AnalyzerPropertyKeys.HasToleranceValue);
-        internal static readonly string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
-        internal static readonly string IsGenericMethod = nameof(AnalyzerPropertyKeys.IsGenericMethod);
+        internal const string HasToleranceValue = nameof(AnalyzerPropertyKeys.HasToleranceValue);
+        internal const string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
+        internal const string IsGenericMethod = nameof(AnalyzerPropertyKeys.IsGenericMethod);
     }
 }

--- a/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class AnalyzerPropertyKeys
     {
-        internal static string HasToleranceValue = nameof(AnalyzerPropertyKeys.HasToleranceValue);
-        internal static string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
-        internal static string IsGenericMethod = nameof(AnalyzerPropertyKeys.IsGenericMethod);
+        internal static readonly string HasToleranceValue = nameof(AnalyzerPropertyKeys.HasToleranceValue);
+        internal static readonly string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
+        internal static readonly string IsGenericMethod = nameof(AnalyzerPropertyKeys.IsGenericMethod);
     }
 }

--- a/src/nunit.analyzers/Constants/ComparableTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/ComparableTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class ComparableTypesConstants
     {
-        internal static string Title = "Incompatible types for comparison constraint.";
-        internal static string Message = "The comparison constraint always fails as the actual and the expected value are not comparable.";
-        internal static string Description = "The comparison constraint always fails as the actual and the expected value are not comparable.";
+        internal const string Title = "Incompatible types for comparison constraint.";
+        internal const string Message = "The comparison constraint always fails as the actual and the expected value are not comparable.";
+        internal const string Description = "The comparison constraint always fails as the actual and the expected value are not comparable.";
     }
 }

--- a/src/nunit.analyzers/Constants/EqualToIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/EqualToIncompatibleTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class EqualToIncompatibleTypesConstants
     {
-        internal static string Title = "Incompatible types for EqualTo constraint.";
-        internal static string Message = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
-        internal static string Description = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
+        internal static readonly string Title = "Incompatible types for EqualTo constraint.";
+        internal static readonly string Message = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
+        internal static readonly string Description = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
     }
 }

--- a/src/nunit.analyzers/Constants/EqualToIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/EqualToIncompatibleTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class EqualToIncompatibleTypesConstants
     {
-        internal static readonly string Title = "Incompatible types for EqualTo constraint.";
-        internal static readonly string Message = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
-        internal static readonly string Description = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
+        internal static const string Title = "Incompatible types for EqualTo constraint.";
+        internal static const string Message = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
+        internal static const string Description = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
     }
 }

--- a/src/nunit.analyzers/Constants/EqualToIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/EqualToIncompatibleTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class EqualToIncompatibleTypesConstants
     {
-        internal static const string Title = "Incompatible types for EqualTo constraint.";
-        internal static const string Message = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
-        internal static const string Description = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
+        internal const string Title = "Incompatible types for EqualTo constraint.";
+        internal const string Message = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
+        internal const string Description = "The EqualTo constraint always fails as the actual and the expected value cannot be equal.";
     }
 }

--- a/src/nunit.analyzers/Constants/ParallelizableUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/ParallelizableUsageAnalyzerConstants.cs
@@ -1,6 +1,6 @@
 namespace NUnit.Analyzers.Constants
 {
-    class ParallelizableUsageAnalyzerConstants
+    internal class ParallelizableUsageAnalyzerConstants
     {
         internal const string ParallelScopeSelfNoEffectOnAssemblyTitle = "Specifying ParallelScope.Self on assembly level has no effect.";
         internal const string ParallelScopeSelfNoEffectOnAssemblyMessage = "Specifying ParallelScope.Self on assembly level has no effect.";

--- a/src/nunit.analyzers/Constants/SameAsIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SameAsIncompatibleTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers
 {
     internal class SameAsIncompatibleTypesConstants
     {
-        internal static string Title = "Incompatible types for SameAs constraint.";
-        internal static string Message = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
-        internal static string Description = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
+        internal static readonly string Title = "Incompatible types for SameAs constraint.";
+        internal static readonly string Message = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
+        internal static readonly string Description = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
     }
 }

--- a/src/nunit.analyzers/Constants/SameAsIncompatibleTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SameAsIncompatibleTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers
 {
     internal class SameAsIncompatibleTypesConstants
     {
-        internal static readonly string Title = "Incompatible types for SameAs constraint.";
-        internal static readonly string Message = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
-        internal static readonly string Description = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
+        internal const string Title = "Incompatible types for SameAs constraint.";
+        internal const string Message = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
+        internal const string Description = "The SameAs constraint always fails because the actual and expected values have mutually exclusive types.";
     }
 }

--- a/src/nunit.analyzers/Constants/SameAsOnValueTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SameAsOnValueTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class SameAsOnValueTypesConstants
     {
-        internal static string Title = "Non-reference types for SameAs constraint.";
-        internal static string Message = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
-        internal static string Description = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
+        internal static readonly string Title = "Non-reference types for SameAs constraint.";
+        internal static readonly string Message = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
+        internal static readonly string Description = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
     }
 }

--- a/src/nunit.analyzers/Constants/SameAsOnValueTypesConstants.cs
+++ b/src/nunit.analyzers/Constants/SameAsOnValueTypesConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class SameAsOnValueTypesConstants
     {
-        internal static readonly string Title = "Non-reference types for SameAs constraint.";
-        internal static readonly string Message = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
-        internal static readonly string Description = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
+        internal const string Title = "Non-reference types for SameAs constraint.";
+        internal const string Message = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
+        internal const string Description = "The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference.";
     }
 }

--- a/src/nunit.analyzers/Constants/SomeItemsConstraintUsageConstants.cs
+++ b/src/nunit.analyzers/Constants/SomeItemsConstraintUsageConstants.cs
@@ -1,4 +1,4 @@
-namespace NUnit.Analyzers.Constants
+﻿namespace NUnit.Analyzers.Constants
 {
     internal static class SomeItemsConstraintUsageConstants
     {

--- a/src/nunit.analyzers/Constants/TestMethodUsageAnalyzerConstants.cs
+++ b/src/nunit.analyzers/Constants/TestMethodUsageAnalyzerConstants.cs
@@ -9,7 +9,7 @@ namespace NUnit.Analyzers.Constants
 
         internal const string SpecifiedExpectedResultForVoidMethodTitle = "ExpectedResult must not be specified when the method returns void.";
         internal const string SpecifiedExpectedResultForVoidMethodMessage = "Don't specify ExpectedResult when the method returns void";
-        internal const string SpecifiedExpectedResultForVoidMethodDescription= "ExpectedResult must not be specified when the method returns void. This will lead to an error at run-time.";
+        internal const string SpecifiedExpectedResultForVoidMethodDescription = "ExpectedResult must not be specified when the method returns void. This will lead to an error at run-time.";
 
         internal const string NoExpectedResultButNonVoidReturnTypeTitle = "The method has non-void return type, but no result is expected in ExpectedResult.";
         internal const string NoExpectedResultButNonVoidReturnTypeMessage = "The method has non-void return type '{0}', but no result is expected in ExpectedResult.";

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
@@ -13,13 +13,15 @@ namespace NUnit.Analyzers.ConstraintUsage
     {
         internal const string SuggestedConstraintString = nameof(SuggestedConstraintString);
 
-        protected static readonly string[] SupportedPositiveAssertMethods = new[] {
+        protected static readonly string[] SupportedPositiveAssertMethods = new[]
+        {
             NameOfAssertThat,
             NameOfAssertTrue,
             NameOfAssertIsTrue
         };
 
-        protected static readonly string[] SupportedNegativeAssertMethods = new[] {
+        protected static readonly string[] SupportedNegativeAssertMethods = new[]
+        {
             NameOfAssertFalse,
             NameOfAssertIsFalse
         };

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -88,7 +88,8 @@ namespace NUnit.Analyzers.ConstraintUsage
                 ? assertNode.ArgumentList.Arguments.Skip(2)
                 : assertNode.ArgumentList.Arguments.Skip(1);
 
-            var newArguments = new[] {
+            var newArguments = new[]
+            {
                 SyntaxFactory.Argument(actual),
                 SyntaxFactory.Argument(constraintExpression)
             }.Union(remainingArguments);

--- a/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageCodeFix.cs
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.ConstraintUsage
                     }
 
                     // Equals(actual, expected)
-                    else if (invocation.Expression.IsKind(SyntaxKind.IdentifierName)
+                    if (invocation.Expression.IsKind(SyntaxKind.IdentifierName)
                         && arguments.Count == 2)
                     {
                         return (arguments[0].Expression, arguments[1].Expression);

--- a/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageCodeFix.cs
@@ -46,6 +46,7 @@ namespace NUnit.Analyzers.ConstraintUsage
                     {
                         return (memberAccess.Expression, arguments[0].Expression);
                     }
+
                     // Equals(actual, expected)
                     else if (invocation.Expression.IsKind(SyntaxKind.IdentifierName)
                         && arguments.Count == 2)

--- a/src/nunit.analyzers/ConstraintUsage/SomeItemsConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/SomeItemsConstraintUsageAnalyzer.cs
@@ -26,8 +26,8 @@ namespace NUnit.Analyzers.ConstraintUsage
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
-        protected override (DiagnosticDescriptor? descriptor, string? suggestedConstraint) GetDiagnosticData
-            (OperationAnalysisContext context, IOperation actual, bool negated)
+        protected override (DiagnosticDescriptor? descriptor, string? suggestedConstraint) GetDiagnosticData(
+            OperationAnalysisContext context, IOperation actual, bool negated)
         {
             if (actual is IInvocationOperation invocationOperation)
             {

--- a/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
@@ -38,9 +38,6 @@ namespace NUnit.Analyzers.ConstraintUsage
 
         #endregion Descriptors
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
-            = ImmutableArray.Create(containsDescriptor, startsWithDescriptor, endsWithDescriptor);
-
         private static readonly Dictionary<string, (string doesMethod, DiagnosticDescriptor descriptor)> SupportedMethods
             = new Dictionary<string, (string, DiagnosticDescriptor)>
             {
@@ -48,6 +45,9 @@ namespace NUnit.Analyzers.ConstraintUsage
                 [nameof(string.StartsWith)] = (NunitFrameworkConstants.NameOfDoesStartWith, startsWithDescriptor),
                 [nameof(string.EndsWith)] = (NunitFrameworkConstants.NameOfDoesEndWith, endsWithDescriptor)
             };
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(containsDescriptor, startsWithDescriptor, endsWithDescriptor);
 
         protected override (DiagnosticDescriptor? descriptor, string? suggestedConstraint) GetDiagnosticData(
             OperationAnalysisContext context, IOperation actual, bool negated)

--- a/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/StringConstraintUsageAnalyzer.cs
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.ConstraintUsage
             return (null, null);
         }
 
-        private static (DiagnosticDescriptor, string) GetDiagnosticData(string stringMethod, bool negated)
+        private static (DiagnosticDescriptor descriptor, string suggestedConstraint) GetDiagnosticData(string stringMethod, bool negated)
         {
             var (doesMethod, descriptor) = SupportedMethods[stringMethod];
 

--- a/src/nunit.analyzers/Extensions/AttributeArgumentSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentSyntaxExtensions.cs
@@ -56,8 +56,8 @@ namespace NUnit.Analyzers.Extensions
             bool allowImplicitConversion = false,
             bool allowEnumToUnderlyingTypeConversion = false)
         {
-            //See https://github.com/nunit/nunit/blob/f16d12d6fa9e5c879601ad57b4b24ec805c66054/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs#L396
-            //for the reasoning behind this implementation.
+            // See https://github.com/nunit/nunit/blob/f16d12d6fa9e5c879601ad57b4b24ec805c66054/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs#L396
+            // for the reasoning behind this implementation.
             Optional<object> possibleConstantValue = model.GetConstantValue(@this.Expression);
             object? argumentValue = null;
             if (possibleConstantValue.HasValue)

--- a/src/nunit.analyzers/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeSyntaxExtensions.cs
@@ -57,25 +57,6 @@ namespace NUnit.Analyzers.Extensions
             return DerivesFromInterface(semanticModel, @this, NunitFrameworkConstants.FullNameOfTypeIParameterDataSource);
         }
 
-        private static bool DerivesFromInterface(
-            SemanticModel semanticModel,
-            AttributeSyntax attributeSyntax,
-            string interfaceTypeFullName)
-        {
-            var interfaceType = semanticModel.Compilation.GetTypeByMetadataName(interfaceTypeFullName);
-
-            if (interfaceType == null)
-                return false;
-
-            var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type;
-
-            if (attributeType == null)
-                return false;
-
-            return attributeType.AllInterfaces.Any(i => i.Equals(interfaceType));
-
-        }
-
         internal static bool IsSetUpOrTearDownMethodAttribute(this AttributeSyntax attributeSyntax, SemanticModel semanticModel)
         {
             var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type;
@@ -99,6 +80,24 @@ namespace NUnit.Analyzers.Extensions
         {
             return attributeSyntax.DerivesFromITestBuilder(semanticModel) ||
                    attributeSyntax.DerivesFromISimpleTestBuilder(semanticModel);
+        }
+
+        private static bool DerivesFromInterface(
+            SemanticModel semanticModel,
+            AttributeSyntax attributeSyntax,
+            string interfaceTypeFullName)
+        {
+            var interfaceType = semanticModel.Compilation.GetTypeByMetadataName(interfaceTypeFullName);
+
+            if (interfaceType == null)
+                return false;
+
+            var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type;
+
+            if (attributeType == null)
+                return false;
+
+            return attributeType.AllInterfaces.Any(i => i.Equals(interfaceType));
         }
     }
 }

--- a/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
@@ -9,8 +9,10 @@ namespace NUnit.Analyzers.Extensions
         /// <summary>
         /// Returns argument expression by parameter name.
         /// </summary>
-        public static ExpressionSyntax? GetArgumentExpression(this InvocationExpressionSyntax invocationSyntax,
-            IMethodSymbol methodSymbol, string parameterName)
+        public static ExpressionSyntax? GetArgumentExpression(
+            this InvocationExpressionSyntax invocationSyntax,
+            IMethodSymbol methodSymbol,
+            string parameterName)
         {
             var arguments = invocationSyntax.ArgumentList.Arguments;
 

--- a/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -11,7 +11,7 @@ namespace NUnit.Analyzers.Extensions
         /// <param name="this">The <see cref="IMethodSymbol"/> reference to get parameters from.</param>
         /// <returns>
         /// The first count is the required parameters, the second is the optional count,
-        /// and the last is the <c>params</c> count.
+        /// and the last is the <see langword="params" /> count.
         /// </returns>
         internal static (uint requiredParameters, uint optionalParameters, uint paramsCount) GetParameterCounts(
             this IMethodSymbol @this)

--- a/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -10,8 +10,8 @@ namespace NUnit.Analyzers.Extensions
         /// </summary>
         /// <param name="this">The <see cref="IMethodSymbol"/> reference to get parameters from.</param>
         /// <returns>
-        /// The first count is the required parameters, the second is the optional count, 
-        /// and the last is the <code>params</code> count.
+        /// The first count is the required parameters, the second is the optional count,
+        /// and the last is the. <code>params</code> count.
         /// </returns>
         internal static (uint requiredParameters, uint optionalParameters, uint paramsCount) GetParameterCounts(
             this IMethodSymbol @this)
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Extensions
         }
 
         /// <summary>
-        /// Returns true if method is implementation of method in interface
+        /// Returns true if method is implementation of method in interface.
         /// </summary>
         internal static bool IsInterfaceImplementation(this IMethodSymbol @this, string interfaceFullName)
         {

--- a/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -11,7 +11,7 @@ namespace NUnit.Analyzers.Extensions
         /// <param name="this">The <see cref="IMethodSymbol"/> reference to get parameters from.</param>
         /// <returns>
         /// The first count is the required parameters, the second is the optional count,
-        /// and the last is the. <code>params</code> count.
+        /// and the last is the <c>params</c> count.
         /// </returns>
         internal static (uint requiredParameters, uint optionalParameters, uint paramsCount) GetParameterCounts(
             this IMethodSymbol @this)

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -22,7 +22,7 @@ namespace NUnit.Analyzers.Extensions
         internal static bool IsAssert(this ITypeSymbol @this)
         {
             return @this != null &&
-                NunitFrameworkConstants.NUnitFrameworkAssemblyName == @this.ContainingAssembly.Name &&
+                @this.ContainingAssembly.Name == NunitFrameworkConstants.NUnitFrameworkAssemblyName &&
                 @this.Name == NunitFrameworkConstants.NameOfAssert;
         }
 
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Extensions
         {
             return @this != null && @this.GetAllBaseTypes()
                 .Any(t => t.Name == NunitFrameworkConstants.NameOfConstraint
-                    && NunitFrameworkConstants.NUnitFrameworkAssemblyName == @this.ContainingAssembly.Name);
+                    && @this.ContainingAssembly.Name == NunitFrameworkConstants.NUnitFrameworkAssemblyName);
         }
 
         internal static string GetFullMetadataName(this ITypeSymbol @this)
@@ -142,7 +142,7 @@ namespace NUnit.Analyzers.Extensions
         /// Return value indicates whether type implements IEnumerable interface.
         /// </summary>
         /// <param name="elementType">Contains IEnumerable generic argument, or null, if type implements
-        /// only non-generic IEnumerable interface, or no IEnumerable interface at all</param>
+        /// only non-generic IEnumerable interface, or no IEnumerable interface at all.</param>
         internal static bool IsIEnumerable(this ITypeSymbol @this, out ITypeSymbol? elementType)
         {
             elementType = null;

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -10,7 +10,7 @@ namespace NUnit.Analyzers.Helpers
     internal static class AssertHelper
     {
         /// <summary>
-        /// Get provided 'actual' and 'expression' arguments to Assert.That method
+        /// Get provided 'actual' and 'expression' arguments to Assert.That method.
         /// </summary>
         /// <returns>
         /// True, if arguments found. Otherwise - false.

--- a/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
+++ b/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
@@ -11,7 +11,7 @@ namespace NUnit.Analyzers.Helpers
     {
         /// <summary>
         /// Returns true if it is possible that <see cref="NUnit.Framework.Constraints.NUnitEqualityComparer.AreEqual"/>
-        /// returns true for given argument types. 
+        /// returns true for given argument types.
         /// False otherwise.
         /// </summary>
         public static bool CanBeEqual(
@@ -58,7 +58,6 @@ namespace NUnit.Analyzers.Helpers
 
             var actualFullName = actualType.GetFullMetadataName();
             var expectedFullName = expectedType.GetFullMetadataName();
-
 
             if (actualType is INamedTypeSymbol namedActualType
                 && expectedType is INamedTypeSymbol namedExpectedType)

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -45,7 +45,7 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
                     continue;
 
                 // e.g. Is.EqualTo(expected).IgnoreCase
-                // Need to check type of expected 
+                // Need to check type of expected
 
                 var ignoreCaseSuffix = constraintPart.GetSuffix(NunitFrameworkConstants.NameOfIgnoreCase) as IPropertyReferenceOperation;
 

--- a/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
+++ b/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
@@ -40,7 +40,7 @@ namespace NUnit.Analyzers.MissingProperty
 
             foreach (var constraintPart in constraintExpression.ConstraintParts)
             {
-                // Only 'Has' allowed (or none) - e.g. 'Throws' leads to verification on exception, which is not supported here. 
+                // Only 'Has' allowed (or none) - e.g. 'Throws' leads to verification on exception, which is not supported here.
                 var helperClassName = constraintPart.HelperClass?.Name;
                 if (helperClassName != null && helperClassName != NunitFrameworkConstants.NameOfHas)
                 {

--- a/src/nunit.analyzers/Operations/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpression.cs
@@ -15,6 +15,11 @@ namespace NUnit.Analyzers.Operations
         private readonly IOperation expressionOperation;
         private ConstraintExpressionPart[]? constraintParts;
 
+        public ConstraintExpression(IOperation expressionOperation)
+        {
+            this.expressionOperation = expressionOperation;
+        }
+
         public ConstraintExpressionPart[] ConstraintParts
         {
             get
@@ -28,11 +33,6 @@ namespace NUnit.Analyzers.Operations
 
                 return this.constraintParts;
             }
-        }
-
-        public ConstraintExpression(IOperation expressionOperation)
-        {
-            this.expressionOperation = expressionOperation;
         }
 
         /// <summary>

--- a/src/nunit.analyzers/Operations/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpression.cs
@@ -8,7 +8,7 @@ using NUnit.Analyzers.Extensions;
 namespace NUnit.Analyzers.Operations
 {
     /// <summary>
-    /// Represents assert constraint expression, e.g. 'Is.EqualTo(expected)', 'Is.Not.Null & Is.Not.Empty'
+    /// Represents assert constraint expression, e.g. 'Is.EqualTo(expected)', 'Is.Not.Null & Is.Not.Empty'.
     /// </summary>
     internal class ConstraintExpression
     {
@@ -47,7 +47,7 @@ namespace NUnit.Analyzers.Operations
 
         /// <summary>
         /// If provided constraint expression is combined using &, | operators - return multiple split expressions.
-        /// Otherwise - returns single <paramref name="constraintExpression"/> value
+        /// Otherwise - returns single <paramref name="constraintExpression"/> value.
         /// </summary>
         private static IEnumerable<IOperation> SplitConstraintByBinaryOperators(IOperation constraintExpression)
         {
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Operations
         }
 
         /// <summary>
-        /// If constraint expression is combined using And, Or, With properties - 
+        /// If constraint expression is combined using And, Or, With properties -
         /// returns parts of expression split by those properties.
         /// For each part returns operations split by call chains.
         /// </summary>
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Operations
             SplitConstraintByConstraintExpressionOperators(IOperation constraintExpression)
         {
             // e.g. Does.Contain(a).IgnoreCase.And.Contain(b).And.Not.Null
-            // --> 
+            // -->
             // Does.Contain(a).IgnoreCase,
             // Does.Contain(a).IgnoreCase.And.Contain(b)
             // Does.Contain(a).IgnoreCase.And.Contain(b).And.Not.Null
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.Operations
         }
 
         /// <summary>
-        /// Returns true if current expression is And/Or/With constraint operator
+        /// Returns true if current expression is And/Or/With constraint operator.
         /// </summary>
         private static bool IsConstraintExpressionOperator(IOperation operation)
         {

--- a/src/nunit.analyzers/Operations/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpression.cs
@@ -8,7 +8,7 @@ using NUnit.Analyzers.Extensions;
 namespace NUnit.Analyzers.Operations
 {
     /// <summary>
-    /// Represents assert constraint expression, e.g. 'Is.EqualTo(expected)', 'Is.Not.Null & Is.Not.Empty'.
+    /// Represents assert constraint expression, e.g. 'Is.EqualTo(expected)', 'Is.Not.Null &amp; Is.Not.Empty'.
     /// </summary>
     internal class ConstraintExpression
     {
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.Operations
         }
 
         /// <summary>
-        /// Split constraints into parts by binary ('&' or '|')  or constraint expression operators.
+        /// Split constraints into parts by binary ('&amp;' or '|')  or constraint expression operators.
         /// Returns oparations split by call chains.
         /// </summary>
         private static IEnumerable<List<IOperation>> SplitConstraintByOperators(IOperation constraintExpression)
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Operations
         }
 
         /// <summary>
-        /// If provided constraint expression is combined using &, | operators - return multiple split expressions.
+        /// If provided constraint expression is combined using &amp;, | operators - return multiple split expressions.
         /// Otherwise - returns single <paramref name="constraintExpression"/> value.
         /// </summary>
         private static IEnumerable<IOperation> SplitConstraintByBinaryOperators(IOperation constraintExpression)

--- a/src/nunit.analyzers/Operations/ConstraintExpression.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpression.cs
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.Operations
 
         /// <summary>
         /// Split constraints into parts by binary ('&amp;' or '|')  or constraint expression operators.
-        /// Returns oparations split by call chains.
+        /// Returns operations split by call chains.
         /// </summary>
         private static IEnumerable<List<IOperation>> SplitConstraintByOperators(IOperation constraintExpression)
         {

--- a/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
@@ -23,24 +23,24 @@ namespace NUnit.Analyzers.Operations
         }
 
         /// <summary>
-        /// Helper class used to access constraints,
+        /// Gets helper class used to access constraints,
         /// e.g. 'Has', 'Is', 'Throws', 'Does', etc.
         /// </summary>
         public ITypeSymbol? HelperClass { get; }
 
         /// <summary>
-        /// Constraint modifiers that go before actual constraint,
+        /// Gets constraint modifiers that go before actual constraint,
         /// e.g. 'Not', 'Some', 'Property(propertyName)', etc.
         /// </summary>
         public IReadOnlyCollection<IOperation> Prefixes { get; }
 
         /// <summary>
-        /// Actual constraint, e.g. 'EqualTo(expected)', 'Null', 'Empty', etc.
+        /// Gets actual constraint, e.g. 'EqualTo(expected)', 'Null', 'Empty', etc.
         /// </summary>
         public IOperation? Root { get; }
 
         /// <summary>
-        /// Constraint modifiers that go after actual constraint,
+        /// Gets constraint modifiers that go after actual constraint,
         /// e.g. 'IgnoreCase', 'After(timeout)', 'Within(range)', etc.
         /// </summary>
         public IReadOnlyCollection<IOperation> Suffixes { get; }

--- a/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
@@ -45,6 +45,32 @@ namespace NUnit.Analyzers.Operations
         /// </summary>
         public IReadOnlyCollection<IOperation> Suffixes { get; }
 
+        public TextSpan Span
+        {
+            get
+            {
+                // If constraint is built using And/ Or methods, and current part is second operand,
+                // we need to cut after operator.
+                var operation = this.callChainOperations[0];
+                var syntax = operation.Syntax;
+
+                int spanStart = syntax.SpanStart;
+
+                // If instance is null - that means we're accessing static helper class, no need to cut anything.
+                if (operation.GetInstance() != null)
+                {
+                    if (syntax is MemberAccessExpressionSyntax memberAccess)
+                        spanStart = memberAccess.Name.Span.Start;
+                    else if (syntax is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax invokedMemberAccess })
+                        spanStart = invokedMemberAccess.Name.Span.Start;
+                }
+
+                var spanEnd = this.callChainOperations.Last().Syntax.Span.End;
+
+                return TextSpan.FromBounds(spanStart, spanEnd);
+            }
+        }
+
         /// <summary>
         /// Returns prefixes names (i.e. method or property names).
         /// </summary>
@@ -134,32 +160,6 @@ namespace NUnit.Analyzers.Operations
             }
 
             return false;
-        }
-
-        public TextSpan Span
-        {
-            get
-            {
-                // If constraint is built using And/ Or methods, and current part is second operand,
-                // we need to cut after operator.
-                var operation = this.callChainOperations[0];
-                var syntax = operation.Syntax;
-
-                int spanStart = syntax.SpanStart;
-
-                // If instance is null - that means we're accessing static helper class, no need to cut anything.
-                if (operation.GetInstance() != null)
-                {
-                    if (syntax is MemberAccessExpressionSyntax memberAccess)
-                        spanStart = memberAccess.Name.Span.Start;
-                    else if (syntax is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax invokedMemberAccess })
-                        spanStart = invokedMemberAccess.Name.Span.Start;
-                }
-
-                var spanEnd = this.callChainOperations.Last().Syntax.Span.End;
-
-                return TextSpan.FromBounds(spanStart, spanEnd);
-            }
         }
 
         public Location GetLocation()

--- a/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
@@ -9,7 +9,7 @@ using NUnit.Analyzers.Extensions;
 namespace NUnit.Analyzers.Operations
 {
     /// <summary>
-    /// Represents part of <see cref="ConstraintExpression"/>, which is combined with others with 
+    /// Represents part of <see cref="ConstraintExpression"/>, which is combined with others with
     /// binary operators ('&', '|')  or methods ('And', 'Or', 'With').
     /// </summary>
     internal class ConstraintExpressionPart
@@ -140,7 +140,7 @@ namespace NUnit.Analyzers.Operations
         {
             get
             {
-                // If constraint is built using And/ Or methods, and current part is second operand, 
+                // If constraint is built using And/ Or methods, and current part is second operand,
                 // we need to cut after operator.
                 var operation = this.callChainOperations[0];
                 var syntax = operation.Syntax;

--- a/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
@@ -10,7 +10,7 @@ namespace NUnit.Analyzers.Operations
 {
     /// <summary>
     /// Represents part of <see cref="ConstraintExpression"/>, which is combined with others with
-    /// binary operators ('&', '|')  or methods ('And', 'Or', 'With').
+    /// binary operators ('&amp;', '|')  or methods ('And', 'Or', 'With').
     /// </summary>
     internal class ConstraintExpressionPart
     {

--- a/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ParallelizableUsage/ParallelizableUsageAnalyzer.cs
@@ -61,7 +61,7 @@ namespace NUnit.Analyzers.ParallelizableUsage
             var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
 
             if (parallelizableAttributeType.ContainingAssembly.Identity != attributeSymbol?.ContainingAssembly.Identity ||
-                NunitFrameworkConstants.NameOfParallelizableAttribute != attributeSymbol?.ContainingType.Name)
+                attributeSymbol?.ContainingType.Name != NunitFrameworkConstants.NameOfParallelizableAttribute)
             {
                 return;
             }

--- a/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
@@ -23,7 +23,6 @@ namespace NUnit.Analyzers.SameAsIncompatibleTypes
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
-
         protected override void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation)
         {
             if (!AssertHelper.TryGetActualAndConstraintOperations(assertOperation,

--- a/src/nunit.analyzers/SourceCommon/SourceAttributeInformation.cs
+++ b/src/nunit.analyzers/SourceCommon/SourceAttributeInformation.cs
@@ -4,12 +4,6 @@ namespace NUnit.Analyzers.SourceCommon
 {
     internal sealed class SourceAttributeInformation
     {
-        public INamedTypeSymbol SourceType { get; }
-        public string? SourceName { get; }
-        public SyntaxNode? SyntaxNode { get; }
-        public bool IsStringLiteral { get; }
-        public int? NumberOfMethodParameters { get; }
-
         public SourceAttributeInformation(
             INamedTypeSymbol sourceType,
             string? sourceName,
@@ -23,5 +17,11 @@ namespace NUnit.Analyzers.SourceCommon
             this.IsStringLiteral = isStringLiteral;
             this.NumberOfMethodParameters = numberOfMethodParameters;
         }
+
+        public INamedTypeSymbol SourceType { get; }
+        public string? SourceName { get; }
+        public SyntaxNode? SyntaxNode { get; }
+        public bool IsStringLiteral { get; }
+        public int? NumberOfMethodParameters { get; }
     }
 }

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -189,6 +189,7 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
                                 methodParametersFromAttribute,
                                 method.Parameters.Length));
                         }
+
                         break;
                 }
             }

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.TestCaseUsage
                     var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
 
                     if (testCaseType.ContainingAssembly.Identity == attributeSymbol?.ContainingAssembly.Identity &&
-                        NunitFrameworkConstants.NameOfTestCaseAttribute == attributeSymbol?.ContainingType.Name)
+                        attributeSymbol?.ContainingType.Name == NunitFrameworkConstants.NameOfTestCaseAttribute)
                     {
                         context.CancellationToken.ThrowIfCancellationRequested();
 
@@ -198,7 +198,7 @@ namespace NUnit.Analyzers.TestCaseUsage
                         continue;
                     }
                 }
-                
+
                 context.ReportDiagnostic(Diagnostic.Create(parameterTypeMismatch,
                     attributeArgument.GetLocation(),
                     i,

--- a/src/nunit.analyzers/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFix.cs
+++ b/src/nunit.analyzers/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFix.cs
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.TestMethodAccessibilityLevel
             return new SyntaxTokenList(newSyntaxTokens);
         }
 
-        public static SyntaxTokenList AddPublicModifier(MethodDeclarationSyntax originalExpression)
+        private static SyntaxTokenList AddPublicModifier(MethodDeclarationSyntax originalExpression)
         {
             var modifiers = originalExpression.Modifiers;
             var syntaxTriviaList = modifiers.Any()

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -28,7 +28,6 @@ namespace NUnit.Analyzers.TestCaseUsage
             defaultSeverity: DiagnosticSeverity.Error,
             description: TestMethodUsageAnalyzerConstants.SpecifiedExpectedResultForVoidMethodDescription);
 
-
         private static readonly DiagnosticDescriptor noExpectedResultButNonVoidReturnType = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.TestMethodNoExpectedResultButNonVoidReturnType,
             title: TestMethodUsageAnalyzerConstants.NoExpectedResultButNonVoidReturnTypeTitle,

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
   <Target Name="AfterBuild">
     <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
       <Output TaskParameter="Assemblies" ItemName="AnalyzerAssemblyInfo" />

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -16,6 +16,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.205">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,17 @@
+{
+  "settings": {
+    "documentationRules": {
+      "xmlHeader": false
+    },
+    "layoutRules": {
+      "newlineAtEndOfFile": "require"
+    },
+    "namingRules": {
+      "tupleElementNameCasing": "camelCase"
+    },
+    "orderingRules": {
+      "systemUsingDirectivesFirst": true,
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #20

Since we have lots of nitpick comments in PRs to fix spacing and formatting, I decided to open PR with suggestion to add StyleCop analyzer to project.
I used Unstable package, as current stable release has issues with nullabl annotations.

Based on current project style, I disabled the following rules:
- SA0001: Xml comment analysis disabled
- SA1101: Prefix local calls with this (disabled, but it is already checked by IDE analyzer)
- SA1116: Split parameters should start on line after declaration
- SA1117: Parameters should be on same line or separate lines
- SA1122: Use string.Empty for empty strings
- SA1124: Do not use regions
- SA1118: Parameter should not span multiple lines
- SA1200: Using directives should be placed correctly
- SA1201: Elements should appear in the correct order
- SA1202: Elements should be ordered by access
- SA1204: Static elements should appear before instance elements
- SA1311: Static readonly fields should begin with upper-case letter
- SA1316: Tuple element names should use correct casing
- SA1401: Fields should be private
- SA1413: Use trailing comma in multi-line initializers
- SA1503: Braces should not be omitted
- SA1512: Single-line comments should not be followed by blank line
- SA1516: Elements should be separated by blank line
- SA1600: Elements should be documented
- SA1623: Property summary documentation should match accessors
- SA1615: Element return value should be documented
- SA1611: Element parameters should be documented
- SA1612: Element parameter documentation should match element parameters
- SA1633: File should have header

If you think that any of those should be enabled (or the contrary - if any additional rules should be disabled), let me know.