### PR TITLE
Suppress "Possible Null" from a return value of Assert.Throws

### DIFF
--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Analyzers.Tests</RootNamespace>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
-    <PackageReference Include="NUnit" Version="3.12" />
+    <PackageReference Include="NUnit" Version="3.13" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.261">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes #333 

Suppress CS86xx for return values from Assert.Throw, except if run inside an Assert.Multiple