### PR TITLE
NonTestMethodAccessibilityLevelAnalyzer: Detect Test attributes from overridden methods.

### DIFF
--- a/documentation/NUnit1028.md
+++ b/documentation/NUnit1028.md
@@ -13,6 +13,7 @@
 ## Description
 
 A fixture should not contain any public non-test methods.
+There are two exceptions: A public constructor and an `IDisposable.Dispose` method implementation.
 
 ## Motivation
 

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
@@ -81,5 +81,27 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         {modifiers} void ↓AssertMethod() {{ }}");
             AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
+
+        [TestCaseSource(nameof(TestMethodRelatedAttributes))]
+        public void AnalyzeWhenTestMethodIsPublicAndOverridden(string attribute)
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
+        public class BaseTestClass
+        {{
+            [{attribute}]
+            public virtual void TestMethod() {{ }}
+        }}
+
+        public sealed class DerivedTestClass : BaseTestClass
+        {{
+            public override void TestMethod() {{ }}
+
+            [Test]
+            public void OtherTestMethod() {{ }}
+        }}
+        ");
+
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
@@ -103,5 +103,74 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
 
             AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
         }
+
+        [Test]
+        public void AnalyzeConstructor()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+        public sealed class TestClass
+        {
+            public TestClass() {}
+
+            [Test]
+            public void TestMethod() { }
+        }
+        ");
+
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenMethodIsExplicitDispose()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+        public sealed class TestClass : IDisposable
+        {
+            [Test]
+            public void TestMethod() { }
+
+            void IDisposable.Dispose() { }
+        }
+        ");
+
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenMethodIsDispose()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+        public sealed class TestClass : IDisposable
+        {
+            [Test]
+            public void TestMethod() { }
+
+            public void Dispose() { }
+        }
+        ");
+
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenMethodIsDisposeOverride()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+        public class BaseClass : IDisposable
+        {
+            public virtual void Dispose() { }
+        }
+
+        public sealed class DerivedClass : BaseClass
+        {
+            [Test]
+            public void TestMethod() { }
+
+            public override void Dispose() { }
+        }
+        ");
+
+            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
@@ -62,6 +62,12 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
 
         private static bool IsTestRelatedMethod(Compilation compilation, IMethodSymbol methodSymbol)
         {
+            return HasTestRelatedAttributes(compilation, methodSymbol) ||
+                (methodSymbol.IsOverride && IsTestRelatedMethod(compilation, methodSymbol.OverriddenMethod));
+        }
+
+        private static bool HasTestRelatedAttributes(Compilation compilation, IMethodSymbol methodSymbol)
+        {
             return methodSymbol.GetAttributes().Any(
                 a => a.IsSetUpOrTearDownMethodAttribute(compilation) || a.IsTestMethodAttribute(compilation));
         }

--- a/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
+++ b/src/nunit.analyzers/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -45,7 +46,7 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
             {
                 if (IsTestRelatedMethod(context.Compilation, method))
                     hasTestMethods = true;
-                else if (IsPublicOrInternalMethod(method))
+                else if (IsPublicOrInternalMethod(method) && !IsDisposeMethod(method))
                     publicNonTestMethods.Add(method);
             }
 
@@ -84,6 +85,16 @@ namespace NUnit.Analyzers.NonTestMethodAccessibilityLevel
                 default:
                     return false;
             }
+        }
+
+        private static bool IsDisposeMethod(IMethodSymbol method)
+        {
+            if (method.IsOverride)
+            {
+                return IsDisposeMethod(method.OverriddenMethod);
+            }
+
+            return method.IsInterfaceImplementation("System.IDisposable");
         }
     }
 }


### PR DESCRIPTION
Fixes #308 
Fixes #311 

If a method is an override, check the attributes on the overridden method.