### PR TITLE
Actual value delegate

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -389,14 +389,14 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithFuncActualValue()
+        public void AnalyzeWhenActualAndExpectedTypesAreSameWithFuncActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Func<string> actual = () => """";
                 var expected = """";
-                Assert.That(actual, Is.EqualTo(expected));");
+                Assert.That(actual, Is.EqualTo(↓expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
@@ -105,5 +105,27 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
 
             AnalyzerAssert.Valid(analyzer, testCode);
         }
+
+        [TestCase("Is.Null")]
+        [TestCase("Is.Not.Null")]
+        public void ValidWhenActualIsAction(string constraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                Action<bool> action = b => {{ }};
+                Assert.That(action, {constraint});");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [TestCase("Is.Null")]
+        [TestCase("Is.Not.Null")]
+        public void ValidWhenActualIsFunc(string constraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                Func<bool, bool> function = b => b;
+                Assert.That(function, {constraint});");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -139,5 +141,73 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
+        [Test]
+        public void ActualNUnitFunction()
+        {
+            bool functionCalled = false;
+
+#pragma warning disable IDE0039 // Use local function
+            Func<bool> function = () =>
+            {
+                functionCalled = true;
+                return false;
+            };
+#pragma warning restore IDE0039 // Use local function
+
+            Assert.That(function, Is.Not.Null);
+            Assert.That(functionCalled, Is.False);
+
+            Assert.That(() => function, Is.Not.Null);
+            Assert.That(functionCalled, Is.False);
+
+            Assert.That(() => function(), Is.Not.Null);
+            Assert.That(functionCalled, Is.True);
+        }
+
+        [Test]
+        public void ActualNUnitAsyncFunction()
+        {
+            bool functionCalled = false;
+
+#pragma warning disable IDE0039 // Use local function
+            Func<Task<bool>> asyncFunction = () =>
+            {
+                functionCalled = true;
+                return Task.FromResult(false);
+            };
+#pragma warning restore IDE0039 // Use local function
+
+            Assert.That(asyncFunction, Is.Not.Null);
+            Assert.That(functionCalled, Is.False);
+
+            Assert.That(() => asyncFunction, Is.Not.Null);
+            Assert.That(functionCalled, Is.False);
+
+            Assert.That(() => asyncFunction(), Is.Not.Null);
+            Assert.That(functionCalled, Is.True);
+        }
+
+        [Test]
+        public void ActualNUnitForAction()
+        {
+            bool actionCalled = false;
+
+#pragma warning disable IDE0039 // Use local function
+            Action action = () => actionCalled = true;
+#pragma warning restore IDE0039 // Use local function
+
+            Assert.That(action, Is.Not.Null);
+            Assert.That(actionCalled, Is.False);
+
+            Assert.That(() => action, Is.Not.Null);
+            Assert.That(actionCalled, Is.False);
+
+            Assert.That(() => action(), Is.Not.Null);
+
+#if EXPECT_TEST_DELEGATE_TO_BE_CALLED
+            // The above test succeeds, but does not call the action!
+            Assert.That(actionCalled, Is.True);
+#endif
+        }
     }
 }

--- a/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
@@ -127,5 +127,17 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
 
             AnalyzerAssert.Valid(analyzer, testCode);
         }
+
+        [TestCase("Is.Null")]
+        [TestCase("Is.Not.Null")]
+        public void AnalyzeWhenActualIsTestDelegate(string constraint)
+        {
+            var testCode = TestUtility.WrapInTestMethod($@"
+                Action<bool> action = b => {{ }};
+                Assert.That(() => action(true), ↓{constraint});");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
     }
 }

--- a/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
@@ -284,14 +284,14 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
 
         [Test]
-        public void NoDiagnosticWhenActualAndExpectedTypesAreSameWithFuncActualValue()
+        public void AnalyzeWhenActualAndExpectedTypesAreSameWithFuncActualValue()
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 Func<string> actual = () => """";
                 var expected = """";
-                Assert.That(actual, Is.SameAs(expected));");
+                Assert.That(actual, Is.SameAs(↓expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -102,6 +102,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfSubPathConstraint = "NUnit.Framework.Constraints.SubPathConstraint";
         public const string FullNameOfSubstringConstraint = "NUnit.Framework.Constraints.SubstringConstraint";
         public const string FullNameOfContainsConstraint = "NUnit.Framework.Constraints.ContainsConstraint";
+        public const string FullNameOfActualValueDelegate = "NUnit.Framework.Constraints.ActualValueDelegate`1";
 
         public const string NameOfTestCaseAttribute = "TestCaseAttribute";
         public const string NameOfTestCaseSourceAttribute = "TestCaseSourceAttribute";

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -103,6 +103,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfSubstringConstraint = "NUnit.Framework.Constraints.SubstringConstraint";
         public const string FullNameOfContainsConstraint = "NUnit.Framework.Constraints.ContainsConstraint";
         public const string FullNameOfActualValueDelegate = "NUnit.Framework.Constraints.ActualValueDelegate`1";
+        public const string FullNameOfTestDelegate = "NUnit.Framework.TestDelegate";
 
         public const string NameOfTestCaseAttribute = "TestCaseAttribute";
         public const string NameOfTestCaseSourceAttribute = "TestCaseSourceAttribute";

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -39,15 +39,15 @@ namespace NUnit.Analyzers.Helpers
         // Unwrap underlying type from delegate or awaitable.
         public static ITypeSymbol UnwrapActualType(ITypeSymbol actualType)
         {
-            if (actualType is INamedTypeSymbol namedType && namedType.DelegateInvokeMethod != null)
+            if (actualType is INamedTypeSymbol namedType &&
+                namedType.GetFullMetadataName() == NunitFrameworkConstants.FullNameOfActualValueDelegate)
             {
                 ITypeSymbol returnType = namedType.DelegateInvokeMethod.ReturnType;
 
                 if (returnType.IsAwaitable(out ITypeSymbol? awaitReturnType))
                     returnType = awaitReturnType;
 
-                if (returnType.SpecialType != SpecialType.System_Void)
-                    actualType = returnType;
+                return returnType;
             }
 
             return actualType;

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -39,15 +39,19 @@ namespace NUnit.Analyzers.Helpers
         // Unwrap underlying type from delegate or awaitable.
         public static ITypeSymbol UnwrapActualType(ITypeSymbol actualType)
         {
-            if (actualType is INamedTypeSymbol namedType &&
-                namedType.GetFullMetadataName() == NunitFrameworkConstants.FullNameOfActualValueDelegate)
+            if (actualType is INamedTypeSymbol namedType)
             {
-                ITypeSymbol returnType = namedType.DelegateInvokeMethod.ReturnType;
+                var fullTypeName = namedType.GetFullMetadataName();
+                if (fullTypeName == NunitFrameworkConstants.FullNameOfActualValueDelegate ||
+                    fullTypeName == NunitFrameworkConstants.FullNameOfTestDelegate)
+                {
+                    ITypeSymbol returnType = namedType.DelegateInvokeMethod.ReturnType;
 
-                if (returnType.IsAwaitable(out ITypeSymbol? awaitReturnType))
-                    returnType = awaitReturnType;
+                    if (returnType.IsAwaitable(out ITypeSymbol? awaitReturnType))
+                        returnType = awaitReturnType;
 
-                return returnType;
+                    return returnType;
+                }
             }
 
             return actualType;


### PR DESCRIPTION
Fixes #290 

The branch contains two commits, the first addressing the actual issue.

The 2nd commit adds a warning to something that caught me out:

```csharp
Assert.That(() => function(), Is.Not.Null);
Assert.That(() => action(), Is.Not.Null);
```

The two statements look the same, but the first actually calls _function_, but the 2nd does not call _action_.
The last test passes because it compares the delegate with _null_, not the _void_ result of the _action_.

With the 2nd commit, the analyzer will complain about incompatible types.
