### PR TITLE
Move to latest GuOrg.Roslyn.Assert package

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                 ""message"",
                 Guid.NewGuid());");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.Not.EqualTo(2d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.Not.EqualTo(2d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.Not.EqualTo(2d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.Not.SameAs(expected));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.Not.SameAs(expected), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.Not.SameAs(expected), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.SameAs(expected));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.SameAs(expected), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.SameAs(expected), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzerTests.cs
@@ -98,7 +98,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             Assert.That(true, Is.True);
         }
     }");
-            AnalyzerAssert.Valid<ClassicModelAssertUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             public static bool AreEqual(int a, int b) => false;
         }
     }");
-            AnalyzerAssert.Valid<ClassicModelAssertUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsTrue(true);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.True(true);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -165,7 +165,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsFalse(false);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -181,7 +181,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.False(false);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreEqual(2, 2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -213,7 +213,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreEqual(2d, 2d, 0.0000001d);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -229,7 +229,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreNotEqual(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -245,7 +245,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreSame(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -262,7 +262,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNull(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.Null(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -296,7 +296,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNotNull(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -313,7 +313,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.NotNull(obj);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -324,7 +324,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
     {
         private static readonly string fullTypeName = typeof(string).GetType().FullName;
     }");
-            AnalyzerAssert.Valid<ClassicModelAssertUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -340,7 +340,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.Greater(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -356,7 +356,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.GreaterOrEqual(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -372,7 +372,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.Less(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -388,7 +388,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.LessOrEqual(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -404,7 +404,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.AreNotSame(2, 3);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -420,7 +420,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.Zero(2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -436,7 +436,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.NotZero(2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -452,7 +452,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNaN(2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -468,7 +468,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsEmpty(Array.Empty<object>());
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -484,7 +484,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNotEmpty(Array.Empty<object>());
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -497,10 +497,10 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
     {
         public void Test()
         {
-            ↓Assert.Contains(this, Array.Empty<object>()));
+            ↓Assert.Contains(this, Array.Empty<object>());
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -516,7 +516,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsInstanceOf(typeof(int), 2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -532,7 +532,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsInstanceOf<int>(2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -548,7 +548,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNotInstanceOf(typeof(int), 2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -564,7 +564,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             ↓Assert.IsNotInstanceOf<int>(2);
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Does.Contain(instance));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Does.Contain(instance), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Does.Contain(instance), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.GreaterThan(3d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.GreaterThan(3d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.GreaterThan(3d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                 ""message"",
                 Guid.NewGuid());");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float y = 2;
             Assert.That((float)x, Is.GreaterThan(y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyFloat y = 2;
             Assert.That(x, Is.GreaterThan((float)y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.GreaterThanOrEqualTo(3d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.GreaterThanOrEqualTo(3d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.GreaterThanOrEqualTo(3d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                 ""message"",
                 Guid.NewGuid());");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float y = 2;
             Assert.That((float)x, Is.GreaterThanOrEqualTo(y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyFloat y = 2;
             Assert.That(x, Is.GreaterThanOrEqualTo((float)y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Is.Empty);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Is.Empty, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Is.Empty, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyString s = string.Empty;
             Assert.That((string)s, Is.Empty);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(false, Is.False);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(false, Is.False, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(false, Is.False, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
@@ -116,7 +116,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyBool x = false;
             Assert.That((bool)x, Is.False);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.InstanceOf(expected));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.InstanceOf(expected), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.InstanceOf(expected), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 Assert.That(actual, Is.InstanceOf<int>());
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 public T Value { get; }
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 public T Value { get; }
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 Assert.That(actual, Is.InstanceOf<int>(), ""message"");
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 Assert.That(actual, Is.InstanceOf<int>(), ""message"", Guid.NewGuid());
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.NaN);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.NaN, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.NaN, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Is.Not.Empty);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Is.Not.Empty, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(collection, Is.Not.Empty, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyString s = ""Hello NUnit"";
             Assert.That((string)s, Is.Not.Empty);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.Not.InstanceOf(expected));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.Not.InstanceOf(expected), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(actual, Is.Not.InstanceOf(expected), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 Assert.That(actual, Is.Not.InstanceOf<int>());
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 public T Value { get; }
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 public T Value { get; }
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 Assert.That(actual, Is.Not.InstanceOf<int>(), ""message"");
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
                 Assert.That(actual, Is.Not.InstanceOf<int>(), ""message"", Guid.NewGuid());
             }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             object obj = null;
             Assert.That(obj, Is.Not.Null);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             object obj = null;
             Assert.That(obj, Is.Not.Null, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             object obj = null;
             Assert.That(obj, Is.Not.Null, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             object obj = null;
             Assert.That(obj, Is.Null);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             object obj = null;
             Assert.That(obj, Is.Null, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             object obj = null;
             Assert.That(obj, Is.Null, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(true, Is.True);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(true, Is.True, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(true, Is.True, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
@@ -116,7 +116,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyBool x = true;
             Assert.That((bool)x, Is.True);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(true);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: CodeFixConstants.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
         }
 
@@ -59,7 +59,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(true, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: CodeFixConstants.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
         }
 
@@ -79,7 +79,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(true, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: CodeFixConstants.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.LessThan(3d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.LessThan(3d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.LessThan(3d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                 ""message"",
                 Guid.NewGuid());");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float y = 2;
             Assert.That((float)x, Is.LessThan(y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyFloat y = 2;
             Assert.That(x, Is.LessThan((float)y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.LessThanOrEqualTo(3d));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.LessThanOrEqualTo(3d), ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(2d, Is.LessThanOrEqualTo(3d), ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
                 ""message"",
                 Guid.NewGuid());");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float y = 2;
             Assert.That((float)x, Is.LessThanOrEqualTo(y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             MyFloat y = 2;
             Assert.That(x, Is.LessThanOrEqualTo((float)y));
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.Not.Zero);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.Not.Zero, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.Not.Zero, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.Zero);
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.Zero, ""message"");
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
             Assert.That(expr, Is.Zero, ""message"", Guid.NewGuid());
         }");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.TransformToConstraintModelDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ComparableTypes/ComparableTypesAnalyzerTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(1, Is.LessThan(↓\"1\"));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -35,7 +35,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         Assert.That(o, Is.LessThan(↓1));
         ");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 ExpectedDiagnostic.Create(AnalyzerIdentifiers.ComparableOnObject), testCode);
         }
 
@@ -49,7 +49,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         Assert.That(smallValue, Is.LessThan(bigValue));
         ");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         Assert.That(smallValue, Is.LessThan(bigValue));
         ");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                 {expectedType} expected = 1;
                 Assert.That(actual, Is.LessThanOrEqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -220,7 +220,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -245,7 +245,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -264,7 +264,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -283,7 +283,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -308,7 +308,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
         }
     }", "using System.Collections;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -319,7 +319,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
             int? expected = 5;
             Assert.That(actual, Is.GreaterThan(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -330,7 +330,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
             double expected = 5.0;
             Assert.That(actual, Is.GreaterThan(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -341,7 +341,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
             double expected = 5.0;
             Assert.That(() => actual, Is.GreaterThan(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -350,13 +350,13 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
             var testCode = TestUtility.WrapInTestMethod($@"
                 Assert.That(5, Is.GreaterThan(4) & Is.LessThan(↓""6""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
         public void AnalyzeWhenFirstConstraintExpressionUsesComparer()
         {
-            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
                 class AsInt32Comparer : IComparer
                 {
                     public int Compare(object x, object y) => Convert.ToInt32(x).CompareTo(Convert.ToInt32(y));
@@ -368,7 +368,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     Assert.That(5, Is.GreaterThan(""4"").Using(new AsInt32Comparer()) & Is.LessThan(↓""6""));
                 }", "using System.Collections;");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -395,7 +395,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -422,7 +422,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -449,7 +449,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -472,7 +472,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -498,7 +498,7 @@ namespace NUnit.Analyzers.Tests.ComparableTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.AreEqual(expected, ↓1);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -35,7 +35,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.AreEqual(actual: ↓1, expected: expected);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.That(↓(2 + 3) * 1024, Is.Positive);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.AreEqual(expected, ↓actual);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.AreEqual(actual: ↓actual, expected: expected);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.That(↓actual, Is.EqualTo(expected));
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.AreEqual(actual, string.Empty);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.That(string.Empty, Is.EqualTo(actual));
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -170,7 +170,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -188,7 +188,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -224,7 +224,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -260,7 +260,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -277,7 +277,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -294,7 +294,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -309,7 +309,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 }
             }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageCodeFixTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.{classicAssertMethod}(1, expected);
                 }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: CodeFixConstants.SwapArgumentsDescription);
         }
 
@@ -56,7 +56,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.AreEqual(actual: expected, expected: 1);
                 }");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: CodeFixConstants.SwapArgumentsDescription);
         }
 
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.That(expected, Is.{isConstraint}(""a""));
                 }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: CodeFixConstants.SwapArgumentsDescription);
         }
 
@@ -97,7 +97,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.That(↓4, Is.{isConstraint}(expected));
                 }}");
 
-            AnalyzerAssert.NoFix(analyzer, fix, expectedDiagnostic, code);
+            RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, code);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                     Assert.That(↓4, Is.Not.EqualTo(3).And.Not.EqualTo(5));
                 }}");
 
-            AnalyzerAssert.NoFix(analyzer, fix, expectedDiagnostic, code);
+            RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, code);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual == ""abc"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual != ""bcd"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual.Equals(""abc""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓!actual.Equals(""bcd""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓Equals(actual,""abc""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -72,9 +72,9 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = ""abc"";
-                Assert.That(↓!Equals(actual,""abc"")));");
+                Assert.That(↓!Equals(actual,""abc""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual.Equals(""abc""), Is.True);");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual.Equals(""abc""), Is.False);");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.True(↓actual.Equals(""abc""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.False(↓actual.Equals(""bcd""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.IsTrue(↓actual.Equals(""abc""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.IsFalse(↓actual.Equals(""bcd""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.IsFalse(↓!actual.Equals(""bcd""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual == ""abc"", ""Assertion message"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(↓actual.Equals(""abc""), Is.True, ""Assertion message"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.True(↓actual.Equals(""abc""), ""Assertion message"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.False(↓actual.Equals(""bcd""), ""Assertion message"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, isNotEqualToDiagnostic, testCode);
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""bcd""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -204,7 +204,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual.Contains(""bc""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""), ""Assertion message"");");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""), ""Assertion message"");");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -220,7 +220,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.EqualTo(""abc""), ""Assertion message"");");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var actual = ""abc"";
                 Assert.That(actual, Is.Not.EqualTo(""bcd""), ""Assertion message"");");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(actual, Is.Not.EqualTo(""bcd""),
                     ""Assertion message from new line"");");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, equalConstraintDiagnostic, code, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageAnalyzerTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(↓new List<int> {1, 2, 3}.Contains(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.IsTrue(↓new List<int> {1, 2, 3}.Contains(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.IsFalse(↓new List<int> {1, 2, 3}.Contains(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, doesNotContainDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, doesNotContainDiagnostic, testCode);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(↓new[] {1, 2, 3}.Contains(1));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.IsTrue(↓new[] {1, 2, 3}.Contains(1));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, doesContainDiagnostic, testCode);
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.IsFalse(↓new[] {1, 2, 3}.Contains(1));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.Diagnostics(analyzer, doesNotContainDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, doesNotContainDiagnostic, testCode);
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new List<int> { 1, 2, 3 }.Remove(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(""1, 2, 3"".Contains(""1""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/SomeItemsConstraintUsageCodeFixTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new List<int> {1, 2, 3}, Does.Contain(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new List<int> {1, 2, 3}, Does.Contain(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new List<int> {1, 2, 3}, Does.Not.Contain(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, doesNotContainDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, doesNotContainDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new[] {1, 2, 3}, Does.Contain(1));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new[] {1, 2, 3}, Does.Contain(1));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, doesContainDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 Assert.That(new[] {1, 2, 3}, Does.Not.Contain(1));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, doesNotContainDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, doesNotContainDiagnostic, testCode, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageAnalyzerTests.cs
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
@@ -52,7 +52,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -72,7 +72,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -92,7 +92,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var diagnostic = ExpectedDiagnostic.Create(analyzerId,
                 string.Format(CultureInfo.InvariantCulture, StringConstraintUsageConstants.Message, suggestedConstraint));
-            AnalyzerAssert.Diagnostics(analyzer, diagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, diagnostic, testCode);
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var testCode = TestUtility.WrapInTestMethod(@"Assert.That(""abc"".IsNormalized());");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.That(new System.Collections.Generic.List<string> { ""a"",""ab""}.Contains(""ab""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/StringConstraintUsageCodeFixTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
@@ -43,7 +43,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
@@ -53,7 +53,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(PositiveAssertData))]
@@ -63,7 +63,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -73,7 +73,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
 
         [TestCaseSource(nameof(NegativeAssertData))]
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
 
             var fixedCode = TestUtility.WrapInTestMethod($@"Assert.That(""abc"", {suggestedConstraint}(""ab""));");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, ExpectedDiagnostic.Create(analyzerId), code, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(123, ↓Does.Contain(\"1\"));");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with an actual value of type 'int'"),
                 testCode);
         }
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
                 var actual = new[] {1, 2, 3};
                 Assert.That(actual, ↓Does.Contain(""1""));");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with an actual value of type 'int[]'"),
                 testCode);
         }
@@ -41,7 +41,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(Task.FromResult(\"1234\"), ↓Does.Contain(\"1\"));");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 expectedDiagnostic.WithMessage("The ContainsConstraint cannot be used with an actual value of type 'Task<string>'"),
                 testCode);
         }
@@ -52,7 +52,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(\"123\", Does.Contain(\"1\"));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
                 var actual = new[] {""1"", ""2"", ""3""};
                 Assert.That(actual, Does.Contain(""1""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(new [] {\"Aa\", \"Ba\", \"Ca\"}, Has.All.Contains(\"a\"));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace NUnit.Analyzers.Tests.ContainsConstraintWrongActualType
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(() => \"1234\", Does.Contain(\"1\"));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(1, Is.EqualTo(↓\"1\"));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.AreEqual(↓\"1\", 1);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(↓expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(↓expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(↓expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = Tuple.Create(""1"", 2);
                 Assert.That(actual, Is.EqualTo(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = (""1"", 2);
                 Assert.That(actual, Is.EqualTo(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -161,9 +161,10 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                         Assert.That(actual, Is.EqualTo(↓expected));
                     }
                 }",
-                additionalUsings: "using System.Collections.Generic;");
+                additionalUsings: @"using System.Collections;
+using System.Collections.Generic;");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -184,7 +185,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -195,7 +196,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var expected = ""A"";
             Assert.That(actual, Is.EqualTo(↓expected).IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -206,7 +207,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var expected = ""A"";
             Assert.That(actual, Is.EqualTo(↓expected), ""Assertion Message"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -227,7 +228,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -248,7 +249,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -268,7 +269,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -289,7 +290,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -310,7 +311,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -331,7 +332,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -342,7 +343,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -353,7 +354,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             string expected = ""5"";
             Assert.That(actual, Is.EqualTo(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -364,7 +365,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -375,7 +376,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.Not.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -385,7 +386,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(() => """", Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -396,7 +397,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -407,7 +408,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -428,7 +429,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -449,7 +450,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -462,7 +463,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 {expectedType} expected = 1;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -473,7 +474,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = (int)actual;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -493,7 +494,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -513,7 +514,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -524,7 +525,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = new System.IO.MemoryStream();
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -536,7 +537,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -548,7 +549,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -560,7 +561,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -572,7 +573,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Assert.That(actual, Is.EqualTo(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -583,7 +584,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = Tuple.Create(""1"", 2);
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -594,7 +595,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = (""1"", 2);
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -619,7 +620,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -644,7 +645,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                     }
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -655,7 +656,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -666,7 +667,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 dynamic expected = 2;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -687,7 +688,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -708,7 +709,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -718,7 +719,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var actual = ""abc"";
             Assert.That(actual, Has.Property(""Length"").EqualTo(3));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -729,7 +730,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             int expected = 5;
             Assert.That(actual, Is.EqualTo(5));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -740,7 +741,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             int? expected = 5;
             Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -751,7 +752,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             double expected = 5.0;
             Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -761,7 +762,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             bool shouldBePresent = true;
             Assert.That(new[] { 1, 2, 3 }, (shouldBePresent ? Has.Some : Has.None).EqualTo(2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -772,7 +773,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var constraintModifier = (shouldBePresent ? Has.Some : Has.None);
             Assert.That(new[] { 1, 2, 3 }, constraintModifier.EqualTo(2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -782,7 +783,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 object actual = 3;
                 Assert.That(actual, Is.EqualTo(3));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -793,7 +794,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = HaveNoIdea();
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            RoslynAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -804,7 +805,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = 3;
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            RoslynAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -815,7 +816,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = new[] { 3 };
                 Assert.That(actual, Is.EqualTo(expected));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            RoslynAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -826,7 +827,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var expected = HaveNoIdea();
                 Assert.That(actual, Is.EqualTo(new[] { expected }));");
 
-            AnalyzerAssert.NoAnalyzerDiagnostics(analyzer, testCode);
+            RoslynAssert.NoAnalyzerDiagnostics(analyzer, testCode);
         }
 
         [Test]
@@ -836,7 +837,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var actual = new[] { 1,2,2,1 };
                 Assert.That(actual, Has.All.EqualTo(1).Or.EqualTo(2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -847,7 +848,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 var y = x;
                 Assert.That(y, Is.EqualTo(x));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -857,7 +858,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Task wait = Task.CompletedTask;
                 Assert.That(await Task.WhenAny(wait).ConfigureAwait(false), Is.EqualTo(wait));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -868,7 +869,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
                 Task task2 = Task.CompletedTask;
                 Assert.That(task1, Is.SameAs(task2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -877,7 +878,7 @@ namespace NUnit.Analyzers.Tests.EqualToIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod($@"
                 Assert.That(5, Is.Not.EqualTo(4) & Is.Not.EqualTo(↓""6""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/IgnoreCaseUsage/IgnoreCaseUsageAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(1, Is.EqualTo(1).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase(nameof(Is.EqualTo))]
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = new[] {{3,2,1}};
                 Assert.That(actual, Is.{constraintMethod}(expected).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 };
                 Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = (1, 2, false);
                 Assert.That(actual, Is.EqualTo((1, 2, false)).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = System.Tuple.Create(1, 2);
                 Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.Generic.KeyValuePair<bool, int>(true, 1);
                 Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                     Assert.That(actual, Is.EqualTo(expected).↓IgnoreCase);
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(1, Is.EqualTo(1).↓IgnoreCase | Is.EqualTo(true).↓IgnoreCase);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
             var testCode = TestUtility.WrapInTestMethod(@"
                 Assert.That(""A"", Is.EqualTo(""a"").IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase(nameof(Is.EqualTo))]
@@ -128,7 +128,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = new[] {{""A"",""C"",""B""}};
                 Assert.That(actual, Is.{constraintMethod}(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 System.Collections.IEnumerable expected = new[] {""A"",""C"",""B""};
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 };
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = (""a"", 2, false);
                 Assert.That(actual, Is.EqualTo((""A"", 2, false)).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = System.Tuple.Create(1, ""A"");
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.Generic.KeyValuePair<string, int>(""A"", 1);
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.Generic.KeyValuePair<int, string>(1, ""A"");
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var actual = new System.Collections.DictionaryEntry(1, ""A"");
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -218,7 +218,7 @@ namespace NUnit.Analyzers.Tests.IgnoreCaseUsage
                 var expected = (1, new[] { new[] { ""A"" } });
                 Assert.That(actual, Is.EqualTo(expected).IgnoreCase);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyAnalyzerTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, ↓Has.Count.EqualTo(2));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = new System.Collections.Generic.List<int> {1, 2, 3};
                 Assert.That(actual, ↓Has.Length.EqualTo(2));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, ↓Has.Message.EqualTo(2),
                     ""Nope, we can't!"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = 12345;
                 Assert.That(actual, ↓Has.InnerException.TypeOf<InvalidCastException>());");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = 12345;
                 Assert.That(actual, ↓Has.Property(""Whatever"").EqualTo(1));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 int getActual() => 12345;
                 Assert.That(getActual, ↓Has.Property(""Whatever"").EqualTo(1));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, Has.Count.EqualTo(2));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, Has.Count.EqualTo(2));",
                 additionalUsings: "using System.Linq; using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = new[] {1, 2, 3};
                 Assert.That(actual, Has.Length.EqualTo(3));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = ""ABCDefgh"";
                 Assert.That(actual, Has.Length.EqualTo(8));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = new Exception(""SomeMessage"");
                 Assert.That(actual, Has.Message.EqualTo(""SomeMessage""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = new Exception(""SomeMessage"", innerException);
                 Assert.That(actual, Has.InnerException.Not.Null);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = DateTime.UtcNow;
                 Assert.That(actual, Has.Property(""Ticks"").GreaterThan(0));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 string getActual() => ""12345"";
                 Assert.That(getActual, Has.Property(""Length"").EqualTo(5));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 string actual = ""321"";
                 Assert.That(actual, Has.No.Property(""Whatever""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 int actual = 321;
                 Assert.That(actual, Has.No.Count);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 var actual = new { Foo = new { Bar = ""Baz"" } };
                 Assert.That(actual, Has.Property(""Foo"").With.Property(""Bar"").EqualTo(""Baz""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -201,7 +201,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 };
                 Assert.That(actual, Has.Some.With.Property(""Foo"").And.Property(""Bar""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 string getActual() => throw new System.Exception(""Oops"");
                 Assert.That(getActual, Throws.Exception.With.Message.EqualTo(""Oops""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/MissingProperty/MissingPropertyCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/MissingProperty/MissingPropertyCodeFixTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(collection, Has.Count.EqualTo(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: string.Format(CultureInfo.InvariantCulture, CodeFixConstants.UsePropertyDescriptionFormat, "Count"));
         }
 
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(collection, Has.Length.EqualTo(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: string.Format(CultureInfo.InvariantCulture, CodeFixConstants.UsePropertyDescriptionFormat, "Length"));
         }
 
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, ↓Has.Length.EqualTo(2));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
+            RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, ↓Has.Count.EqualTo(2));",
                 additionalUsings: "using System.Linq;");
 
-            AnalyzerAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
+            RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -77,9 +77,9 @@ namespace NUnit.Analyzers.Tests.MissingProperty
         {
             var testCode = TestUtility.WrapInTestMethod(@"
                 var actual = ""Can we consider string as message?..."";
-                Assert.That(actual, ↓Has.Message.EqualTo(2);");
+                Assert.That(actual, ↓Has.Message.EqualTo(2));");
 
-            AnalyzerAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
+            RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Analyzers.Tests.MissingProperty
                 Assert.That(actual, ↓Has.Property(""Whatever"").EqualTo(1));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
+            RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelAnalyzerTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         public void AssertMethod() {{ }}");
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         [Test]
         public void TestMethod() {{ AssertMethod(); }}
         private void AssertMethod() {{ }}");
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         [Test]
         public void TestMethod() {{ AssertMethod(); }}
         protected virtual void AssertMethod() {{ }}");
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCaseSource(nameof(TestMethodRelatedAttributes))]
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         public void TestMethod() {{ }}
         [{attribute}]
         public void AuxiliaryMethod() {{ }}");
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCaseSource(nameof(NonPrivateModifiers))]
@@ -79,7 +79,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         [TestCase(1)]
         public void TestMethod(int i) {{ AssertMethod(); }}
         {modifiers} void ↓AssertMethod() {{ }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(TestMethodRelatedAttributes))]
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         }}
         ");
 
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         }
         ");
 
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         }
         ");
 
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         }
         ");
 
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -170,7 +170,7 @@ namespace NUnit.Analyzers.Tests.NonTestMethodAccessibilityLevel
         }
         ");
 
-            AnalyzerAssert.Valid<NonTestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/NonTestMethodAccessibilityLevel/NonTestMethodAccessibilityLevelCodeFixTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         public void TestMethod() {{ AssertMethod(); }}
         {modifiersAfter} void AssertMethod() {{ }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/NullConstraintUsage/NullConstraintUsageAnalyzerTests.cs
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
             var testCode = TestUtility.WrapInTestMethod($@"
                 var actual = default(int);
                 Assert.That(actual, ↓{constraint});");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 var actual = default(int);
                 Assert.That(() => actual, ↓{constraint});");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
             var testCode = TestUtility.WrapInTestMethod($@"
                 Assert.That(() => Task.FromResult(3), ↓{constraint});");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -53,7 +53,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 bool? actual = false;
                 Assert.That(actual, {constraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 var actual = new string[] {{ ""TestString"" }};
                 Assert.That(actual, {constraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -75,7 +75,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 var actual = new string[] {{ ""TestString"" }};
                 Assert.That(() => actual, {constraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                     Assert.That(actual, Has.Property(""RefTypeProp"").Null);
                 }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -105,7 +105,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 var task = Task.CompletedTask;
                 Assert.That(task, {constraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -116,7 +116,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 Action<bool> action = b => {{ }};
                 Assert.That(action, {constraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -127,7 +127,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 Func<bool, bool> function = b => b;
                 Assert.That(function, {constraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("Is.Null")]
@@ -138,7 +138,7 @@ namespace NUnit.Analyzers.Tests.NullConstraintUsage
                 Action<bool> action = b => {{ }};
                 Assert.That(() => action(true), ↓{constraint});");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ParallelizableUsage/ParallelizableUsageAnalyzerTests.cs
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.Tests.ParallelizableUsage
             var testCode = $@"
 using NUnit.Framework;
 [assembly: Parallelizable(ParallelScope.{enumValue})]";
-            AnalyzerAssert.Valid<ParallelizableUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -80,7 +80,7 @@ using NUnit.Framework;
             var testCode = $@"
 using NUnit.Framework;
 [assembly: ↓Parallelizable(ParallelScope.Self)]";
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -93,7 +93,7 @@ using NUnit.Framework;
             var testCode = $@"
 using NUnit.Framework;
 [assembly: ↓Parallelizable()]";
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Theory]
@@ -106,7 +106,7 @@ using NUnit.Framework;
     public sealed class AnalyzeWhenAttributeIsOnClass
     {{
     }}");
-            AnalyzerAssert.Valid<ParallelizableUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -122,7 +122,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Valid<ParallelizableUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [TestCase(ParallelScope.All)]
@@ -144,7 +144,7 @@ using NUnit.Framework;
         {{
         }}
     }}");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -164,7 +164,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(ParallelScopesExceptFixtures))]
@@ -181,7 +181,7 @@ using NUnit.Framework;
         {{
         }}
     }}");
-            AnalyzerAssert.Valid<ParallelizableUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -201,7 +201,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(ParallelScopesExceptFixtures))]
@@ -218,7 +218,7 @@ using NUnit.Framework;
         {{
         }}
     }}");
-            AnalyzerAssert.Valid<ParallelizableUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -238,7 +238,7 @@ using NUnit.Framework;
         {
         }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SameActualExpectedValue/SameActualExpectedValueAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SameActualExpectedValue/SameActualExpectedValueAnalyzerTests.cs
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 Assert.That(str, Is.{constraintMethod}(↓str));");
 
             var message = "The actual and the expected argument is the same 'str'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 Assert.That(str.Trim(), Is.EqualTo(↓str.Trim()));");
 
             var message = "The actual and the expected argument is the same 'str.Trim()'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 var str = ""test"";
                 Assert.That(str, Is.EqualTo(↓str).And.EquivalentTo(↓str));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                     .And.StartsWith(↓str));");
 
             var message = "The actual and the expected argument is the same 'str'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 var str = ""test"";
                 Assert.That(str, Is.EqualTo(↓str) | Is.EquivalentTo(↓str));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                     & Does.Contain(↓str)
                     | Does.StartWith(↓str));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase(nameof(Is.EqualTo))]
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 var str2 = ""test2"";
                 Assert.That(str1, Is.{constraintMethod}(str2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.Tests.SameActualExpectedValue
                 var str = ""test"";
                 Assert.That(str.Trim(), Is.EqualTo(str.TrimEnd()));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzerTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
     class B { }
 
     public class Tests
-    {{
+    {
         [Test]
         public void AnalyzeWhenIncompatibleTypesProvidedWithNegatedAssert()
         {
@@ -173,7 +173,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -226,7 +226,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -237,7 +237,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -248,7 +248,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.AreSame(expected, actual);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.Not.SameAs(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -270,7 +270,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.AreNotSame(expected, actual);");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -280,7 +280,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(() => """", Is.SameAs(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -291,7 +291,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -302,7 +302,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -323,7 +323,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -344,7 +344,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -353,7 +353,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(new string[0], Has.None.SameAs(string.Empty));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -364,7 +364,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 var expected = """";
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -375,7 +375,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
                 dynamic expected = 2;
                 Assert.That(actual, Is.SameAs(expected));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -396,7 +396,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -418,7 +418,7 @@ namespace NUnit.Analyzers.Tests.SameAsIncompatibleTypes
         }
     }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SameAsOnValueTypes/SameAsOnValueTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SameAsOnValueTypes/SameAsOnValueTypesAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(1, Is.SameAs(↓1));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.That(actual, Is.SameAs(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.That(() => expected, Is.SameAs(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.That(Task.FromResult(expected), Is.SameAs(↓expected));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.That(""3"", Is.Not.SameAs(↓3));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.That(↓3, Is.Not.SameAs(""3""));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.That(""3"", Is.SameAs(""3""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
                 Assert.That(actual, Is.SameAs(expected));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.AreSame(↓1, 1);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.AreSame(↓expected, actual);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.AreNotSame(↓3, ""3"");");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.AreNotSame(""3"", ↓3);");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -139,16 +139,16 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
             var testCode = TestUtility.WrapInTestMethod(
                 @"Assert.AreSame(""3"", ""3"");");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
         public void AnalyzeWhenMoreThanOneConstraintExpressionIsUsed()
         {
             var testCode = TestUtility.WrapInTestMethod(
-                @"Assert.That(""1"", Is.Not.SameAs(""1"") & Is.Not.SameAs(↓2);");
+                @"Assert.That(""1"", Is.Not.SameAs(""1"") & Is.Not.SameAs(↓2));");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SameAsOnValueTypes/SameAsOnValueTypesCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/SameAsOnValueTypes/SameAsOnValueTypesCodeFixTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.That(actual, Is.EqualTo(expected));
             ");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.That(() => expected, Is.Not.EqualTo(expected), ""message"");
             ");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.That(Task.FromResult(expected), Is.EqualTo(expected), ""message"", Guid.Empty);
             ");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.AreEqual(expected, actual);
             ");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.AreNotEqual(expected, Guid.NewGuid(), ""message"");
             ");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
                 Assert.AreEqual(expected, expected, ""message"", Guid.Empty);
             ");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace NUnit.Analyzers.Tests.SameAsOnValueTypes
 
             var fixedCode = TestUtility.WrapInTestMethod(
                 @"Assert.That(""1"", Is.Not.SameAs(""1"") & Is.Not.EqualTo(2));");
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: CodeFixConstants.UseIsEqualToDescription);
         }
     }
 }

--- a/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 $"Assert.That(123, ↓{this.constraint}(1));");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 expectedDiagnostic.WithMessage($"The '{this.constraint}' constraint cannot be used with actual argument of type 'int' and expected argument of type 'int'"),
                 testCode);
         }
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 $"Assert.That(new[] {{\"1\", \"2\"}}, ↓{this.constraint}(1));");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 expectedDiagnostic.WithMessage($"The '{this.constraint}' constraint cannot be used with actual argument of type 'string[]' and expected argument of type 'int'"),
                 testCode);
         }
@@ -50,7 +50,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 $"Assert.That(Task.FromResult(new[] {{1,2,3}}), ↓{this.constraint}(1));");
 
-            AnalyzerAssert.Diagnostics(analyzer,
+            RoslynAssert.Diagnostics(analyzer,
                 expectedDiagnostic.WithMessage($"The '{this.constraint}' constraint cannot be used with actual argument of type 'Task<int[]>' and expected argument of type 'int'"),
                 testCode);
         }
@@ -61,7 +61,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 $"Assert.That(new [] {{1, 2, 3}}, {this.constraint}(2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
                 Assert.That(actual, {this.constraint}(new[] {{ 2, 3 }}));",
                 additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 $"Assert.That(new [] {{1.1, 2.0, 3.2}}, {this.constraint}(2));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
                 $"Assert.That(new ArrayList {{ 1, 2, 3 }}, {this.constraint}(2));",
                 additionalUsings: "using System.Collections;");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 "Assert.That(new[] { new[] { 1 }, new[] { 1, 2 } }, Has.All.Contain(1));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
             var testCode = TestUtility.WrapInTestMethod(
                 $"Assert.That(() => new[] {{1,2,3}}, {this.constraint}(1));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/StringConstraintWrongActualType/StringConstraintWrongActualTypeAnalyzerTests.cs
@@ -34,7 +34,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = 1234;
                 Assert.That(actual, ↓{stringConstraint});");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = Task.FromResult(""1234"");
                 Assert.That(actual, ↓{stringConstraint});");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = ""1234"";
                 Assert.That(actual, {stringConstraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = ""1234"";
                 Assert.That(() => actual, {stringConstraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = Task.FromResult(""1234"");
                 Assert.That(() => actual, {stringConstraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = 1234;
                 Assert.That(actual.ToString(), {stringConstraint});");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.StringConstraintWrongActualType
                 var actual = new[] {{""11"", ""12"", ""13""}};
                 Assert.That(actual, Has.All.StartsWith(""1""));");
 
-            AnalyzerAssert.Valid(analyzer, testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceExistsTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceExistsTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         }
     }");
             var message = "The TestCaseSource argument 'Missing' does not specify an existing member";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceSourceTypeTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceSourceTypeTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         }
     }",
     additionalUsings: "using System.Collections;");
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceSourceTypeNotIEnumerable)
                 .WithMessage("The source type 'MyTests' does not implement IEnumerable");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceSourceTypeNoDefaultConstructor)
                 .WithMessage("The source type 'MyTests' does not have a default constructor");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzerTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         {
         }
     }");
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceSourceIsNotStatic)
                 .WithMessage("The specified source 'Tests' is not static");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         }
     }");
             var descriptor = new DiagnosticDescriptor(AnalyzerIdentifiers.TestCaseSourceStringUsage, string.Empty, string.Empty, string.Empty, DiagnosticSeverity.Warning, true);
-            AnalyzerAssert.Valid(analyzer, descriptor, testCode);
+            RoslynAssert.Valid(analyzer, descriptor, testCode);
         }
 
         [TestCase("private static readonly TestCaseData[] TestCases = new TestCaseData[0];")]
@@ -95,7 +95,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }}");
 
             var message = "Consider using nameof(TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }");
 
             var message = "Consider using nameof(TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         }
     }", additionalUsings: "using System.Collections.Generic;");
 
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -187,7 +187,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceMismatchInNumberOfParameters)
                 .WithMessage("The TestCaseSource provides '1' parameter(s), but the target method expects '0' parameter(s)");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceMismatchInNumberOfParameters)
                 .WithMessage("The TestCaseSource provides '0' parameter(s), but the target method expects '1' parameter(s)");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -241,7 +241,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceMismatchInNumberOfParameters)
                 .WithMessage("The TestCaseSource provides '3' parameter(s), but the target method expects '2' parameter(s)");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -271,7 +271,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceMismatchInNumberOfParameters)
                 .WithMessage("The TestCaseSource provides '3' parameter(s), but the target method expects '2' parameter(s)");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase("private static readonly TestCaseData[] TestCases = new TestCaseData[0];")]
@@ -290,7 +290,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         }}
     }}");
 
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("private static readonly object TestCases = null;", "object")]
@@ -318,7 +318,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceDoesNotReturnIEnumerable)
                 .WithMessage($"The TestCaseSource does not return an IEnumerable or a type that implements IEnumerable. Instead it returns a '{returnType}'.");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase("private static readonly TestCaseData[] TestCases = new TestCaseData[0];", "fields")]
@@ -339,7 +339,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.TestCaseSourceSuppliesParametersToFieldOrProperty)
                 .WithMessage($"The TestCaseSource provides '3' parameter(s), but {kind} cannot take parameters");
-            AnalyzerAssert.Diagnostics<TestCaseSourceUsesStringAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -364,7 +364,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             new object[] { 12, 4, 3 }
         };
     }");
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             };
         }
     }");
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -415,7 +415,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             yield return ""YetAnotherName"";
         }
     }", additionalUsings: "using System.Collections.Generic;");
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -454,13 +454,13 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }";
 
             var testDataReference = MetadataReferences.CreateBinary(testDataCode);
-            var references = AnalyzerAssert.MetadataReferences.Concat(new[] { testDataReference });
+            var references = MetadataReferences.FromAttributes().Concat(new[] { testDataReference });
 
             var solution = CodeFactory.CreateSolution(testCode,
                 CodeFactory.DefaultCompilationOptions(analyzer),
                 references);
 
-            AnalyzerAssert.Valid<TestCaseSourceUsesStringAnalyzer>(solution);
+            RoslynAssert.Valid(analyzer, solution);
         }
 
         [Test]
@@ -491,7 +491,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }}");
 
             var message = "Consider using nameof(InnerClass.TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -522,7 +522,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }}");
 
             var message = "Consider using nameof(AnotherClass.TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -559,7 +559,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     }}");
 
             var message = "Consider using nameof(AnotherClass.InnerClass.TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic.WithMessage(message), testCode, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -74,7 +74,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         private sealed class TestCaseAttribute : Attribute
         { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [Test]
         public void ATest() { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase]
         public void ATest() { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(2)]
         public void Test(int a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [TestCaseSource(nameof(SpecialConversions))]
@@ -122,7 +122,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(""{value}"")]
         public void Test({targetType.Name} a) {{ }}
     }}");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase((byte)2)]
         public void Test(byte a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(-2)]
         public void Test(int a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(TestEnum.B)]
         public void Test(TestEnum e) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(1)]
         public void Test(TestEnum e) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -191,7 +191,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(TestEnum.B)]
         public void Test(int e) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(new byte[] { 1, 2, 3, 4 })]
         public void Test(byte[] buffer) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -222,7 +222,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓""B"")]
         public void Test(TestEnum e) { }
     }");
-            AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(
+            RoslynAssert.Diagnostics(this.analyzer,
                 ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
                 testCode);
         }
@@ -239,7 +239,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓TestEnum.B)]
         public void Test(string e) { }
     }");
-            AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(
+            RoslynAssert.Diagnostics(this.analyzer,
                 ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
                 testCode);
         }
@@ -253,7 +253,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(uint.MaxValue)]
         public void Test(long e) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -272,7 +272,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     struct CustomType { }
     class CustomTypeConverter : TypeConverter { }");
 
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -291,7 +291,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     struct CustomType { }
     class CustomTypeConverter : TypeConverter { }");
 
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -311,7 +311,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     class BaseType { }
     class BaseTypeConverter : TypeConverter { }");
 
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -330,7 +330,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     struct CustomType { }
     class CustomTypeConverter : TypeConverter { }");
 
-            AnalyzerAssert.Diagnostics<TestCaseUsageAnalyzer>(
+            RoslynAssert.Diagnostics(this.analyzer,
                 ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
                 testCode);
         }
@@ -349,7 +349,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓2)]
         public void Test(char a) { }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -366,7 +366,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓null)]
         public void Test(char a) { }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -378,7 +378,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(null)]
         public void Test(int? a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -390,7 +390,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(2)]
         public void Test(int? a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -407,7 +407,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int a, char b) { }
     }");
             var message = "The TestCaseAttribute provided too few arguments. Expected '2', but got '1'.";
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -424,7 +424,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int a) { }
     }");
             var message = "The TestCaseAttribute provided too many arguments. Expected '1', but got '2'.";
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -441,7 +441,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         public void Test(int a, char b = 'c') { }
     }");
             var message = "The TestCaseAttribute provided too many arguments. Expected '2', but got '3'.";
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -453,7 +453,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(1, 2, 3, 4)]
         public void Test(int a, int b, params int[] c) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -465,7 +465,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase]
         public void Test(params object[] a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -477,7 +477,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(""a"")]
         public void Test(params string[] a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -494,7 +494,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓2)]
         public void Test(params string[] a) { }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -511,7 +511,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(↓null)]
         public void Test(params int[] a) { }
     }");
-            AnalyzerAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -523,7 +523,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(null)]
         public void Test(params string[] a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -535,7 +535,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(new int[0])]
         public void Test(params int[] a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -547,7 +547,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(byte.MaxValue)]
         public void Test(params int[] a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -561,7 +561,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(value)]
         public void Test(decimal a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -573,7 +573,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(-600)]
         public void Test(decimal a) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -585,7 +585,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(""a"")]
         public void Test(object[] array) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -597,7 +597,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(""a"", ""b"")]
         public void Test(object[] array) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -609,7 +609,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(""a"", ""b"", ""c"")]
         public void Test(object[] array) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -621,7 +621,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(1, ""b"")]
         public void Test(object[] array) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]
@@ -633,7 +633,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         [TestCase(1)]
         public void TestWithGenericParameter<T>(T arg1) { }
     }");
-            AnalyzerAssert.Valid<TestCaseUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestHelpers.cs
+++ b/src/nunit.analyzers.tests/TestHelpers.cs
@@ -16,7 +16,7 @@ namespace NUnit.Analyzers.Tests
 
             return CSharpCompilation.Create(Guid.NewGuid().ToString("N"),
                 syntaxTrees,
-                references: AnalyzerAssert.MetadataReferences,
+                references: MetadataReferences.FromAttributes(),
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         }
 
@@ -26,7 +26,7 @@ namespace NUnit.Analyzers.Tests
 
             var compilation = CSharpCompilation.Create(Guid.NewGuid().ToString("N"),
                 syntaxTrees: new[] { tree },
-                references: AnalyzerAssert.MetadataReferences,
+                references: MetadataReferences.FromAttributes(),
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             var model = compilation.GetSemanticModel(tree);

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelAnalyzerTests.cs
@@ -74,7 +74,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [{attribute}]
         public void SetUpTearDownMethod() {{ }}");
-            AnalyzerAssert.Valid<TestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCaseSource(nameof(SetUpTearDownMethodRelatedAttributes))]
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [{attribute}]
         protected void SetUpTearDownMethod() {{ }}");
-            AnalyzerAssert.Valid<TestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [Test]
         public void TestMethod() {{ }}");
-            AnalyzerAssert.Valid<TestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [TestCase(1)]
         public void TestMethod(int i) {{ }}");
-            AnalyzerAssert.Valid<TestMethodAccessibilityLevelAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [{attribute}]
         {modifiers} void ↓SetUpTearDownMethod() {{ }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NonPublicModifiers))]
@@ -120,7 +120,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [Test]
         {modifiers} void ↓TestMethod() {{ }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NonPublicModifiers))]
@@ -129,7 +129,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [TestCase(1)]
         {modifiers} void ↓TestMethod(int i) {{ }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NonPublicModifiers))]
@@ -138,7 +138,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [Test]
         {modifiers} async Task ↓TestMethod() {{ }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCaseSource(nameof(NonPublicModifiers))]
@@ -147,7 +147,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         [TestCase(1)]
         {modifiers} async Task ↓TestMethod(int i) {{ }}");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodAccessibilityLevel/TestMethodAccessibilityLevelCodeFixTests.cs
@@ -50,7 +50,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         [TestCase(1)]
         {modifiersAfter} void TestMethod(int i) {{ }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         [TestCase(1)]
         public void TestMethod(int i) {{ }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
     [TestCase(1)]
         public void TestMethod(int i) {{ }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace NUnit.Analyzers.Tests.TestMethodAccessibilityLevel
         [TestCase(1)]
         public async Task TestMethod(int i) {{ }}");
 
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(""{value}"", ExpectedResult = ""{value}"")]
         public {targetType.Name} Test({targetType.Name} a) {{ return a; }}
     }}");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(2, ExpectedResult = 3)]
         public int Test(int a) { return 3; }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(2, ↓ExpectedResult = '3')]
         public void Test(int a) { }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(2, ↓ExpectedResult = '3')]
         public int Test(int a) { return 3; }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(2, ↓ExpectedResult = null)]
         public int Test(int a) { return 3; }
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(2, ExpectedResult = null)]
         public int? Test(int a) { return null; }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [TestCase(2, ExpectedResult = 2)]
         public int? Test(int a) { return 2; }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         public string Test3() => ""12"";
     }");
             var message = "The method has non-void return type 'string', but no result is expected in ExpectedResult";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -188,10 +188,10 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
     public sealed class AnalyzeWhenTestCaseAttributeExpectedResultIsNotProvidedAndReturnTypeIsNotVoid
     {
         [↓TestCase(1)]
-        public int Test4(int i) => ""12"";
+        public int Test4(int i) => 12;
     }");
             var message = "The method has non-void return type 'int', but no result is expected in ExpectedResult";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         public async Task<int> AsyncGenericTaskTest() => await Task.FromResult(1);
     }");
             var message = "The async test method must have a non-generic Task return type when no result is expected, but the return type was 'System.Threading.Tasks.Task<int>'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         public Task<int> AsyncGenericTaskTest() => Task.FromResult(1);
     }");
             var message = "The async test method must have a non-generic Task return type when no result is expected, but the return type was 'System.Threading.Tasks.Task<int>'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -238,7 +238,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [↓Test]
         public async void AsyncVoidTest() => await Task.FromResult(1);
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         [↓TestCase(4)]
         public async void AsyncVoidTest(int x) => await Task.FromResult(1);
     }");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -268,7 +268,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         {
         }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -283,7 +283,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
           return await Task.Run(() => 1);
         }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -298,7 +298,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
           return Task.Run(() => 1);
         }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -322,7 +322,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         }
     }
 ");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -351,7 +351,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         }
     }
 ");
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
 #if !NET461
@@ -365,7 +365,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
                     return 1;
                 }");
 
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -383,7 +383,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
                     return 1;
                 }");
 
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 #endif
 
@@ -403,7 +403,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         }
     }");
             var message = "The async test method must have a Task<T> return type when a result is expected, but the return type was 'System.Threading.Tasks.Task'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -422,7 +422,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         }
     }");
             var message = "The async test method must have a Task<T> return type when a result is expected, but the return type was 'System.Threading.Tasks.Task'";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -437,7 +437,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
             return arg1;
         }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -463,7 +463,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         }
     }",
     additionalUsings: "using System.Collections;");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -479,7 +479,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
             return value == 1;
         }
     }");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -505,7 +505,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         }
     }",
     additionalUsings: "using NUnit.Framework.Interfaces; using NUnit.Framework.Internal; using System.Collections.Generic;");
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -523,7 +523,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
     }");
 
             var message = "The test method has '1' parameter(s), but only '0' argument(s) are supplied by attributes";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -540,7 +540,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
     }");
 
             var message = "The test method has '3' parameter(s), but only '1' argument(s) are supplied by attributes";
-            AnalyzerAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic.WithMessage(message), testCode);
         }
 
         [Test]
@@ -553,7 +553,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         Assert.That(p, Is.EqualTo(42));
     }");
 
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -566,7 +566,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         Assert.That(p, Is.EqualTo(42));
     }");
 
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -581,7 +581,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         Assert.That(p, Is.EqualTo(42));
     }");
 
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -600,7 +600,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
         private static int[] Source => new[] { 1, 2, 3 };
     }");
 
-            AnalyzerAssert.Valid<TestMethodUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ValueSourceUsage/ValueSourceUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ValueSourceUsage/ValueSourceUsageAnalyzerTests.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
         {
         }
     }");
-            AnalyzerAssert.Valid<ValueSourceUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -41,14 +41,14 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
         string[] Tests = new[] { ""Data"" };
 
         [Test]
-        public void Test([ValueSource(↓nameof(Tests))] input)
+        public void Test([ValueSource(↓nameof(Tests))] string input)
         {
         }
     }");
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.ValueSourceIsNotStatic)
                 .WithMessage("The specified source 'Tests' is not static");
-            AnalyzerAssert.Diagnostics<ValueSourceUsageAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
         }
     }");
             var descriptor = new DiagnosticDescriptor(AnalyzerIdentifiers.ValueSourceStringUsage, string.Empty, string.Empty, string.Empty, DiagnosticSeverity.Warning, true);
-            AnalyzerAssert.Valid(analyzer, descriptor, testCode);
+            RoslynAssert.Valid(analyzer, descriptor, testCode);
         }
 
         [TestCase("private static readonly TestCaseData[] TestCases = new TestCaseData[0];")]
@@ -94,7 +94,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     }}");
 
             var message = "Consider using nameof(TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     }");
 
             var message = "Consider using nameof(TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.ValueSourceMethodExpectParameters)
                 .WithMessage("The ValueSource cannot supply parameters, but the target method expects '1' parameter(s)");
-            AnalyzerAssert.Diagnostics<ValueSourceUsageAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.ValueSourceMethodExpectParameters)
                 .WithMessage("The ValueSource cannot supply parameters, but the target method expects '2' parameter(s)");
-            AnalyzerAssert.Diagnostics<ValueSourceUsageAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [TestCase("private static readonly TestCaseData[] TestCases = new TestCaseData[0];")]
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
         }}
     }}");
 
-            AnalyzerAssert.Valid<ValueSourceUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [TestCase("private static readonly object TestCases = null;", "object")]
@@ -239,7 +239,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
             var expectedDiagnostic = ExpectedDiagnostic
                 .Create(AnalyzerIdentifiers.ValueSourceDoesNotReturnIEnumerable)
                 .WithMessage($"The ValueSource does not return an IEnumerable or a type that implements IEnumerable. Instead it returns a '{returnType}'.");
-            AnalyzerAssert.Diagnostics<ValueSourceUsageAnalyzer>(expectedDiagnostic, testCode);
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     {
         static int[] Numbers => new int[] { 1, 2, 3 };
     }");
-            AnalyzerAssert.Valid<ValueSourceUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
             static int[] Numbers => new int[] { 1, 2, 3 };
         }
     }");
-            AnalyzerAssert.Valid<ValueSourceUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -303,7 +303,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
             yield return ""YetAnotherName"";
         }
     }", additionalUsings: "using System.Collections.Generic;");
-            AnalyzerAssert.Valid<ValueSourceUsageAnalyzer>(testCode);
+            RoslynAssert.Valid(analyzer, testCode);
         }
 
         [Test]
@@ -334,7 +334,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     }}");
 
             var message = "Consider using nameof(InnerClass.TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -365,7 +365,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     }}");
 
             var message = "Consider using nameof(AnotherClass.TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
         }
 
         [Test]
@@ -402,7 +402,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     }}");
 
             var message = "Consider using nameof(AnotherClass.InnerClass.TestCases) instead of \"TestCases\"";
-            AnalyzerAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnosticCodeFix.WithMessage(message), testCode, fixedCode);
         }
     }
 }

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Analyzers.Tests</RootNamespace>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
@@ -10,7 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Gu.Roslyn.Asserts" Version="2.6.3" />
+    <PackageReference Include="Gu.Roslyn.Asserts" Version="3.3.1" />
+    <PackageReference Include="Gu.Roslyn.Asserts.Analyzers" Version="3.3.1" >
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="NUnit" Version="3.12" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />


### PR DESCRIPTION
Fixes #323 

The big downside with 'strings' as test is that they contained compile timer errors without us realizing it.
This new version of the package fails the test if there are compile time errors.
Fixed about 10 cases where our tests contained compile time errors.

The other downside is that we don't know if the test examples actually work on nunit.
