### PR TITLE
Add FxCop Analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -190,6 +190,3 @@ dotnet_diagnostic.CA1056.severity = none
 # CA1062: Validate arguments of public methods
 # Our callers are roslyn and ourselves.
 dotnet_diagnostic.CA1062.severity = none
-
-# CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -177,3 +177,19 @@ dotnet_diagnostic.SA1612.severity = none
 
 # SA1633: File should have header
 dotnet_diagnostic.SA1633.severity = none
+
+##################################################################################
+# FxCop Analyzers
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = none
+
+# CA1056: URI-like properties should not be strings
+dotnet_diagnostic.CA1056.severity = none
+
+# CA1062: Validate arguments of public methods
+# Our callers are roslyn and ourselves.
+dotnet_diagnostic.CA1062.severity = none
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new AreEqualClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.AreEqualUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new AreNotEqualClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.AreNotEqualUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new AreNotSameClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.AreNotSameUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new AreSameClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.AreSameUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
@@ -24,9 +25,9 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             foreach (var diagnostic in diagnostics)
             {
-                Assert.That(diagnostic.Title.ToString(), Is.Not.Empty,
+                Assert.That(diagnostic.Title.ToString(CultureInfo.InvariantCulture), Is.Not.Empty,
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
-                Assert.That(diagnostic.MessageFormat.ToString(), Is.Not.Empty,
+                Assert.That(diagnostic.MessageFormat.ToString(CultureInfo.InvariantCulture), Is.Not.Empty,
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.MessageFormat)}");
                 Assert.That(diagnostic.Category, Is.EqualTo(Categories.Assertion),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new ContainsClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.ContainsUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new GreaterClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.GreaterUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new GreaterOrEqualClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.GreaterOrEqualUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsEmptyClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsEmptyUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsFalseAndFalseClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsFalseUsage, AnalyzerIdentifiers.FalseUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsInstanceOfClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsInstanceOfUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsNaNClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsNaNUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsNotEmptyClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsNotEmptyUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsNotInstanceOfClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsNotInstanceOfUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsNotNullAndNotNullClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsNotNullUsage, AnalyzerIdentifiers.NotNullUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsNullAndNullClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsNullUsage, AnalyzerIdentifiers.NullUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsTrueAndTrueClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsTrueUsage, AnalyzerIdentifiers.TrueUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.IsTrueUsage, AnalyzerIdentifiers.TrueUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new LessClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.LessUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new LessOrEqualClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.LessOrEqualUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new NotZeroClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.NotZeroUsage }));
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new ZeroClassicModelAssertUsageCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.ZeroUsage }));
         }

--- a/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
@@ -27,7 +27,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
-        public void AnalyzeWhenNonComparableTypesProvided_WithLambdaActualValue()
+        public void AnalyzeWhenNonComparableTypesProvidedWithLambdaActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -35,7 +35,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenNonComparableTypesProvided_WithLambdaActualValue()
+        public void AnalyzeWhenNonComparableTypesProvidedWithLambdaActualValue()
         {
             var expected = new A();
             Assert.That(() => new A(), Is.GreaterThanOrEqualTo(↓expected));
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithLocalFunctionActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithLocalFunctionActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithLocalFunctionActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithLocalFunctionActualValue()
         {
             A actual() => new A();
             var expected = new A();
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithFuncActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithFuncActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -74,7 +74,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             Func<A> actual = () => new A();
             var expected = new A();
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithTaskActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithTaskActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = Task.FromResult(new A());
             var expected = new A();

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -10,9 +11,11 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
     {
         private static readonly DiagnosticAnalyzer analyzer = new EqualConstraintUsageAnalyzer();
         private static readonly ExpectedDiagnostic isEqualToDiagnostic =
-            ExpectedDiagnostic.Create(AnalyzerIdentifiers.EqualConstraintUsage, string.Format(EqualConstraintUsageConstants.Message, "Is.EqualTo"));
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.EqualConstraintUsage,
+                string.Format(CultureInfo.InvariantCulture, EqualConstraintUsageConstants.Message, "Is.EqualTo"));
         private static readonly ExpectedDiagnostic isNotEqualToDiagnostic =
-            ExpectedDiagnostic.Create(AnalyzerIdentifiers.EqualConstraintUsage, string.Format(EqualConstraintUsageConstants.Message, "Is.Not.EqualTo"));
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.EqualConstraintUsage,
+                string.Format(CultureInfo.InvariantCulture, EqualConstraintUsageConstants.Message, "Is.Not.EqualTo"));
 
         [Test]
         public void AnalyzeWhenEqualsOperatorUsed()

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -11,10 +12,10 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         private static readonly DiagnosticAnalyzer analyzer = new SomeItemsConstraintUsageAnalyzer();
 
         private static readonly ExpectedDiagnostic doesContainDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.CollectionContainsConstraintUsage,
-            string.Format(SomeItemsConstraintUsageConstants.Message, "Does.Contain"));
+            string.Format(CultureInfo.InvariantCulture, SomeItemsConstraintUsageConstants.Message, "Does.Contain"));
 
         private static readonly ExpectedDiagnostic doesNotContainDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.CollectionContainsConstraintUsage,
-            string.Format(SomeItemsConstraintUsageConstants.Message, "Does.Not.Contain"));
+            string.Format(CultureInfo.InvariantCulture, SomeItemsConstraintUsageConstants.Message, "Does.Not.Contain"));
 
         [Test]
         public void AnalyzeWhenListContainsUsed_AssertThat()

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             string.Format(CultureInfo.InvariantCulture, SomeItemsConstraintUsageConstants.Message, "Does.Not.Contain"));
 
         [Test]
-        public void AnalyzeWhenListContainsUsed_AssertThat()
+        public void AnalyzeWhenListContainsUsedAssertThat()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(↓new List<int> {1, 2, 3}.Contains(1));",
@@ -28,7 +28,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenListContainsUsed_AssertIsTrue()
+        public void AnalyzeWhenListContainsUsedAssertIsTrue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsTrue(↓new List<int> {1, 2, 3}.Contains(1));",
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenListContainsUsed_AssertIsFalse()
+        public void AnalyzeWhenListContainsUsedAssertIsFalse()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsFalse(↓new List<int> {1, 2, 3}.Contains(1));",
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenLinqContainsUsed_AssertThat()
+        public void AnalyzeWhenLinqContainsUsedAssertThat()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(↓new[] {1, 2, 3}.Contains(1));",
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenLinqContainsUsed_AssertIsTrue()
+        public void AnalyzeWhenLinqContainsUsedAssertIsTrue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsTrue(↓new[] {1, 2, 3}.Contains(1));",
@@ -68,7 +68,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenLinqContainsUsed_AssertIsFalse()
+        public void AnalyzeWhenLinqContainsUsedAssertIsFalse()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsFalse(↓new[] {1, 2, 3}.Contains(1));",

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -14,10 +15,10 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         private static readonly CodeFixProvider fix = new SomeItemsConstraintUsageCodeFix();
 
         private static readonly ExpectedDiagnostic doesContainDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.CollectionContainsConstraintUsage,
-            string.Format(SomeItemsConstraintUsageConstants.Message, "Does.Contain"));
+            string.Format(CultureInfo.InvariantCulture, SomeItemsConstraintUsageConstants.Message, "Does.Contain"));
 
         private static readonly ExpectedDiagnostic doesNotContainDiagnostic = ExpectedDiagnostic.Create(AnalyzerIdentifiers.CollectionContainsConstraintUsage,
-            string.Format(SomeItemsConstraintUsageConstants.Message, "Does.Not.Contain"));
+            string.Format(CultureInfo.InvariantCulture, SomeItemsConstraintUsageConstants.Message, "Does.Not.Contain"));
 
         [Test]
         public void AnalyzeWhenListContainsUsed_AssertThat()

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             string.Format(CultureInfo.InvariantCulture, SomeItemsConstraintUsageConstants.Message, "Does.Not.Contain"));
 
         [Test]
-        public void AnalyzeWhenListContainsUsed_AssertThat()
+        public void AnalyzeWhenListContainsUsedAssertThat()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(↓new List<int> {1, 2, 3}.Contains(1));",
@@ -35,7 +35,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenListContainsUsed_AssertIsTrue()
+        public void AnalyzeWhenListContainsUsedAssertIsTrue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsTrue(↓new List<int> {1, 2, 3}.Contains(1));",
@@ -49,7 +49,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenListContainsUsed_AssertIsFalse()
+        public void AnalyzeWhenListContainsUsedAssertIsFalse()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsFalse(↓new List<int> {1, 2, 3}.Contains(1));",
@@ -63,7 +63,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenLinqContainsUsed_AssertThat()
+        public void AnalyzeWhenLinqContainsUsedAssertThat()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(↓new[] {1, 2, 3}.Contains(1));",
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenLinqContainsUsed_AssertIsTrue()
+        public void AnalyzeWhenLinqContainsUsedAssertIsTrue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsTrue(↓new[] {1, 2, 3}.Contains(1));",
@@ -91,7 +91,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [Test]
-        public void AnalyzeWhenLinqContainsUsed_AssertIsFalse()
+        public void AnalyzeWhenLinqContainsUsedAssertIsFalse()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.IsFalse(↓new[] {1, 2, 3}.Contains(1));",

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -30,7 +31,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
@@ -40,7 +41,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.IsTrue(↓""abc"".{method}(""ab""));");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
@@ -50,7 +51,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""));");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
@@ -60,7 +61,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.True);");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
@@ -70,7 +71,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
@@ -80,7 +81,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.IsFalse(↓""abc"".{method}(""ab""));");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
@@ -90,7 +91,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.False);");
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
-                string.Format(StringConstraintUsageConstants.Message, suggestedConstraint));
+                string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
             AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -26,7 +26,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         };
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertTrue(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
 
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertIsTrue(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertIsTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.IsTrue(↓""abc"".{method}(""ab""));");
 
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThat(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""));");
 
@@ -56,7 +56,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat_IsTrue(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThatIsTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.True);");
 
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertFalse(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
 
@@ -76,7 +76,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertIsFalse(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertIsFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.IsFalse(↓""abc"".{method}(""ab""));");
 
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat_IsFalse(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThatIsFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var testCode = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.False);");
 

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -27,7 +27,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         };
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertTrue(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.True(↓""abc"".{method}(""ab""));");
 
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertIsTrue(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertIsTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.IsTrue(↓""abc"".{method}(""ab""));");
 
@@ -47,7 +47,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThat(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""));");
 
@@ -57,7 +57,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat_IsTrue(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThatIsTrue(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.True);");
 
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat_Negated(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThatNegated(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.That(↓!""abc"".{method}(""ab""));");
 
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertFalse(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.False(↓""abc"".{method}(""ab""));");
 
@@ -87,7 +87,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertIsFalse(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertIsFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.IsFalse(↓""abc"".{method}(""ab""));");
 
@@ -97,7 +97,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
-        public void AnalyzeStringBooleanMethod_AssertThat_IsFalse(string method, string analyzerId, string suggestedConstraint)
+        public void AnalyzeStringBooleanMethodAssertThatIsFalse(string method, string analyzerId, string suggestedConstraint)
         {
             var code = TestUtility.WrapInTestMethod($@"Assert.That(↓""abc"".{method}(""ab""), Is.False);");
 

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests
         [TestCaseSource(nameof(DescriptorsWithDocs))]
         public void EnsureThatFirstLineMatchesId(DescriptorInfo descriptorInfo)
         {
-            var firstLine = descriptorInfo.DocumentationFile.AllLines.First();
+            var firstLine = descriptorInfo.DocumentationFile.AllLines[0];
             Assert.That(firstLine, Is.EqualTo($"# {descriptorInfo.Descriptor.Id}"));
         }
 

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -81,7 +81,7 @@ namespace NUnit.Analyzers.Tests
             var actual = descriptorInfo
                 .DocumentationFile.AllLines
                 .Skip(1)
-                .Select(l => l.Replace(@"\<", "<"))
+                .Select(l => l.Replace(@"\<", "<", StringComparison.Ordinal))
                 .Take(2);
 
             Assert.AreEqual(expected, actual);
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests
                               .SkipWhile(l => !l.StartsWith("## Description", StringComparison.OrdinalIgnoreCase))
                               .Skip(1)
                               .FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))
-                              ?.Replace("`", string.Empty);
+                              ?.Replace("`", string.Empty, StringComparison.Ordinal);
 
             DumpIfDebug(expected);
             DumpIfDebug(actual);
@@ -165,7 +165,7 @@ namespace NUnit.Analyzers.Tests
 
         private static string GetTable(string doc, string headerRow)
         {
-            var startIndex = doc.IndexOf(headerRow);
+            var startIndex = doc.IndexOf(headerRow, StringComparison.Ordinal);
             if (startIndex < 0)
             {
                 return string.Empty;
@@ -202,7 +202,7 @@ namespace NUnit.Analyzers.Tests
         }
 
         private static string EscapeTags(LocalizableString str)
-            => str.ToString(CultureInfo.InvariantCulture).Replace("<", @"\<");
+            => str.ToString(CultureInfo.InvariantCulture).Replace("<", @"\<", StringComparison.Ordinal);
 
         public class DescriptorInfo
         {
@@ -309,8 +309,8 @@ Or put this at the top of the file to disable all instances.
 <!-- end generated config severity -->
 ";
 
-                return stub.Replace("| Code     | [<TYPENAME>](<URL>)\r\n", text)
-                           .Replace("| Code     | [<TYPENAME>](<URL>)\n", text);
+                return stub.Replace("| Code     | [<TYPENAME>](<URL>)\r\n", text, StringComparison.Ordinal)
+                           .Replace("| Code     | [<TYPENAME>](<URL>)\n", text, StringComparison.Ordinal);
             }
         }
 
@@ -349,7 +349,7 @@ Or put this at the top of the file to disable all instances.
 
             public string Name { get; }
 
-            public string Uri => RepoOnMaster + this.Name.Substring(RepositoryDirectory.FullName.Length).Replace("\\", "/");
+            public string Uri => RepoOnMaster + this.Name.Substring(RepositoryDirectory.FullName.Length).Replace('\\', '/');
 
             public static CodeFile Find(Type type)
             {

--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -167,7 +167,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithCombinedConstraints()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithCombinedConstraints()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -188,7 +188,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithModifier()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithModifier()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
             var actual = 1;
@@ -199,7 +199,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithMessage()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithMessage()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
             var actual = 1;
@@ -210,7 +210,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -219,7 +219,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = new A();
             var expected = new B();
@@ -231,7 +231,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeClassicWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeClassicWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -240,7 +240,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = new A();
             var expected = new B();
@@ -252,7 +252,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithLambdaActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithLambdaActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -261,7 +261,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var expected = new B();
             Assert.That(() => new A(), Is.Not.EqualTo(↓expected));
@@ -272,7 +272,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithLocalFunctionActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithLocalFunctionActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -281,7 +281,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             A actual() => new A();
             var expected = new B();
@@ -293,7 +293,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithFuncActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithFuncActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -302,7 +302,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             Func<A> actual = () => new A();
             var expected = new B();
@@ -314,7 +314,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithTaskActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithTaskActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -323,7 +323,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = Task.FromResult(new A());
             var expected = new B();
@@ -335,7 +335,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenActualAndExpectedTypesAreSame_WithTaskActualValue()
+        public void AnalyzeWhenActualAndExpectedTypesAreSameWithTaskActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = Task.FromResult("""");
@@ -368,7 +368,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithNegatedAssert()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithNegatedAssert()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = """";
@@ -379,7 +379,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithLambdaActualValue()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithLambdaActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var expected = """";
@@ -389,7 +389,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithFuncActualValue()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithFuncActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Func<string> actual = () => """";
@@ -400,7 +400,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithLocalFunctionActualValue()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithLocalFunctionActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 string actual() => """";

--- a/src/nunit.analyzers.tests/Extensions/AttributeArgumentTypedConstantExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/AttributeArgumentTypedConstantExtensionsTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         }}
     }}
 }}";
-            var (typedConstant, typeSymbol, compilation) = await GetAttributeConstantAsync(testCode);
+            var (typedConstant, typeSymbol, compilation) = await GetAttributeConstantAsync(testCode).ConfigureAwait(false);
 
             Assert.That(typedConstant.CanAssignTo(typeSymbol, compilation), expectedResult);
         }
@@ -104,7 +104,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         private static async Task<(TypedConstant argumentConstant, ITypeSymbol typeSymbol, Compilation compilation)>
             GetAttributeConstantAsync(string code)
         {
-            var (root, semanticModel) = await TestHelpers.GetRootAndModel(code);
+            var (root, semanticModel) = await TestHelpers.GetRootAndModel(code).ConfigureAwait(false);
 
             // It's assumed the code will have one attribute with one argument,
             // along with one method with one parameter

--- a/src/nunit.analyzers.tests/Extensions/AttributeSyntaxExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/AttributeSyntaxExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public double BProperty { get; set; }
     }
 }";
-            var attribute = await AttributeSyntaxExtensionsTests.GetAttributeSyntaxAsync(testCode, "GetArguments");
+            var attribute = await GetAttributeSyntaxAsync(testCode, "GetArguments").ConfigureAwait(false);
             var (positionalArguments, namedArguments) = attribute.GetArguments();
 
             Assert.That(positionalArguments.Length, Is.EqualTo(1), nameof(positionalArguments));
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
     public sealed class NoArgumentsAttribute : Attribute
     { }
 }";
-            var attribute = await AttributeSyntaxExtensionsTests.GetAttributeSyntaxAsync(testCode, "GetArgumentsWhenNoneExist");
+            var attribute = await GetAttributeSyntaxAsync(testCode, "GetArgumentsWhenNoneExist").ConfigureAwait(false);
             var (positionalArguments, namedArguments) = attribute.GetArguments();
 
             Assert.That(positionalArguments.Length, Is.EqualTo(0), nameof(positionalArguments));
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 
         private static async Task<AttributeSyntax> GetAttributeSyntaxAsync(string code, string typeName)
         {
-            var rootAndModel = await TestHelpers.GetRootAndModel(code);
+            var rootAndModel = await TestHelpers.GetRootAndModel(code).ConfigureAwait(false);
 
             return rootAndModel.Node
                 .DescendantNodes().OfType<TypeDeclarationSyntax>()

--- a/src/nunit.analyzers.tests/Extensions/IMethodSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/IMethodSymbolExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public void Foo(int a1, int a2, int a3, string b1 = ""b1"", string b2 = ""b2"", params char[] c) { }
     }
 }";
-            var method = await GetMethodSymbolAsync(testCode);
+            var method = await GetMethodSymbolAsync(testCode).ConfigureAwait(false);
             var (requiredParameters, optionalParameters, paramsCount) = method.GetParameterCounts();
 
             Assert.That(requiredParameters, Is.EqualTo(3), nameof(requiredParameters));
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 
         private static async Task<IMethodSymbol> GetMethodSymbolAsync(string code)
         {
-            var rootAndModel = await TestHelpers.GetRootAndModel(code);
+            var rootAndModel = await TestHelpers.GetRootAndModel(code).ConfigureAwait(false);
 
             return rootAndModel.Model.GetDeclaredSymbol(rootAndModel.Node
                 .DescendantNodes().OfType<TypeDeclarationSyntax>().Single()

--- a/src/nunit.analyzers.tests/Extensions/IMethodSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/IMethodSymbolExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public void Foo(int a1, int a2, int a3, string b1 = ""b1"", string b2 = ""b2"", params char[] c) { }
     }
 }";
-            var method = await this.GetMethodSymbolAsync(testCode);
+            var method = await GetMethodSymbolAsync(testCode);
             var (requiredParameters, optionalParameters, paramsCount) = method.GetParameterCounts();
 
             Assert.That(requiredParameters, Is.EqualTo(3), nameof(requiredParameters));
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
             Assert.That(paramsCount, Is.EqualTo(1), nameof(paramsCount));
         }
 
-        private async Task<IMethodSymbol> GetMethodSymbolAsync(string code)
+        private static async Task<IMethodSymbol> GetMethodSymbolAsync(string code)
         {
             var rootAndModel = await TestHelpers.GetRootAndModel(code);
 

--- a/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenThisIsNull" });
+                new[] { "IsAssignableFromWhenThisIsNull" }).ConfigureAwait(false);
             var other = types[0];
 
             Assert.That((null as ITypeSymbol).IsAssignableFrom(other), Is.False);
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsNull" });
+                new[] { "IsAssignableFromWhenOtherIsNull" }).ConfigureAwait(false);
             var instance = types[0];
 
             Assert.That(instance.IsAssignableFrom(null as ITypeSymbol), Is.False);
@@ -55,7 +55,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsSameTypeAsThis" });
+                new[] { "IsAssignableFromWhenOtherIsSameTypeAsThis" }).ConfigureAwait(false);
             var instance = types[0];
             var other = instance;
 
@@ -72,11 +72,11 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types1 = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" });
+                new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" }).ConfigureAwait(false);
             var instance = types1[0];
             var types2 = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" });
+                new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" }).ConfigureAwait(false);
             var other = types2[0];
 
             Assert.That(instance.IsAssignableFrom(other), Is.False);
@@ -100,7 +100,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
                 {
                     "IsAssignableFromWhenOtherIsASubclassBase",
                     "IsAssignableFromWhenOtherIsASubclassSub"
-                });
+                }).ConfigureAwait(false);
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.True);
         }
@@ -121,7 +121,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
                 {
                     "IsAssignableFromWhenOtherIsNotASubclassA",
                     "IsAssignableFromWhenOtherIsNotASubclassB"
-                });
+                }).ConfigureAwait(false);
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.False);
         }
@@ -144,7 +144,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
                 {
                     "IsAssignableFromWhenOtherImplementsInterface",
                     "IsAssignableFromWhenOtherImplementsInterfaceType"
-                });
+                }).ConfigureAwait(false);
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.True);
         }
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public Guid x;
     }
 }";
-            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsNotInNUnitAssembly");
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsNotInNUnitAssembly").ConfigureAwait(false);
             Assert.That(typeSymbol.IsAssert(), Is.False);
         }
 
@@ -179,7 +179,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public Is x;
     }
 }";
-            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsInNUnitAssemblyAndNotAssertType");
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsInNUnitAssemblyAndNotAssertType").ConfigureAwait(false);
             Assert.That(typeSymbol.IsAssert(), Is.False);
         }
 
@@ -196,13 +196,13 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public Assert x;
     }
 }";
-            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsAssertType");
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsAssertType").ConfigureAwait(false);
             Assert.That(typeSymbol.IsAssert(), Is.True);
         }
 
         private static async Task<ImmutableArray<ITypeSymbol>> GetTypeSymbolAsync(string code, string[] typeNames)
         {
-            var rootAndModel = await TestHelpers.GetRootAndModel(code);
+            var rootAndModel = await TestHelpers.GetRootAndModel(code).ConfigureAwait(false);
 
             var types = new List<ITypeSymbol>();
 
@@ -218,7 +218,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 
         private static async Task<ITypeSymbol> GetTypeSymbolFromFieldAsync(string code, string typeName)
         {
-            var rootAndModel = await TestHelpers.GetRootAndModel(code);
+            var rootAndModel = await TestHelpers.GetRootAndModel(code).ConfigureAwait(false);
 
             var fieldNode = rootAndModel.Node
                 .DescendantNodes().OfType<TypeDeclarationSyntax>()

--- a/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 {
     public sealed class IsAssignableFromWhenThisIsNull { }
 }";
-            var types = await this.GetTypeSymbolAsync(
+            var types = await GetTypeSymbolAsync(
                 testCode,
                 new[] { "IsAssignableFromWhenThisIsNull" });
             var other = types[0];
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 {
     public sealed class IsAssignableFromWhenOtherIsNull { }
 }";
-            var types = await this.GetTypeSymbolAsync(
+            var types = await GetTypeSymbolAsync(
                 testCode,
                 new[] { "IsAssignableFromWhenOtherIsNull" });
             var instance = types[0];
@@ -53,7 +53,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 {
     public sealed class IsAssignableFromWhenOtherIsSameTypeAsThis { }
 }";
-            var types = await this.GetTypeSymbolAsync(
+            var types = await GetTypeSymbolAsync(
                 testCode,
                 new[] { "IsAssignableFromWhenOtherIsSameTypeAsThis" });
             var instance = types[0];
@@ -70,11 +70,11 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 {
     public sealed class IsAssignableFromWhenOtherIsInDifferentAssembly { }
 }";
-            var types1 = await this.GetTypeSymbolAsync(
+            var types1 = await GetTypeSymbolAsync(
                 testCode,
                 new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" });
             var instance = types1[0];
-            var types2 = await this.GetTypeSymbolAsync(
+            var types2 = await GetTypeSymbolAsync(
                 testCode,
                 new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" });
             var other = types2[0];
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
        : IsAssignableFromWhenOtherIsASubclassBase
     { }
 }";
-            var types = await this.GetTypeSymbolAsync(
+            var types = await GetTypeSymbolAsync(
                 testCode,
                 new[]
                 {
@@ -115,7 +115,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 
     public class IsAssignableFromWhenOtherIsNotASubclassB { }
 }";
-            var types = await this.GetTypeSymbolAsync(
+            var types = await GetTypeSymbolAsync(
                 testCode,
                 new[]
                 {
@@ -138,7 +138,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         : IsAssignableFromWhenOtherImplementsInterface
     { }
 }";
-            var types = await this.GetTypeSymbolAsync(
+            var types = await GetTypeSymbolAsync(
                 testCode,
                 new[]
                 {
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public Guid x;
     }
 }";
-            var typeSymbol = await this.GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsNotInNUnitAssembly");
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsNotInNUnitAssembly");
             Assert.That(typeSymbol.IsAssert(), Is.False);
         }
 
@@ -179,7 +179,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public Is x;
     }
 }";
-            var typeSymbol = await this.GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsInNUnitAssemblyAndNotAssertType");
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsInNUnitAssemblyAndNotAssertType");
             Assert.That(typeSymbol.IsAssert(), Is.False);
         }
 
@@ -196,11 +196,11 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         public Assert x;
     }
 }";
-            var typeSymbol = await this.GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsAssertType");
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAssertWhenSymbolIsAssertType");
             Assert.That(typeSymbol.IsAssert(), Is.True);
         }
 
-        private async Task<ImmutableArray<ITypeSymbol>> GetTypeSymbolAsync(string code, string[] typeNames)
+        private static async Task<ImmutableArray<ITypeSymbol>> GetTypeSymbolAsync(string code, string[] typeNames)
         {
             var rootAndModel = await TestHelpers.GetRootAndModel(code);
 
@@ -216,7 +216,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
             return types.ToImmutableArray();
         }
 
-        private async Task<ITypeSymbol> GetTypeSymbolFromFieldAsync(string code, string typeName)
+        private static async Task<ITypeSymbol> GetTypeSymbolFromFieldAsync(string code, string typeName)
         {
             var rootAndModel = await TestHelpers.GetRootAndModel(code);
 

--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyCodeFixTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -29,7 +30,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 additionalUsings: "using System.Collections.Generic;");
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
-                fixTitle: string.Format(CodeFixConstants.UsePropertyDescriptionFormat, "Count"));
+                fixTitle: string.Format(CultureInfo.InvariantCulture, CodeFixConstants.UsePropertyDescriptionFormat, "Count"));
         }
 
         [Test]
@@ -46,7 +47,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 additionalUsings: "using System.Collections.Generic;");
 
             AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
-                fixTitle: string.Format(CodeFixConstants.UsePropertyDescriptionFormat, "Length"));
+                fixTitle: string.Format(CultureInfo.InvariantCulture, CodeFixConstants.UsePropertyDescriptionFormat, "Length"));
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/Operations/ConstraintExpressionPartTests.cs
+++ b/src/nunit.analyzers.tests/Operations/ConstraintExpressionPartTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task ConstraintMethodWithNoPrefixesAndSuffixes()
         {
-            var constraintPart = await CreateConstraintPart("Does.Contain(1)");
+            var constraintPart = await CreateConstraintPart("Does.Contain(1)").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Does"));
 
@@ -27,7 +27,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task ConstraintPropertyWithNoPrefixesAndSuffixes()
         {
-            var constraintPart = await CreateConstraintPart("Is.Null");
+            var constraintPart = await CreateConstraintPart("Is.Null").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Is"));
 
@@ -40,7 +40,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task WithPropertyPrefix()
         {
-            var constraintPart = await CreateConstraintPart("Has.Some.EqualTo(1)");
+            var constraintPart = await CreateConstraintPart("Has.Some.EqualTo(1)").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Has"));
 
@@ -53,7 +53,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task WithMethodPrefix()
         {
-            var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(2)");
+            var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(2)").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Has"));
             Assert.That(constraintPart.Suffixes, Is.Empty);
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task WithPropertySuffix()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Is"));
             Assert.That(constraintPart.Prefixes, Is.Empty);
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task WithMethodSuffix()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(10)");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(10)").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Is"));
             Assert.That(constraintPart.Prefixes, Is.Empty);
@@ -89,7 +89,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task ConstraintIsBuiltUsingMethodOperator()
         {
-            var constraintParts = await CreateConstraintParts("Is.Empty.Or.Some.EqualTo(\"A\").IgnoreCase");
+            var constraintParts = await CreateConstraintParts("Is.Empty.Or.Some.EqualTo(\"A\").IgnoreCase").ConfigureAwait(false);
 
             var firstPart = constraintParts[0];
             Assert.That(firstPart.HelperClass.Name, Is.EqualTo("Is"));
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task ConstraintIsCreatedViaConstructor()
         {
-            var constraintPart = await CreateConstraintPart("new NUnit.Framework.Constraints.EqualConstraint(1)");
+            var constraintPart = await CreateConstraintPart("new NUnit.Framework.Constraints.EqualConstraint(1)").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass, Is.Null);
             Assert.That(constraintPart.Prefixes, Is.Empty);
@@ -119,7 +119,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task PrefixNameReturnsPropertyName()
         {
-            var constraintPart = await CreateConstraintPart("Is.Not.Null");
+            var constraintPart = await CreateConstraintPart("Is.Not.Null").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetPrefixesNames(), Is.EqualTo(new[] { "Not" }));
         }
@@ -127,7 +127,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task PrefixNameReturnsMethodName()
         {
-            var constraintPart = await CreateConstraintPart("Has.Exactly(2).EqualTo(2)");
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).EqualTo(2)").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetPrefixesNames(), Is.EqualTo(new[] { "Exactly" }));
         }
@@ -135,7 +135,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task SuffixNameReturnsPropertyName()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"A\").IgnoreCase").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetSuffixesNames(), Is.EqualTo(new[] { "IgnoreCase" }));
         }
@@ -143,7 +143,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task SuffixNameReturnsMethodName()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(100, 10)");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).After(100, 10)").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetSuffixesNames(), Is.EqualTo(new[] { "After" }));
         }
@@ -151,7 +151,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetConstraintNameReturnsPropertyName()
         {
-            var constraintPart = await CreateConstraintPart("Is.Not.Empty");
+            var constraintPart = await CreateConstraintPart("Is.Not.Empty").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetConstraintName(), Is.EqualTo("Empty"));
         }
@@ -159,7 +159,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetConstraintNameReturnsMethodName()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(new[] {1, 2}).IgnoreCase");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(new[] {1, 2}).IgnoreCase").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetConstraintName(), Is.EqualTo("EqualTo"));
         }
@@ -167,7 +167,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetHelperClassNameReturnsIdentifierName()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).IgnoreCase");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(1).IgnoreCase").ConfigureAwait(false);
 
             Assert.That(constraintPart.HelperClass.Name, Is.EqualTo("Is"));
         }
@@ -175,7 +175,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetPrefixExpressionByName()
         {
-            var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(1)");
+            var constraintPart = await CreateConstraintPart("Has.Property(\"Prop\").EqualTo(1)").ConfigureAwait(false);
 
             var prefixExpression = constraintPart.GetPrefix("Property");
 
@@ -185,7 +185,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetSuffixExpressionByName()
         {
-            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"a\").IgnoreCase");
+            var constraintPart = await CreateConstraintPart("Is.EqualTo(\"a\").IgnoreCase").ConfigureAwait(false);
 
             var suffixExpression = constraintPart.GetSuffix("IgnoreCase");
 
@@ -195,7 +195,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetConstraintMethodReturnsMethodSymbol()
         {
-            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(1.0).Within(0.01)");
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(1.0).Within(0.01)").ConfigureAwait(false);
 
             var methodSymbol = constraintPart.GetConstraintMethod();
 
@@ -207,7 +207,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetConstraintMethodReturnsNullForPropertyConstraint()
         {
-            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.Null.After(1)");
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.Null.After(1)").ConfigureAwait(false);
 
             Assert.That(constraintPart.GetConstraintMethod(), Is.Null);
         }
@@ -215,7 +215,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task GetExpectedArgumentExpression()
         {
-            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(new[] {1, 2, 3}).After(1)");
+            var constraintPart = await CreateConstraintPart("Has.Exactly(2).Items.EqualTo(new[] {1, 2, 3}).After(1)").ConfigureAwait(false);
 
             var expectedExpression = constraintPart.GetExpectedArgument()?.Syntax;
 
@@ -225,7 +225,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task HasUnknownExpressionsReturnsTrueIfTernaryExpressionPresent()
         {
-            var constraintPart = await CreateConstraintPart("(true ? Has.Some : Has.None).EqualTo(1)");
+            var constraintPart = await CreateConstraintPart("(true ? Has.Some : Has.None).EqualTo(1)").ConfigureAwait(false);
 
             Assert.That(constraintPart.HasUnknownExpressions(), Is.True);
         }
@@ -238,7 +238,7 @@ namespace NUnit.Analyzers.Tests.Operations
                     var presentExpected = true;
                     var prefix = presentExpected ? Has.Some : Has.None;
                     Assert.That(new[] {1, 2, 3}, prefix.EqualTo(1));",
-                expressionString: "prefix.EqualTo(1)"))[0];
+                expressionString: "prefix.EqualTo(1)").ConfigureAwait(false))[0];
 
             Assert.That(constraintPart.HasUnknownExpressions(), Is.True);
         }
@@ -263,7 +263,7 @@ namespace NUnit.Analyzers.Tests.Operations
 
         private static async Task<ConstraintExpressionPart> CreateConstraintPart(string expressionString)
         {
-            return (await CreateConstraintParts(expressionString)).Single();
+            return (await CreateConstraintParts(expressionString).ConfigureAwait(false)).Single();
         }
 
         private static Task<ConstraintExpressionPart[]> CreateConstraintParts(string expressionString)
@@ -274,7 +274,7 @@ namespace NUnit.Analyzers.Tests.Operations
         private static async Task<ConstraintExpressionPart[]> CreateConstraintParts(string testMethod, string expressionString)
         {
             var testCode = TestUtility.WrapInTestMethod(testMethod);
-            var (node, model) = await TestHelpers.GetRootAndModel(testCode);
+            var (node, model) = await TestHelpers.GetRootAndModel(testCode).ConfigureAwait(false);
 
             var expression = node.DescendantNodes()
                 .OfType<ExpressionSyntax>()

--- a/src/nunit.analyzers.tests/Operations/ConstraintExpressionTests.cs
+++ b/src/nunit.analyzers.tests/Operations/ConstraintExpressionTests.cs
@@ -11,7 +11,7 @@ namespace NUnit.Analyzers.Tests.Operations
         [Test]
         public async Task SimpleIsExpression()
         {
-            var constraintExpression = await CreateConstraintExpression("Is.EqualTo(1)");
+            var constraintExpression = await CreateConstraintExpression("Is.EqualTo(1)").ConfigureAwait(false);
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
             Assert.That(constraintParts, Is.EqualTo(new[] { "Is.EqualTo(1)" }));
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.Tests.Operations
         public async Task ConstraintConstructor()
         {
             var constraintExpression = await CreateConstraintExpression(
-                "new NUnit.Framework.Constraints.EqualConstraint(1)");
+                "new NUnit.Framework.Constraints.EqualConstraint(1)").ConfigureAwait(false);
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
             Assert.That(constraintParts, Is.EqualTo(new[] { "new NUnit.Framework.Constraints.EqualConstraint(1)" }));
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.Operations
         public async Task CombinedWithBinaryOperator(string @operator)
         {
             var constraintExpression = await CreateConstraintExpression(
-                $"Has.Count.EqualTo(1) {@operator} Has.Some.EqualTo(2)");
+                $"Has.Count.EqualTo(1) {@operator} Has.Some.EqualTo(2)").ConfigureAwait(false);
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
             Assert.That(constraintParts, Is.EqualTo(new[] { "Has.Count.EqualTo(1)", "Has.Some.EqualTo(2)" }));
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.Operations
         public async Task CombinedWithOperatorMethod(string method)
         {
             var constraintExpression = await CreateConstraintExpression(
-                $"Has.Count.EqualTo(1).{method}.Some.EqualTo(2)");
+                $"Has.Count.EqualTo(1).{method}.Some.EqualTo(2)").ConfigureAwait(false);
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
             Assert.That(constraintParts, Is.EqualTo(new[] { "Has.Count.EqualTo(1)", "Some.EqualTo(2)" }));
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.Operations
         public async Task CombinedWithMixedOperators()
         {
             var constraintExpression = await CreateConstraintExpression(
-                "Is.Not.Empty & Is.EqualTo(new [] { \"1\" }).IgnoreCase.Or.EquivalentTo(new[] { \"1\", \"2\" })");
+                "Is.Not.Empty & Is.EqualTo(new [] { \"1\" }).IgnoreCase.Or.EquivalentTo(new[] { \"1\", \"2\" })").ConfigureAwait(false);
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
 
@@ -71,7 +71,7 @@ namespace NUnit.Analyzers.Tests.Operations
         public async Task WhenWithIsNop()
         {
             var constraintExpression = await CreateConstraintExpression(
-                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")");
+                "Has.Property(\"Foo\").With.Property(\"Bar\").EqualTo(\"Baz\")").ConfigureAwait(false);
 
             var constraintParts = constraintExpression.ConstraintParts.Select(p => p.ToString());
 
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.Operations
         private static async Task<ConstraintExpression> CreateConstraintExpression(string expressionString)
         {
             var testCode = TestUtility.WrapInTestMethod($"Assert.That(1, {expressionString});");
-            var (node, model) = await TestHelpers.GetRootAndModel(testCode);
+            var (node, model) = await TestHelpers.GetRootAndModel(testCode).ConfigureAwait(false);
 
             var expression = node.DescendantNodes()
                 .OfType<ExpressionSyntax>()

--- a/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
@@ -33,13 +34,13 @@ namespace NUnit.Analyzers.Tests.ParallelizableUsage
 
             foreach (var diagnostic in diagnostics)
             {
-                Assert.That(diagnostic.Title.ToString(), Is.Not.Empty,
+                Assert.That(diagnostic.Title.ToString(CultureInfo.InvariantCulture), Is.Not.Empty,
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
                 Assert.That(diagnostic.Category, Is.EqualTo(Categories.Structure),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
             }
 
-            var diagnosticMessage = diagnostics.Select(_ => _.MessageFormat.ToString()).ToImmutableArray();
+            var diagnosticMessage = diagnostics.Select(_ => _.MessageFormat.ToString(CultureInfo.InvariantCulture)).ToImmutableArray();
 
             Assert.That(diagnosticMessage, Contains.Item(ParallelizableUsageAnalyzerConstants.ParallelScopeSelfNoEffectOnAssemblyMessage),
                 $"{ParallelizableUsageAnalyzerConstants.ParallelScopeSelfNoEffectOnAssemblyMessage} is missing.");

--- a/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
@@ -55,7 +55,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithImplicitConversion()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithImplicitConversion()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public class Tests
@@ -73,7 +73,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithCombinedConstraints()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithCombinedConstraints()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = new A();
             var expected = new B();
@@ -115,7 +115,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeClassicWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeClassicWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -124,7 +124,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = new A();
             var expected = new B();
@@ -136,7 +136,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithLambdaActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithLambdaActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -145,7 +145,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var expected = new B();
             Assert.That(() => new A(), Is.Not.SameAs(↓expected));
@@ -156,7 +156,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithLocalFunctionActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithLocalFunctionActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -165,7 +165,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     public class Tests
     {{
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             A actual() => new A();
             var expected = new B();
@@ -177,7 +177,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithFuncActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithFuncActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -186,7 +186,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             Func<A> actual = () => new A();
             var expected = new B();
@@ -198,7 +198,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithTaskActualValue()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithTaskActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     class A { }
@@ -207,7 +207,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     public class Tests
     {
         [Test]
-        public void AnalyzeWhenIncompatibleTypesProvided_WithNegatedAssert()
+        public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
             var actual = Task.FromResult(new A());
             var expected = new B();
@@ -219,7 +219,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void AnalyzeWhenActualAndExpectedTypesAreSame_WithTaskActualValue()
+        public void AnalyzeWhenActualAndExpectedTypesAreSameWithTaskActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = Task.FromResult("""");
@@ -252,7 +252,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithNegatedAssert()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithNegatedAssert()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = """";
@@ -263,7 +263,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticClassicWhenActualAndExpectedTypesAreSame_WithNegatedAssert()
+        public void NoDiagnosticClassicWhenActualAndExpectedTypesAreSameWithNegatedAssert()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = """";
@@ -274,7 +274,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithLambdaActualValue()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithLambdaActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var expected = """";
@@ -284,7 +284,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithFuncActualValue()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithFuncActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Func<string> actual = () => """";
@@ -295,7 +295,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSame_WithLocalFunctionActualValue()
+        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithLocalFunctionActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 string actual() => """";

--- a/src/nunit.analyzers.tests/SameAsOnValueTypes/SameAsOnValueTypesCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/SameAsOnValueTypes/SameAsOnValueTypesCodeFixTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
         public void VerifyGetFixableDiagnosticIds()
         {
             var fix = new SameAsOnValueTypesCodeFix();
-            var ids = fix.FixableDiagnosticIds.ToImmutableArray();
+            var ids = fix.FixableDiagnosticIds;
 
             Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.SameAsOnValueTypes }));
         }

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
@@ -44,14 +45,14 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
 
             foreach (var diagnostic in diagnostics)
             {
-                Assert.That(diagnostic.Title.ToString(), Is.Not.Empty);
+                Assert.That(diagnostic.Title.ToString(CultureInfo.InvariantCulture), Is.Not.Empty);
                 Assert.That(diagnostic.Category, Is.EqualTo(Categories.Structure),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
                 Assert.That(diagnostic.DefaultSeverity, Is.EqualTo(DiagnosticSeverity.Error),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.DefaultSeverity)}");
             }
 
-            var diagnosticMessage = diagnostics.Select(_ => _.MessageFormat.ToString()).ToImmutableArray();
+            var diagnosticMessage = diagnostics.Select(_ => _.MessageFormat.ToString(CultureInfo.InvariantCulture)).ToImmutableArray();
 
             Assert.That(diagnosticMessage, Contains.Item(TestCaseUsageAnalyzerConstants.NotEnoughArgumentsMessage),
                 $"{TestCaseUsageAnalyzerConstants.NotEnoughArgumentsMessage} is missing.");
@@ -323,7 +324,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "char"));
+                string.Format(CultureInfo.InvariantCulture,
+                    TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "char"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenArgumentTypeIsIncorrect
@@ -339,7 +341,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "char"));
+                string.Format(CultureInfo.InvariantCulture,
+                    TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "char"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenArgumentPassesNullToValueType
@@ -466,7 +469,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "int", "a", "string[]"));
+                string.Format(CultureInfo.InvariantCulture, TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage,
+                              0, "int", "a", "string[]"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenMethodHasOnlyParamsAndArgumentTypeIsIncorrect
@@ -482,7 +486,8 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage,
-                string.Format(TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage, 0, "<null>", "a", "int[]"));
+                string.Format(CultureInfo.InvariantCulture, TestCaseUsageAnalyzerConstants.ParameterTypeMismatchMessage,
+                              0, "<null>", "a", "int[]"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenMethodHasOnlyParamsAndArgumentPassesNullToValueType

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
@@ -86,6 +86,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             AnalyzerAssert.Valid<TestMethodAccessibilityLevelAnalyzer>(testCode);
         }
 
+        [Test]
         public void AnalyzeWhenSimpleTestMethodIsPublic()
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
@@ -47,7 +48,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
 
             foreach (var diagnostic in diagnostics)
             {
-                Assert.That(diagnostic.Title.ToString(), Is.Not.Empty,
+                Assert.That(diagnostic.Title.ToString(CultureInfo.InvariantCulture), Is.Not.Empty,
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Title)}");
                 Assert.That(diagnostic.Category, Is.EqualTo(Categories.Structure),
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.Category)}");
@@ -55,7 +56,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
                     $"{diagnostic.Id} : {nameof(DiagnosticDescriptor.DefaultSeverity)}");
             }
 
-            var diagnosticMessage = diagnostics.Select(_ => _.MessageFormat.ToString()).ToImmutableArray();
+            var diagnosticMessage = diagnostics.Select(_ => _.MessageFormat.ToString(CultureInfo.InvariantCulture)).ToImmutableArray();
 
             Assert.That(diagnosticMessage, Contains.Item(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage),
                 $"{TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage} is missing.");
@@ -108,7 +109,8 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
-                string.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
+                string.Format(CultureInfo.InvariantCulture,
+                    TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenExpectedResultIsProvidedAndTypeIsIncorrect
@@ -124,7 +126,8 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
-                string.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
+                string.Format(CultureInfo.InvariantCulture,
+                    TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenExpectedResultIsProvidedAndPassesNullToValueType
@@ -327,7 +330,8 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
-                string.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
+                string.Format(CultureInfo.InvariantCulture,
+                    TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenTestMethodHasCustomAwaitableReturnTypeAndExpectedResultIsIncorrect
@@ -368,7 +372,8 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(
                 AnalyzerIdentifiers.TestMethodExpectedResultTypeMismatchUsage,
-                string.Format(TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
+                string.Format(CultureInfo.InvariantCulture,
+                    TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
                 [TestCase(ExpectedResult = '1')]

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -18,6 +18,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.ConstActualValueUsage
                 return;
 
             // The actual expression is a constant field, check if expected is also constant
-            var expectedOperation = this.GetExpectedOperation(assertOperation);
+            var expectedOperation = GetExpectedOperation(assertOperation);
 
             if (expectedOperation != null && !expectedOperation.ConstantValue.HasValue && !IsStringEmpty(expectedOperation))
             {
@@ -75,7 +75,7 @@ namespace NUnit.Analyzers.ConstActualValueUsage
             }
         }
 
-        private IOperation? GetExpectedOperation(IInvocationOperation assertOperation)
+        private static IOperation? GetExpectedOperation(IInvocationOperation assertOperation)
         {
             var expectedOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfExpectedParameter);
 

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -22,7 +23,8 @@ namespace NUnit.Analyzers.ConstraintUsage
         {
             var suggestedConstraintString = context.Diagnostics[0].Properties[BaseConditionConstraintAnalyzer.SuggestedConstraintString];
 
-            var description = string.Format(CodeFixConstants.UseConstraintDescriptionFormat, suggestedConstraintString);
+            var description = string.Format(CultureInfo.InvariantCulture,
+                CodeFixConstants.UseConstraintDescriptionFormat, suggestedConstraintString);
 
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);

--- a/src/nunit.analyzers/ConstraintUsage/SomeItemsConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/SomeItemsConstraintUsageAnalyzer.cs
@@ -34,8 +34,8 @@ namespace NUnit.Analyzers.ConstraintUsage
                 var symbol = invocationOperation.TargetMethod;
                 var argumentCount = invocationOperation.Arguments.Length;
 
-                if ((argumentCount == 1 && this.IsCollectionContains(symbol))
-                    || (argumentCount == 2 && this.IsLinqContains(symbol)))
+                if ((argumentCount == 1 && IsCollectionContains(symbol))
+                    || (argumentCount == 2 && IsLinqContains(symbol)))
                 {
                     var suggestedConstraint = negated ? DoesNotContain : DoesContain;
                     return (descriptor, suggestedConstraint);
@@ -45,14 +45,14 @@ namespace NUnit.Analyzers.ConstraintUsage
             return (null, null);
         }
 
-        private bool IsLinqContains(IMethodSymbol methodSymbol)
+        private static bool IsLinqContains(IMethodSymbol methodSymbol)
         {
             return methodSymbol.IsExtensionMethod
                && methodSymbol.Name == "Contains"
                && methodSymbol.ContainingType.GetFullMetadataName() == typeof(System.Linq.Enumerable).FullName;
         }
 
-        private bool IsCollectionContains(IMethodSymbol methodSymbol)
+        private static bool IsCollectionContains(IMethodSymbol methodSymbol)
         {
             return methodSymbol.Name == "Contains"
                 && (methodSymbol.IsInterfaceImplementation(typeof(ICollection<>).FullName!)

--- a/src/nunit.analyzers/DiagnosticDescriptorCreator.cs
+++ b/src/nunit.analyzers/DiagnosticDescriptorCreator.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.CodeAnalysis;
 
 namespace NUnit.Analyzers
@@ -37,7 +38,7 @@ namespace NUnit.Analyzers
                 isEnabledByDefault: isEnabledByDefault,
                 description: description,
                 helpLinkUri: CreateLink(id),
-                customTags: new string[0]);
+                customTags: Array.Empty<string>());
 
         private static string CreateLink(string id) =>
             $"https://github.com/nunit/nunit.analyzers/tree/master/documentation/{id}.md";

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -28,8 +29,8 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
             IOperation? actualOperation;
             IOperation? expectedOperation;
 
-            if (assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreEqual) ||
-                assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreNotEqual))
+            if (assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreEqual, StringComparison.Ordinal) ||
+                assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreNotEqual, StringComparison.Ordinal))
             {
                 actualOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfActualParameter);
                 expectedOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfExpectedParameter);

--- a/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
@@ -205,7 +205,9 @@ namespace NUnit.Analyzers.Extensions
                             typeConverter.ConvertFrom(null, CultureInfo.InvariantCulture, argumentValue);
                             return true;
                         }
+#pragma warning disable CA1031 // Do not catch general exception types
                         catch
+#pragma warning restore CA1031 // Do not catch general exception types
                         {
                         }
                     }

--- a/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
+++ b/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -177,7 +178,7 @@ namespace NUnit.Analyzers.Helpers
 
         private static bool IsTuple(string fullName)
         {
-            return fullName.StartsWith("System.Tuple`");
+            return fullName.StartsWith("System.Tuple`", StringComparison.Ordinal);
         }
 
         private static bool IsIEquatable(ITypeSymbol typeSymbol, ITypeSymbol equatableTypeArguments)

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -99,7 +100,7 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
             if (fullName == "System.Collections.Generic.KeyValuePair`2")
                 return namedType.TypeArguments.Any(t => IsTypeSupported(t, checkedTypes));
 
-            if (fullName.StartsWith("System.Tuple`"))
+            if (fullName.StartsWith("System.Tuple`", StringComparison.Ordinal))
                 return namedType.TypeArguments.Any(t => IsTypeSupported(t, checkedTypes));
 
             // Only value might be supported for Dictionary

--- a/src/nunit.analyzers/MissingProperty/MissingPropertyCodeFix.cs
+++ b/src/nunit.analyzers/MissingProperty/MissingPropertyCodeFix.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -58,7 +59,8 @@ namespace NUnit.Analyzers.MissingProperty
 
                 var newRoot = root.ReplaceNode(originalExpression, memberAccess);
 
-                var description = string.Format(CodeFixConstants.UsePropertyDescriptionFormat, target);
+                var description = string.Format(CultureInfo.InvariantCulture,
+                        CodeFixConstants.UsePropertyDescriptionFormat, target);
 
                 var codeAction = CodeAction.Create(
                     description,

--- a/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpressionPart.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Operations
                         spanStart = invokedMemberAccess.Name.Span.Start;
                 }
 
-                var spanEnd = this.callChainOperations.Last().Syntax.Span.End;
+                var spanEnd = this.callChainOperations[this.callChainOperations.Count - 1].Syntax.Span.End;
 
                 return TextSpan.FromBounds(spanStart, spanEnd);
             }
@@ -170,7 +170,7 @@ namespace NUnit.Analyzers.Operations
 
         public override string ToString()
         {
-            var operationSyntax = this.callChainOperations.Last().Syntax;
+            var operationSyntax = this.callChainOperations[this.callChainOperations.Count - 1].Syntax;
             var startDelta = this.Span.Start - operationSyntax.Span.Start;
 
             return operationSyntax.ToString().Substring(startDelta);

--- a/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -29,8 +30,8 @@ namespace NUnit.Analyzers.SameAsIncompatibleTypes
             IOperation? actualOperation;
             IOperation? expectedOperation;
 
-            if (assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreSame) ||
-                assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreNotSame))
+            if (assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreSame, StringComparison.Ordinal) ||
+                assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreNotSame, StringComparison.Ordinal))
             {
                 actualOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfActualParameter);
                 expectedOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfExpectedParameter);

--- a/src/nunit.analyzers/SameAsOnValueTypes/SameAsOnValueTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsOnValueTypes/SameAsOnValueTypesAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -28,8 +29,8 @@ namespace NUnit.Analyzers.SameAsOnValueTypes
             IOperation? actualOperation;
             IOperation? expectedOperation;
 
-            if (assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreSame) ||
-                assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreNotSame))
+            if (assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreSame, StringComparison.Ordinal) ||
+                assertOperation.TargetMethod.Name.Equals(NunitFrameworkConstants.NameOfAssertAreNotSame, StringComparison.Ordinal))
             {
                 actualOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfActualParameter);
                 expectedOperation = assertOperation.GetArgumentOperation(NunitFrameworkConstants.NameOfExpectedParameter);

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -138,7 +138,7 @@ namespace NUnit.Analyzers.TestCaseUsage
 
         private static bool IsSoleParameterAnObjectArray(IMethodSymbol methodSymbol)
         {
-            if (methodSymbol.Parameters.Count() != 1)
+            if (methodSymbol.Parameters.Length != 1)
                 return false;
 
             var parameterType = methodSymbol.Parameters[0].Type;

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -20,6 +20,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #288 

I fixed the rule violations in separate commits so it would be easier to see what each rule does.

I have disabled the following rules:
* CA1031 Do not catch general exception types.
  * Only one violation which could be alternatively suppressed in the source file.
* CA1034: Nested types should not be visible
  * Only violation is in the `DocumentationTests` but as NUnit requires public methods we could not pass a nested private class as a `TestCaseSource`.
  * As this potential could be an issue in future test, I disabled the rule.
* CA1056: URI-like properties should not be strings
  * Only violation is in the `DocumentationTests`. Uri concatentation doesn't work. 
* CA1062: Validate arguments of public methods
  * Our only caller is the roslyn framework, no need to check arguments.
* CA1707: Identifiers should not contain underscores
  * Used in some Unit tests.
  * I added an extra commit to remove the _ for those tests. We use PascalCasing every where else. However, I'm happy to drop that commit if you think the test names are more readable that way.