### PR TITLE
Nunit2041 false positives

### DIFF
--- a/documentation/NUnit2042.md
+++ b/documentation/NUnit2042.md
@@ -1,0 +1,86 @@
+# NUnit2042
+
+## Comparison constraint on object.
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2042
+| Severity | Info
+| Enabled  | True
+| Category | Assertion
+| Code     | [ComparableTypesAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs)
+
+## Description
+
+The comparison constraint might fail as the actual and the expected value might not implement IComparable.
+
+## Motivation
+
+```
+public static void ShouldBeGreaterThan(this object actual, object expected, string? message = null)
+{
+    Assert.That(actual, Is.GreaterThan(expected), message);
+}
+```
+
+In the above function it is assumed that every instance of object is comparable.
+The function works if the types actually are comparable, but will result in NUnit runtime errors if they are not.
+
+## How to fix violations
+
+Change the type to `IComparable`. This way you will get compilation failures
+if called with types that do not implement IComparable.
+A similar solution can be created which works for types implementing the generic `IComparable<T>`.
+
+```
+public static void ShouldBeGreaterThan(this IComparable actual, IComparable expected, string? message = null)
+{
+    Assert.That(actual, Is.GreaterThan(expected), message);
+}
+
+public static void ShouldBeGreaterThan<T>(this T actual, T expected, string? message = null)
+    where T : IComparable<T>
+{
+    Assert.That(actual, Is.GreaterThan(expected), message);
+}
+
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via .editorconfig file
+
+```ini
+# NUnit2042: Comparison constraint on object.
+dotnet_diagnostic.NUnit2042.severity = chosenSeverity
+```
+
+where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, or `error`.
+
+### Via #pragma directive
+
+```csharp
+#pragma warning disable NUnit2042 // Comparison constraint on object.
+Code violating the rule here
+#pragma warning restore NUnit2042 // Comparison constraint on object.
+```
+
+Or put this at the top of the file to disable all instances.
+
+```csharp
+#pragma warning disable NUnit2042 // Comparison constraint on object.
+```
+
+### Via attribute `[SuppressMessage]`
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion",
+    "NUnit2042:Comparison constraint on object.",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -95,3 +95,4 @@ Rules which improve assertions in the test code.
 | [NUnit2039](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2039.md) | Consider using Assert.That(actual, Is.Not.InstanceOf(expected)) instead of Assert.IsNotInstanceOf(expected, actual). | :white_check_mark: | :information_source: | :white_check_mark: |
 | [NUnit2040](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2040.md) | Non-reference types for SameAs constraint. | :white_check_mark: | :exclamation: | :white_check_mark: |
 | [NUnit2041](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2041.md) | Incompatible types for comparison constraint. | :white_check_mark: | :exclamation: | :x: |
+| [NUnit2042](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2042.md) | Comparison constraint on object. | :white_check_mark: | :information_source: | :x: |

--- a/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
@@ -399,6 +399,33 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
+        public void AnalyzeWhenTypeImplementsComparableToOtherTypeProvided()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+                class A : IComparable<A>, IComparable<double>
+                {
+                    public int CompareTo(A other) => 0;
+                    public int CompareTo(double other) => 0;
+                }
+
+                class TestClass
+                {
+                    [Test]
+                    public void TestMethod()
+                    {
+                        var actual = new A();
+                        double expected = 123.4;
+                        Assert.That(actual, Is.LessThanOrEqualTo(expected));
+                        // Even though an 'int' is implicit convertible to a 'double', NUnit is not doing this.
+                        int implicitConversion = 567;
+                        Assert.That(actual, Is.LessThanOrEqualTo(↓implicitConversion));
+                    }
+                }");
+
+            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenDifferentNonGenericComparableTypesProvided()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"

--- a/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
@@ -249,6 +249,44 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
+        public void NoDiagnosticForGenericWithIComparableConstraint()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public static class LightWeightAssert
+            {
+                public static void Less<T>(T value, T threshold)
+                    where T : IComparable
+                {
+                    if (value.CompareTo(threshold) >= 0)
+                    {
+                        Assert.That(value, Is.LessThan(threshold));
+                    }
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticForGenericWithIComparableTConstraint()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public static class LightWeightAssert
+            {
+                public static void Less<T>(T value, T threshold)
+                    where T : IComparable<T>
+                {
+                    if (value.CompareTo(threshold) >= 0)
+                    {
+                        Assert.That(value, Is.LessThan(threshold));
+                    }
+                }
+            }");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void NoDiagnosticWhenCustomComparerProvided()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"

--- a/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
@@ -27,6 +27,45 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
 
         [Test]
+        public void AnalyzeWhenObjectTypesProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                @"
+        object o = 0;
+        Assert.That(o, Is.LessThan(↓1));
+        ");
+
+            AnalyzerAssert.Diagnostics(analyzer,
+                ExpectedDiagnostic.Create(AnalyzerIdentifiers.ComparableOnObject), testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticsWhenIComparableTypesProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                @"
+        IComparable smallValue = 0;
+        IComparable bigValue = 9;
+        Assert.That(smallValue, Is.LessThan(bigValue));
+        ");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void NoDiagnosticsWhenGenericIComparableTypesProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                @"
+        IComparable<int> smallValue = 0;
+        int bigValue = 9;
+        Assert.That(smallValue, Is.LessThan(bigValue));
+        ");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenNonComparableTypesProvidedWithLambdaActualValue()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"

--- a/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
+++ b/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -118,7 +119,7 @@ namespace NUnit.Analyzers.ComparableTypes
 
             // NUnit doesn't demand that IComparable is for the same type.
             // But MS does: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable.compareto?view=netcore-3.1
-            if (actualType == expectedType && IsIComparable(actualType))
+            if (actualType.Equals(expectedType) && IsIComparable(actualType))
                 return true;
 
             return false;

--- a/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
+++ b/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
@@ -106,12 +106,15 @@ namespace NUnit.Analyzers.ComparableTypes
 
         private static bool CanCompare(ITypeSymbol actualType, ITypeSymbol expectedType, Compilation compilation)
         {
-            var conversion = compilation.ClassifyConversion(actualType, expectedType);
-            if (conversion.IsNumeric)
-                return true;
-
             if (IsIComparable(actualType, expectedType) || IsIComparable(expectedType, actualType))
                 return true;
+
+            var conversion = compilation.ClassifyConversion(actualType, expectedType);
+            if (conversion.IsNumeric)
+            {
+                // Shortcut numerics as per NUnitComparer
+                return true;
+            }
 
             // NUnit doesn't demand that IComparable is for the same type.
             // But MS does: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable.compareto?view=netcore-3.1

--- a/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
+++ b/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
@@ -123,10 +123,16 @@ namespace NUnit.Analyzers.ComparableTypes
 
         private static bool IsIComparable(ITypeSymbol typeSymbol, ITypeSymbol comparableTypeArguments)
         {
-            const string IComparable = "System.IComparable`1";
+            const string iComparable = "System.IComparable`1";
+
+            if (typeSymbol is ITypeParameterSymbol typeParameterSymbol)
+            {
+                var constraints = typeParameterSymbol.ConstraintTypes;
+                return constraints.Any(t => IsIComparable(t, comparableTypeArguments));
+            }
 
             if (typeSymbol.TypeKind == TypeKind.Interface &&
-                typeSymbol.GetFullMetadataName() == IComparable)
+                typeSymbol.GetFullMetadataName() == iComparable)
             {
                 if (((INamedTypeSymbol)typeSymbol).TypeArguments[0].Equals(comparableTypeArguments))
                 {
@@ -136,7 +142,7 @@ namespace NUnit.Analyzers.ComparableTypes
 
             if (typeSymbol.AllInterfaces.Any(i => i.TypeArguments.Length == 1
                 && i.TypeArguments[0].Equals(comparableTypeArguments)
-                && i.GetFullMetadataName() == IComparable))
+                && i.GetFullMetadataName() == iComparable))
             {
                 return true;
             }
@@ -148,10 +154,16 @@ namespace NUnit.Analyzers.ComparableTypes
 
         private static bool IsIComparable(ITypeSymbol typeSymbol)
         {
-            const string IComparable = "System.IComparable";
+            const string iComparable = "System.IComparable";
 
-            return (typeSymbol.TypeKind == TypeKind.Interface && typeSymbol.GetFullMetadataName() == IComparable) ||
-                typeSymbol.AllInterfaces.Any(i => i.TypeArguments.Length == 0 && i.GetFullMetadataName() == IComparable);
+            if (typeSymbol is ITypeParameterSymbol typeParameterSymbol)
+            {
+                var constraints = typeParameterSymbol.ConstraintTypes;
+                return constraints.Any(t => IsIComparable(t));
+            }
+
+            return (typeSymbol.TypeKind == TypeKind.Interface && typeSymbol.GetFullMetadataName() == iComparable) ||
+                typeSymbol.AllInterfaces.Any(i => i.TypeArguments.Length == 0 && i.GetFullMetadataName() == iComparable);
         }
 
         private static bool HasIncompatiblePrefixes(ConstraintExpressionPart constraintPartExpression)

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -78,6 +78,7 @@ namespace NUnit.Analyzers.Constants
         internal const string IsNotInstanceOfUsage = "NUnit2039";
         internal const string SameAsOnValueTypes = "NUnit2040";
         internal const string ComparableTypes = "NUnit2041";
+        internal const string ComparableOnObject = "NUnit2042";
 
         #endregion Assertion
     }

--- a/src/nunit.analyzers/Constants/ComparableOnObjectConstants.cs
+++ b/src/nunit.analyzers/Constants/ComparableOnObjectConstants.cs
@@ -1,0 +1,9 @@
+﻿namespace NUnit.Analyzers.Constants
+{
+    internal static class ComparableOnObjectConstants
+    {
+        internal const string Title = "Comparison constraint on object.";
+        internal const string Message = "The comparison constraint might fail as the actual and the expected value might not implement IComparable.";
+        internal const string Description = "The comparison constraint might fail as the actual and the expected value might not implement IComparable.";
+    }
+}


### PR DESCRIPTION
Fixes #300 

Adds new rule NUnit2042 with severity information when one of the variables is an object.
Adds code to recognize generic parameter contraints.
