### PR TITLE
Fix EqualTo analyzer when arguments have both IEnumerable and IEquatable

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -649,6 +649,34 @@ using System.Collections.Generic;");
         }
 
         [Test]
+        public void NoDiagnosticWhenExpectedHasIEquatableOfActualAndIsIEnumerable()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+                class B : IEquatable<string>, IEnumerable<string>
+                {
+                    public bool Equals(string other) => true;
+
+                    public IEnumerator<string> GetEnumerator() => new List<string>().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => new List<string>().GetEnumerator();
+                }
+
+                public class Tests
+                {
+                    [Test]
+                    public void TestMethod()
+                    {
+                        var actual = ""123"";
+                        var expected = new B();
+                        Assert.That(actual, Is.EqualTo(expected));
+                    }
+                }",
+                additionalUsings: "using System.Collections;" +
+                    "using System.Collections.Generic;");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void NoDiagnosticWhenActualIsDynamic()
         {
             var testCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
+++ b/src/nunit.analyzers/Helpers/NUnitEqualityComparerHelper.cs
@@ -111,9 +111,10 @@ namespace NUnit.Analyzers.Helpers
                     // whether types are suitable
                     return true;
                 }
-                else
+
+                if (CanBeEqual(actualElementType, expectedElementType, compilation, checkedTypes))
                 {
-                    return CanBeEqual(actualElementType, expectedElementType, compilation, checkedTypes);
+                    return true;
                 }
             }
 


### PR DESCRIPTION
Fixes #322.

We already support IEquatables, but interesting case here is that `string` implements `IEnumerable<char>`, and `StringValues` implements `IEnumerable<string>`.
So IEnumerable path took precedence before, we returned `false` based on that.