### PR TITLE
Fix PropertyAnalyzer for combined asserts with All/Some operators

### DIFF
--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
@@ -188,6 +188,23 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         }
 
         [Test]
+        public void ValidWhenMultiplePartsCombinedWithCollectionOperatorPrefix()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                var actual = new[]
+                {
+                    new
+                    {
+                        Foo = ""Fuzz"",
+                        Bar = ""Buzz""
+                    }
+                };
+                Assert.That(actual, Has.Some.With.Property(""Foo"").And.Property(""Bar""));");
+
+            AnalyzerAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void ValidWhenUsedWithThrowsConstraint()
         {
             var testCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
+++ b/src/nunit.analyzers/MissingProperty/MissingPropertyAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.Operations;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
 using NUnit.Analyzers.Helpers;
+using NUnit.Analyzers.Operations;
 
 namespace NUnit.Analyzers.MissingProperty
 {
@@ -49,6 +50,9 @@ namespace NUnit.Analyzers.MissingProperty
 
                 if (constraintPart.Prefixes.Count == 0)
                     continue;
+
+                if (HasUnsupportedPrefixes(constraintPart))
+                    return;
 
                 // Only first prefix supported (as preceding prefixes might change validated type)
                 var prefix = constraintPart.Prefixes.First();
@@ -101,6 +105,16 @@ namespace NUnit.Analyzers.MissingProperty
             }
 
             return null;
+        }
+
+        private static bool HasUnsupportedPrefixes(ConstraintExpressionPart constraintPart)
+        {
+            // Disable analyzer if part has constraint prefixes other than property operators or Not operator,
+            // as they might change validated type and lead to false positives (e.g. All/Some operators).
+            return constraintPart.GetPrefixesNames().Any(prefix =>
+                !implicitPropertyConstraints.Contains(prefix)
+                && prefix != NunitFrameworkConstants.NameOfHasProperty
+                && prefix != NunitFrameworkConstants.NameOfIsNot);
         }
     }
 }


### PR DESCRIPTION
Fixes #306
(Or not, not sure).

Added checks for other operators, which might lead to false positive (e.g. All/Some)