### PR TITLE
Fix false positive when TestCaseSource type is in another assembly

### DIFF
--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -141,7 +141,7 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
                 return;
             }
 
-            var symbol = SourceHelpers.GetMember(context, attributeInfo);
+            var symbol = SourceHelpers.GetMember(attributeInfo);
             if (symbol is null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(

--- a/src/nunit.analyzers/ValueSourceUsage/ValueSourceUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ValueSourceUsage/ValueSourceUsageAnalyzer.cs
@@ -85,7 +85,7 @@ namespace NUnit.Analyzers.ValueSourceUsage
                 return;
             }
 
-            var symbol = SourceHelpers.GetMember(context, attributeInfo);
+            var symbol = SourceHelpers.GetMember(attributeInfo);
             if (symbol is null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(


### PR DESCRIPTION
Fixes #304.

Analyzer cannot get source information when referenced type is in separate project.
Interestingly enough, in works in VS (no errors), but fails during build. 
Not sure why.