### PR TITLE
Added DiagnosticsSuppressor for NullReference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,5 +55,7 @@ From Visual Studio one can debug the analyzers by setting the **nunit.analyzers.
 ### Building using Cake
 
 The command `.\build.ps1` will restore the packages necessary to build the solution, build the projects, and then run the tests. The script can also build the projects in **Release** mode using the option `-Configuration Release` or create NuGet Packages using the option `-Target Pack`. This will create a NuGet package under `package\Debug\` (for a `Debug` build) and the file will be named `NUnit.Analyzers.***.nupkg` where `***` depends upon the build type (`Debug` vs. `Release`) and the version. The NuGet package can then be referenced from another project.
+You need to use the `-TargetFramework netstandard2.0` option to include the new DiagnosticSuppressor rules (NUnit3001-) which are not available in `netstandard1.6`.
 
 See [NuGet package vs. extension](https://docs.microsoft.com/en-us/visualstudio/code-quality/roslyn-analyzers-overview#nuget-package-vs-extension) for more information about the difference between installing a Roslyn analyzer as a NuGet package or as a Visual Studio extension.
+

--- a/build.cake
+++ b/build.cake
@@ -4,6 +4,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
+var targetFramework = Argument("targetFramework", "netstandard1.6");
 
 //////////////////////////////////////////////////////////////////////
 // SET PACKAGE VERSION
@@ -183,7 +184,8 @@ Task("Pack")
             OutputDirectory = PACKAGE_DIR,
             Properties = new Dictionary<string, string>()
             {
-                {"Configuration", configuration}
+                {"Configuration", configuration},
+                {"TargetFramework", targetFramework }
             }
         });
     });

--- a/build.ps1
+++ b/build.ps1
@@ -17,6 +17,8 @@ and execute your Cake build script with the parameters you provide.
 The build script to execute.
 .PARAMETER Target
 The build script target to run.
+.PARAMETER TargetFramework
+The build script target framework
 .PARAMETER Configuration
 The build configuration to use.
 .PARAMETER Verbosity
@@ -44,6 +46,7 @@ Param(
     [string]$Script = "build.cake",
     [string]$Target,
     [string]$Configuration,
+    [string]$TargetFramework,
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity,
     [switch]$ShowDescription,
@@ -221,6 +224,7 @@ if (!(Test-Path $CAKE_EXE)) {
 # Build Cake arguments
 $cakeArguments = @("$Script");
 if ($Target) { $cakeArguments += "-target=$Target" }
+if ($TargetFramework) { $cakeArguments += "-targetFramework=$TargetFramework" }
 if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
 if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
 if ($ShowDescription) { $cakeArguments += "-showdescription" }

--- a/documentation/NUnit3001.md
+++ b/documentation/NUnit3001.md
@@ -1,0 +1,114 @@
+# NUnit3001
+
+## Expression was checked in an Assert.NotNull, Assert.IsNotNull or Assert.That call
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit3001
+| Severity | Info
+| Enabled  | True
+| Category | Suppressor
+| Code     | [DereferencePossiblyNullReferenceSuppressor](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs)
+
+## Description
+
+This rule check diagnostics reported by the CS8601-CS8607 and CS8629 compiler errors:
+
+`CS8602: Dereference of a possibly null reference.`
+
+It then checks the previous statements for one of:
+* `Assert.NotNull(...)`
+* `Assert.IsNotNull(...)`
+* `Assert.That(..., Is.Not.Null)`
+
+For the same expression as the one that raised the original compiler error.
+If found, the compiler error is suppressed.
+
+The exception is that if the statement is part of an `Assert.Multiple`
+it is not suppressed, as in this case the statement containing the compiler error will be executed.
+
+## Motivation
+
+```csharp
+[TestFixture]
+internal sealed class SomeClassFixture
+{
+    private SomeClass instance;
+
+    [SetUp]
+    public void Setup()
+    {
+        instance = new SomeClass();
+    }
+
+    [Test]
+    public void Test()
+    {
+        string? result = instance.MethodUnderTest();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Length, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void TestMultiple()
+    {
+        string? result = instance.MethodUnderTest();
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Length, Is.GreaterThan(0));
+        });
+    }
+}
+```
+
+In the above fixture the compiler would give a warnings because `result` can be `null` and the compiler knows nothing
+about the `Assert.That(result, Is.Not.Null);` statement.
+
+The first occurrence - in the `Test` method - will be suppressed, the second - in the `TestMultiple` - will not.
+
+## How to fix violations
+
+Ensure that the reference is not `null` before dereferencing it.
+This can be done using regular C# language constructs or NUnit assertions.
+
+<!-- start generated config severity -->
+## Configure severity
+
+The rule has no severity, but can be disabled.
+
+### Via ruleset file
+
+To disable the rule for a project, you need to add a
+[ruleset file](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="NUnit.Analyzer Suppressions" Description="DiagnosticSuppression Rules" ToolsVersion="12.0">
+  <Rules AnalyzerId="DiagnosticSuppressors" RuleNamespace="NUnit.NUnitAnalyzers">
+    <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
+    <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField is Uninitialized -->
+  </Rules>
+</RuleSet>
+```
+
+and add it to the project like:
+
+```xml
+<PropertyGroup>
+  <CodeAnalysisRuleSet>NUnit.Analyzers.Suppressions.ruleset</CodeAnalysisRuleSet>
+</PropertyGroup>
+```
+
+For more info about rulesets see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via .editorconfig file
+
+This is currently not working. Waiting for [Roslyn](https://github.com/dotnet/roslyn/issues/49727)
+
+```ini
+# NUnit3001: Expression was checked in an Assert.NotNull, Assert.IsNotNull or Assert.That call
+dotnet_diagnostic.NUnit3001.severity = none
+```
+<!-- end generated config severity -->
+

--- a/documentation/NUnit3002.md
+++ b/documentation/NUnit3002.md
@@ -1,0 +1,91 @@
+# NUnit3002
+
+## Field is initialized in SetUp or OneTimeSetUp method
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit3002
+| Severity | Info
+| Enabled  | True
+| Category | Suppressor
+| Code     | [NonNullableFieldIsUninitializedSuppressor](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/NonNullableFieldIsUninitializedSuppressor.cs)
+
+## Description
+
+This rule check diagnostics reported by the CS8618 compiler error:
+
+`CS8618: Non-nullable field '_name_' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.`
+
+If the violating field is set in the `SetUp` or `OneTimeSetUp` method. The rule suppresses the error.
+This allows for non-nullable fields to be used in a `TestFixture`.
+
+## Motivation
+
+```csharp
+[TestFixture]
+internal sealed class SomeClassFixture
+{
+    private SomeClass instance;
+
+    [SetUp]
+    public void Setup()
+    {
+        instance = new SomeClass();
+    }
+
+    [Test]
+    public void Test()
+    {
+        Assert.That(instance.MethodUnderTest(), Is.True)
+    }
+}
+```
+
+In the above fixture the compiler would give a warning because `instance` is not set in the constructor.
+The suggestion to mark `instance` as nullable would mean that we have to test for null in all `Test` methods
+or use the null suppression operator (`!`) everywhere.
+
+## How to fix violations
+
+Initialize the field in the `SetUp` or `OneTimeSetUp` methods.
+
+<!-- start generated config severity -->
+## Configure severity
+
+The rule has no severity, but can be disabled.
+
+### Via ruleset file
+
+To disable the rule for a project, you need to add a
+[ruleset file](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="NUnit.Analyzer Suppressions" Description="DiagnosticSuppression Rules" ToolsVersion="12.0">
+  <Rules AnalyzerId="DiagnosticSuppressors" RuleNamespace="NUnit.NUnitAnalyzers">
+    <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
+    <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField is Uninitialized -->
+  </Rules>
+</RuleSet>
+```
+
+and add it to the project like:
+
+```xml
+<PropertyGroup>
+  <CodeAnalysisRuleSet>NUnit.Analyzers.Suppressions.ruleset</CodeAnalysisRuleSet>
+</PropertyGroup>
+```
+
+For more info about rulesets see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via .editorconfig file
+
+This is currently not working. Waiting for [Roslyn](https://github.com/dotnet/roslyn/issues/49727)
+
+```ini
+# NUnit3002: Field is initialized in SetUp or OneTimeSetUp method
+dotnet_diagnostic.NUnit3002.severity = none
+```
+<!-- end generated config severity -->
+

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -96,3 +96,11 @@ Rules which improve assertions in the test code.
 | [NUnit2040](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2040.md) | Non-reference types for SameAs constraint | :white_check_mark: | :exclamation: | :white_check_mark: |
 | [NUnit2041](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2041.md) | Incompatible types for comparison constraint | :white_check_mark: | :exclamation: | :x: |
 | [NUnit2042](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2042.md) | Comparison constraint on object | :white_check_mark: | :information_source: | :x: |
+
+### Suppressor Rules (NUnit3001 - )
+
+Rules which suppress compiler errors based on context.
+
+| Id       | Title       | :mag: | :memo: | :bulb: |
+| :--      | :--         | :--:  | :--:   | :--:   |
+| [NUnit3001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3001.md) | Expression was checked in an Assert.NotNull, Assert.IsNotNull or Assert.That call | :white_check_mark: | :information_source: | :x: |

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -104,3 +104,4 @@ Rules which suppress compiler errors based on context.
 | Id       | Title       | :mag: | :memo: | :bulb: |
 | :--      | :--         | :--:  | :--:   | :--:   |
 | [NUnit3001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3001.md) | Expression was checked in an Assert.NotNull, Assert.IsNotNull or Assert.That call | :white_check_mark: | :information_source: | :x: |
+| [NUnit3002](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3002.md) | Field is initialized in SetUp or OneTimeSetUp method | :white_check_mark: | :information_source: | :x: |

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -82,6 +82,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2040.md = ..\documentation\NUnit2040.md
 		..\documentation\NUnit2041.md = ..\documentation\NUnit2041.md
 		..\documentation\NUnit3001.md = ..\documentation\NUnit3001.md
+		..\documentation\NUnit3002.md = ..\documentation\NUnit3002.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -81,6 +81,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2039.md = ..\documentation\NUnit2039.md
 		..\documentation\NUnit2040.md = ..\documentation\NUnit2040.md
 		..\documentation\NUnit2041.md = ..\documentation\NUnit2041.md
+		..\documentation\NUnit3001.md = ..\documentation\NUnit3001.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -1,0 +1,312 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.DiagnosticSuppressors;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
+{
+    public class DereferencePossiblyNullReferenceSuppressorTests
+    {
+        private const string ABDefinition = @"
+            private static A? GetA(bool create) => create ? new A() : default(A);
+
+            private static B? GetB(bool create) => create ? new B() : default(B);
+
+            private static A? GetAB(string? text) => new A { B = new B { Text = text } };
+                
+            private class A
+            {
+                public B? B { get; set; }
+            }
+
+            private class B
+            {
+                public string? Text { get; set; }
+
+                public void Clear() => this.Text = null;
+
+                [System.Diagnostics.Contracts.Pure]
+                public string SafeGetText() => this.Text ?? string.Empty;
+            }
+        ";
+
+        private static readonly DiagnosticSuppressor suppressor = new DereferencePossiblyNullReferenceSuppressor();
+
+        [TestCase("")]
+        [TestCase("Assert.NotNull(string.Empty)")]
+        [TestCase("Assert.IsNull(s)")]
+        [TestCase("Assert.Null(s)")]
+        [TestCase("Assert.That(s, Is.Null)")]
+        public async Task NoValidAssert(string assert)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                [TestCase("""")]
+                public void Test(string? s)
+                {{
+                    {assert};
+                    Assert.That(s.Length, Is.GreaterThan(0));
+                }}
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureNotSuppressed(suppressor, testCode)
+                                               .ConfigureAwait(false);
+        }
+
+        [TestCase("Assert.NotNull(s)")]
+        [TestCase("Assert.IsNotNull(s)")]
+        [TestCase("Assert.That(s, Is.Not.Null)")]
+        public async Task WithLocalValidAssert(string assert)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                [TestCase("""")]
+                public void Test(string? s)
+                {{
+                    {assert};
+                    Assert.That(s.Length, Is.GreaterThan(0));
+                }}
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [TestCase("Assert.NotNull(s)")]
+        [TestCase("Assert.IsNotNull(s)")]
+        [TestCase("Assert.That(s, Is.Not.Null)")]
+        public async Task WithFieldValidAssert(string assert)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                private string? s;
+                [Test]
+                public void Test()
+                {{
+                    {assert};
+                    Assert.That(s.Length, Is.GreaterThan(0));
+                }}
+
+                public void SetS(string? v) => s = v;
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ReturnValue()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+                [TestCase("""")]
+                public void Test(string? s)
+                {
+                    string result = DoSomething(s);
+                }
+
+                private static string DoSomething(string? s)
+                {
+                    Assert.NotNull(s);
+                    return s;
+                }
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8603"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task Parameter()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+                [TestCase("""")]
+                public void Test(string? s)
+                {
+                    Assert.NotNull(s);
+                    DoSomething(s);
+                }
+
+                private static void DoSomething(string s)
+                {
+                    _ = s;
+                }
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8604"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task NullableCast()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+                [Test]
+                public void Test()
+                {
+                    int? possibleNull = GetNext();
+                    Assert.NotNull(possibleNull);
+                    int i = (int)possibleNull;
+                    Assert.That(i, Is.EqualTo(1));
+                }
+
+                private static int? GetNext() => 1;
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8629"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithReassignedAfterAssert()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+                [TestCase("""")]
+                public void Test(string? s)
+                {
+                    Assert.NotNull(s);
+                    s = null;
+                    Assert.That(s.Length, Is.GreaterThan(0));
+                }
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureNotSuppressed(suppressor, testCode)
+                                               .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithReassignedFieldAfterAssert()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+                private string? s;
+                [Test]
+                public void Test()
+                {
+                    Assert.NotNull(this.s);
+                    this.s = null;
+                    Assert.That(this.s.Length, Is.GreaterThan(0));
+                }
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureNotSuppressed(suppressor, testCode)
+                                               .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithPropertyExpression()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                [Test]
+                public void Test([Values] bool create)
+                {{
+                    A? a = GetA(true);
+                    Assert.That(a, Is.Not.Null);
+                    a.B = GetB(create);
+                    Assert.That(a.B, Is.Not.Null);
+                    a.B.Text = ""?"";
+                }}
+
+                {ABDefinition}
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithComplexExpression()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                [Test]
+                public void Test([Values] bool create)
+                {{
+                    A? a = GetA(create);
+                    Assert.That(a?.B?.Text, Is.Not.Null);
+                    Assert.That(a.B.Text.Length, Is.GreaterThan(0));
+                }}
+
+                {ABDefinition}
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"], testCode)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithComplexReassignAfterAssert()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                [Test]
+                public void Test([Values] bool create)
+                {{
+                    A a = new A {{ B = new B {{ Text = ""."" }} }};
+                    Assert.That(a.B.Text, Is.Not.Null);
+                    a.B = new B();
+                    Assert.That(a.B.Text.Length, Is.GreaterThan(0));
+                }}
+
+                {ABDefinition}
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureNotSuppressed(suppressor, testCode)
+                                               .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task InsideAssertMultiple()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+                [TestCase("""")]
+                public void Test(string? s)
+                {
+                    Assert.Multiple(() =>
+                    {
+                        Assert.NotNull(s);
+                        Assert.That(s.Length, Is.GreaterThan(0));
+                    });
+                }
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureNotSuppressed(suppressor, testCode)
+                                               .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithIndexer()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+                [Test]
+                public void Test()
+                {{
+                    string? directory = GetDirectoryName(""C:/Temp"");
+
+                    Assert.That(directory, Is.Not.Null);
+                    Assert.That(directory[0], Is.EqualTo('T'));
+                }}
+
+                // System.IO.Path.GetDirectoryName is not annotated in the libraries we are referencing.
+                private static string? GetDirectoryName(string path) => System.IO.Path.GetDirectoryName(path);
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"], testCode)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DiagnosticsSuppressorAnalyzer.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DiagnosticsSuppressorAnalyzer.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
+{
+    public static class DiagnosticsSuppressorAnalyzer
+    {
+        public static Task EnsureNotSuppressed(DiagnosticSuppressor suppressor, string testCode)
+        {
+            return EnsureSuppressed(suppressor, null, testCode);
+        }
+
+        public static async Task EnsureSuppressed(DiagnosticSuppressor suppressor, SuppressionDescriptor? suppressionDescriptor, string testCode)
+        {
+            if (suppressionDescriptor != null)
+            {
+                Assert.That(suppressor.SupportedSuppressions, Does.Contain(suppressionDescriptor), "Supported Suppression");
+            }
+
+            Compilation compilation = TestHelpers.CreateCompilation(testCode);
+
+            ImmutableArray<Diagnostic> compilationErrors = compilation.GetDiagnostics();
+
+            ImmutableArray<Diagnostic> nonHiddenErrors =
+                compilationErrors.Where(d => d.Severity != DiagnosticSeverity.Hidden)
+                                 .ToImmutableArray();
+
+            ImmutableArray<Diagnostic> suppressibleErrors =
+                nonHiddenErrors.Where(d => suppressor.SupportedSuppressions.Any(s => s.SuppressedDiagnosticId == d.Id))
+                               .ToImmutableArray();
+
+            Assert.That(nonHiddenErrors, Is.EquivalentTo(suppressibleErrors), "Non suppressible errors");
+            Assert.That(suppressibleErrors, Is.Not.Empty, "No errors to suppress");
+
+            var withAnalyzer = compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(suppressor));
+
+            ImmutableArray<Diagnostic> analyzerErrors =
+                await withAnalyzer.GetAllDiagnosticsAsync()
+                                  .ConfigureAwait(false);
+
+            nonHiddenErrors = analyzerErrors.Where(d => d.Severity != DiagnosticSeverity.Hidden)
+                                            .ToImmutableArray();
+
+            Assert.That(nonHiddenErrors, Is.Not.Empty);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var error in nonHiddenErrors)
+                {
+                    if (suppressionDescriptor is null)
+                    {
+                        Assert.That(error.IsSuppressed, Is.False, "IsSuppressed: " + error);
+                    }
+                    else
+                    {
+                        Assert.That(error.IsSuppressed, Is.True, "IsSuppressed: " + error);
+                        if (error.IsSuppressed)
+                        {
+                            AssertProgrammaticSuppression(error, suppressionDescriptor);
+                        }
+                    }
+                }
+            });
+        }
+
+        private static void AssertProgrammaticSuppression(Diagnostic error, SuppressionDescriptor suppressionDescriptor)
+        {
+            // We cannot check for the correct suppression nicely.
+            // DiagnosticWithProgrammaticSuppression is a private class.
+            // ProgrammaticSuppressionInfo is an internal class.
+            // Resorting to reflection ...
+            Type errorType = error.GetType();
+            Assert.That(errorType.Name, Is.EqualTo("DiagnosticWithProgrammaticSuppression"));
+
+            var programmaticSuppressionInfoProperty = errorType.GetProperty("ProgrammaticSuppressionInfo",
+                                                                            BindingFlags.Instance | BindingFlags.NonPublic);
+            if (programmaticSuppressionInfoProperty == null)
+            {
+                Assert.Fail("Expected a property with the name 'ProgrammaticSuppressionInfo'");
+                return;
+            }
+
+            var programmaticSuppressionInfo = programmaticSuppressionInfoProperty.GetValue(error);
+
+            if (programmaticSuppressionInfo != null)
+            {
+                Type programmaticSuppressionInfoType = programmaticSuppressionInfo.GetType();
+                Assert.That(programmaticSuppressionInfoType.Name, Is.EqualTo("ProgrammaticSuppressionInfo"));
+
+                var suppressionsProperty = programmaticSuppressionInfoType.GetProperty("Suppressions");
+                if (suppressionsProperty != null)
+                {
+                    var suppressions = suppressionsProperty.GetValue(programmaticSuppressionInfo);
+
+                    if (suppressions is ImmutableHashSet<(string Id, LocalizableString Justification)> suppressionsHashSet)
+                    {
+                        Assert.That(suppressionsHashSet, Does.Contain((suppressionDescriptor.Id, suppressionDescriptor.Justification)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/NonNullableFieldIsUninitializedSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/NonNullableFieldIsUninitializedSuppressorTests.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.DiagnosticSuppressors;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
+{
+    public class NonNullableFieldIsUninitializedSuppressorTests
+    {
+        private static readonly DiagnosticSuppressor suppressor = new NonNullableFieldIsUninitializedSuppressor();
+
+        [Test]
+        public async Task FieldNotAssigned()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                #nullable enable
+
+                private string field;
+
+                [Test]
+                public void Test()
+                {
+                    field = string.Empty;
+                    Assert.That(field, Is.Not.Null);
+                }
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureNotSuppressed(suppressor, testCode)
+                                               .ConfigureAwait(false);
+        }
+
+        [TestCase("SetUp", "")]
+        [TestCase("OneTimeSetUp", "this.")]
+        public async Task FieldAssigned(string attribute, string prefix)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                #nullable enable
+
+                private string field;
+
+                [{attribute}]
+                public void Initialize()
+                {{
+                    {prefix}field = string.Empty;
+                }}
+
+                [Test]
+                public void Test()
+                {{
+                    Assert.That({prefix}field, Is.Not.Null);
+                }}
+            ");
+
+            await DiagnosticsSuppressorAnalyzer.EnsureSuppressed(suppressor,
+                NonNullableFieldIsUninitializedSuppressor.NullableFieldInitializedInSetUp, testCode)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/TestHelpers.cs
+++ b/src/nunit.analyzers.tests/TestHelpers.cs
@@ -17,7 +17,8 @@ namespace NUnit.Analyzers.Tests
             return CSharpCompilation.Create(Guid.NewGuid().ToString("N"),
                 syntaxTrees,
                 references: MetadataReferences.FromAttributes(),
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                    reportSuppressedDiagnostics: true));
         }
 
         internal static async Task<(SyntaxNode Node, SemanticModel Model)> GetRootAndModel(string code)

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -6,6 +6,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,4 +41,14 @@
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <GenerateNullableAttributes>false</GenerateNullableAttributes>
+  </PropertyGroup>
+
+  <!-- Get nullability information from .NET5.0 when compiling for non net5.0 targets -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[5.0.0]" />
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
+  </ItemGroup>
+  
 </Project>

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -85,6 +85,7 @@ namespace NUnit.Analyzers.Constants
         #region Suppression
 
         internal const string DereferencePossibleNullReference = "NUnit3001";
+        internal const string NonNullableFieldIsUninitialized = "NUnit3002";
 
         #endregion
     }

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -81,5 +81,11 @@ namespace NUnit.Analyzers.Constants
         internal const string ComparableOnObject = "NUnit2042";
 
         #endregion Assertion
+
+        #region Suppression
+
+        internal const string DereferencePossibleNullReference = "NUnit3001";
+
+        #endregion
     }
 }

--- a/src/nunit.analyzers/Constants/Categories.cs
+++ b/src/nunit.analyzers/Constants/Categories.cs
@@ -4,5 +4,6 @@ namespace NUnit.Analyzers.Constants
     {
         internal const string Structure = nameof(Structure);
         internal const string Assertion = nameof(Assertion);
+        internal const string Suppression = nameof(Suppression);
     }
 }

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintCodeFix.cs
@@ -57,9 +57,12 @@ namespace NUnit.Analyzers.ConstraintUsage
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault();
 
+            if (actual == null || constraintExpression == null || assertNode == null)
+                return;
+
             var assertMethod = semanticModel.GetSymbolInfo(assertNode).Symbol as IMethodSymbol;
 
-            if (actual == null || constraintExpression == null || assertNode == null || assertMethod == null)
+            if (assertMethod == null)
                 return;
 
             var newAssertNode = UpdateAssertNode(assertNode, assertMethod, actual, constraintExpression);

--- a/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
@@ -1,0 +1,196 @@
+#if !NETSTANDARD1_6
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.DiagnosticSuppressors
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DereferencePossiblyNullReferenceSuppressor : DiagnosticSuppressor
+    {
+        private const string Justification = "Expression was checked in an Assert.NotNull, Assert.IsNotNull or Assert.That call";
+
+        // Numbers from: https://cezarypiatek.github.io/post/non-nullable-references-in-dotnet-core/
+        public static ImmutableDictionary<string, SuppressionDescriptor> SuppressionDescriptors { get; } =
+            CreateSuppressionDescriptors(
+                "CS8600", // Converting null literal or possible null value to non-nullable type.
+                "CS8601", // Possible null reference assignment.
+                "CS8602", // Dereference of a possibly null reference.
+                "CS8603", // Possible null reference return.
+                "CS8604", // Possible null reference argument.
+                "CS8605", // Unboxing a possibly null value.
+                "CS8606", // Possible null reference assignment to iteration variable.
+                "CS8607", // A possible null value may not be passed to a target marked with the [DisallowNull] attribute.
+                "CS8629"); // Nullable value type may be null.
+
+        public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
+            ImmutableArray.CreateRange(SuppressionDescriptors.Values);
+
+        public override void ReportSuppressions(SuppressionAnalysisContext context)
+        {
+            foreach (var diagnostic in context.ReportedDiagnostics)
+            {
+                SyntaxNode? node = diagnostic.Location.SourceTree?.GetRoot(context.CancellationToken)
+                                                                  .FindNode(diagnostic.Location.SourceSpan);
+                StatementSyntax? statement = node?.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault();
+                BlockSyntax? parent = node?.Ancestors().OfType<BlockSyntax>().FirstOrDefault();
+
+                if (node is null || parent is null)
+                {
+                    continue;
+                }
+
+                if (IsInsideAssertMultiple(parent))
+                {
+                    continue;
+                }
+
+                string possibleNullReference = node.ToString();
+                if (node is CastExpressionSyntax castExpression)
+                {
+                    // Drop the cast.
+                    possibleNullReference = castExpression.Expression.ToString();
+                }
+
+                var siblings = parent.ChildNodes().ToList();
+
+                int nodeIndex = siblings.FindIndex(x => x == statement);
+
+                while (--nodeIndex >= 0)
+                {
+                    SyntaxNode previous = siblings[nodeIndex];
+
+                    if (previous is ExpressionStatementSyntax expressionStatement)
+                    {
+                        if (expressionStatement.Expression is AssignmentExpressionSyntax assignmentExpression)
+                        {
+                            // If the offending symbol is assigned here, stop searching for Assert
+                            if (InvalidatedBy(assignmentExpression.Left.ToString(), possibleNullReference))
+                            {
+                                break;
+                            }
+                        }
+
+                        // Check if this is Assert.NotNull or Assert.IsNotNull for the same symbol
+                        if (expressionStatement.Expression is InvocationExpressionSyntax invocationExpression &&
+                            invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression &&
+                            memberAccessExpression.Expression is IdentifierNameSyntax identifierName &&
+                            identifierName.Identifier.Text == "Assert")
+                        {
+                            var member = memberAccessExpression.Name.Identifier.Text;
+                            if (member == "NotNull" || member == "IsNotNull" || member == "That")
+                            {
+                                if (member == "That")
+                                {
+                                    // We must check the 2nd argument for anything but "Is.Null"
+                                    // E.g.: Is.Not.Null.And.Not.Empty.
+                                    ArgumentSyntax? secondArgument = invocationExpression.ArgumentList.Arguments.ElementAtOrDefault(1);
+                                    if (secondArgument?.ToString() == "Is.Null")
+                                    {
+                                        continue;
+                                    }
+                                }
+
+                                ArgumentSyntax firstArgument = invocationExpression.ArgumentList.Arguments.First();
+                                if (CoveredBy(firstArgument.Expression.ToString(), possibleNullReference))
+                                {
+                                    context.ReportSuppression(Suppression.Create(SuppressionDescriptors[diagnostic.Id], diagnostic));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool InvalidatedBy(string assignment, string possibleNullReference)
+        {
+            if (assignment == possibleNullReference)
+            {
+                return true;
+            }
+
+            // a.B.C is invalidated when either a or a.B are assigned to.
+            // But ab is not invalidated when a is assigned to
+            return possibleNullReference.StartsWith(assignment, StringComparison.Ordinal) &&
+                possibleNullReference[assignment.Length] == '.';
+        }
+
+        private static bool CoveredBy(string assertedNotNull, string possibleNullReference)
+        {
+            if (possibleNullReference == assertedNotNull)
+            {
+                return true;
+            }
+
+            // If assertedNotNull is a?.B this covers both a.B and a.
+            int question = assertedNotNull.IndexOf('?');
+            if (question >= 0)
+            {
+                do
+                {
+                    string prefix = assertedNotNull.Substring(0, question)
+                                                   .Replace("?", string.Empty);
+
+                    if (possibleNullReference == prefix)
+                    {
+                        return true;
+                    }
+
+                    question = assertedNotNull.IndexOf('?', question + 1);
+                }
+                while (question > 0);
+
+                return possibleNullReference == assertedNotNull.Replace("?", string.Empty);
+            }
+
+            return false;
+        }
+
+        private static bool IsInsideAssertMultiple(SyntaxNode parent)
+        {
+            var possibleAssertMultiple = parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+            if (possibleAssertMultiple != null)
+            {
+                if (possibleAssertMultiple.Expression is MemberAccessExpressionSyntax memberAccessExpression &&
+                    memberAccessExpression.Expression is IdentifierNameSyntax identifierName &&
+                    identifierName.Identifier.Text == "Assert")
+                {
+                    if (memberAccessExpression.Name.Identifier.Text == "Multiple")
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static ImmutableDictionary<string, SuppressionDescriptor> CreateSuppressionDescriptors(params string[] suppressionDiagnosticsIds)
+        {
+            var builder = new Dictionary<string, SuppressionDescriptor>();
+            foreach (var suppressionDiagnosticsId in suppressionDiagnosticsIds)
+            {
+                builder.Add(suppressionDiagnosticsId, CreateSuppressionDescriptor(suppressionDiagnosticsId));
+            }
+
+            return builder.ToImmutableDictionary();
+        }
+
+        private static SuppressionDescriptor CreateSuppressionDescriptor(string suppressedDiagnoticsId)
+        {
+            return new SuppressionDescriptor(
+                id: AnalyzerIdentifiers.DereferencePossibleNullReference,
+                suppressedDiagnosticId: suppressedDiagnoticsId,
+                justification: Justification);
+        }
+    }
+}
+
+#endif

--- a/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset
+++ b/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="NUnit.Analyzer Suppressions" Description="DiagnosticSuppression Rules" ToolsVersion="12.0">
+  <Rules AnalyzerId="DiagnosticSuppressors" RuleNamespace="NUnit.NUnitAnalyzers">
+    <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
+  </Rules>
+</RuleSet>

--- a/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset
+++ b/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset
@@ -2,5 +2,6 @@
 <RuleSet Name="NUnit.Analyzer Suppressions" Description="DiagnosticSuppression Rules" ToolsVersion="12.0">
   <Rules AnalyzerId="DiagnosticSuppressors" RuleNamespace="NUnit.NUnitAnalyzers">
     <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
+    <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField is Uninitialized -->
   </Rules>
 </RuleSet>

--- a/src/nunit.analyzers/DiagnosticSuppressors/NonNullableFieldIsUninitializedSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/NonNullableFieldIsUninitializedSuppressor.cs
@@ -1,0 +1,87 @@
+#if !NETSTANDARD1_6
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.DiagnosticSuppressors
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class NonNullableFieldIsUninitializedSuppressor : DiagnosticSuppressor
+    {
+        internal static readonly SuppressionDescriptor NullableFieldInitializedInSetUp = new SuppressionDescriptor(
+            id: AnalyzerIdentifiers.NonNullableFieldIsUninitialized,
+            suppressedDiagnosticId: "CS8618",
+            justification: "Field is initialized in SetUp or OneTimeSetUp method");
+
+        public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
+            ImmutableArray.Create(NullableFieldInitializedInSetUp);
+
+        public override void ReportSuppressions(SuppressionAnalysisContext context)
+        {
+            foreach (var diagnostic in context.ReportedDiagnostics)
+            {
+                SyntaxNode? node = diagnostic.Location.SourceTree?.GetRoot(context.CancellationToken)
+                                                                  .FindNode(diagnostic.Location.SourceSpan);
+
+                if (node is null)
+                {
+                    continue;
+                }
+
+                string fieldName = node.ToString();
+
+                var classDeclaration = node.Ancestors().OfType<ClassDeclarationSyntax>().First();
+                var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>().ToArray();
+
+                foreach (var method in methods)
+                {
+                    var allAttributes = method.AttributeLists.SelectMany(list => list.Attributes.Select(a => a.Name.ToString()))
+                                                             .ToImmutableHashSet();
+                    if (allAttributes.Contains("SetUp") || allAttributes.Contains("OneTimeSetUp"))
+                    {
+                        // Find (OneTime)SetUps method and check for assignment to this field.
+                        if (FieldIsAssignedIn(method, fieldName))
+                        {
+                            context.ReportSuppression(Suppression.Create(NullableFieldInitializedInSetUp, diagnostic));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool FieldIsAssignedIn(MethodDeclarationSyntax method, string fieldName)
+        {
+            if (method.Body is null)
+            {
+                return false;
+            }
+
+            foreach (var statement in method.Body.Statements)
+            {
+                if (statement is ExpressionStatementSyntax expressionStatement &&
+                    expressionStatement.Expression is AssignmentExpressionSyntax assignmentExpression)
+                {
+                    if (assignmentExpression.Left.ToString() == fieldName)
+                    {
+                        return true;
+                    }
+                    else if (assignmentExpression.Left is MemberAccessExpressionSyntax memberAccessExpression &&
+                        memberAccessExpression.Expression is ThisExpressionSyntax &&
+                        memberAccessExpression.Name.ToString() == fieldName)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}
+
+#endif

--- a/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
@@ -215,7 +215,7 @@ namespace NUnit.Analyzers.Extensions
             }
             else if (argumentValue is null || argumentValue is string)
             {
-                if (compilation.GetTypeByMetadataName(typeof(TypeConverterAttribute).FullName) is { } typeConverterAttribute
+                if (compilation.GetTypeByMetadataName(typeof(TypeConverterAttribute).FullName!) is { } typeConverterAttribute
                     && targetTypeSymbol.GetAllAttributes().Any(data => SymbolEqualityComparer.Default.Equals(typeConverterAttribute, data.AttributeClass)))
                 {
                     return true;

--- a/src/nunit.analyzers/nunit.analyzers.csproj
+++ b/src/nunit.analyzers/nunit.analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <RootNamespace>NUnit.Analyzers</RootNamespace>
@@ -44,4 +44,15 @@
       <Output TaskParameter="Assemblies" ItemName="AnalyzerAssemblyInfo" />
     </GetAssemblyIdentity>
   </Target>
+  
+  <PropertyGroup>
+    <GenerateNullableAttributes>false</GenerateNullableAttributes>
+  </PropertyGroup>
+
+  <!-- Get nullability information from .NET5.0 when compiling for non net5.0 targets -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[5.0.0]" />
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
+  </ItemGroup>
+  
 </Project>

--- a/src/nunit.analyzers/nunit.analyzers.nuspec
+++ b/src/nunit.analyzers/nunit.analyzers.nuspec
@@ -21,7 +21,7 @@
   </metadata>
   <!-- The convention for analyzers is to put language agnostic dlls in analyzers\portable50 and language specific analyzers in either analyzers\portable50\cs or analyzers\portable50\vb -->
   <files>
-    <file src="bin\$Configuration$\netstandard1.6\nunit.analyzers.dll" target="analyzers\dotnet\cs\" />
+    <file src="bin\$Configuration$\$TargetFramework$\nunit.analyzers.dll" target="analyzers\dotnet\cs\" />
     <file src="tools\*.ps1" target="tools\" />
     <file src="..\..\license.txt" target="" />
     <file src="..\..\nunit_256.png" target="images" />


### PR DESCRIPTION
Fixes #157 

Preliminary version:
* Detects: Assert.NotNull, Assert.IsNotNull and Assert.That(..., Is.Not.Null)
* Recognizes: Assert.Multiple
* Recognizes: Assignments

The current version is certainly not catching all cases.
I welcome suggestion for other test cases.