### PR TITLE
feat: Build and pack two versions of the analyzers on CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ From Visual Studio one can debug the analyzers by setting the **nunit.analyzers.
 ### Building using Cake
 
 The command `.\build.ps1` will restore the packages necessary to build the solution, build the projects, and then run the tests. The script can also build the projects in **Release** mode using the option `-Configuration Release` or create NuGet Packages using the option `-Target Pack`. This will create a NuGet package under `package\Debug\` (for a `Debug` build) and the file will be named `NUnit.Analyzers.***.nupkg` where `***` depends upon the build type (`Debug` vs. `Release`) and the version. The NuGet package can then be referenced from another project.
-You need to use the `-TargetFramework netstandard2.0` option to include the new DiagnosticSuppressor rules (NUnit3001-) which are not available in `netstandard1.6`.
+You need to use the `-TargetFramework netstandard1.6` option to build a analyzer version for `netstandard1.6` (VS 2017), this version will not include the new DiagnosticSuppressor rules (NUnit3001-) as these require `netstandard2.0`.
 
 See [NuGet package vs. extension](https://docs.microsoft.com/en-us/visualstudio/code-quality/roslyn-analyzers-overview#nuget-package-vs-extension) for more information about the difference between installing a Roslyn analyzer as a NuGet package or as a Visual Studio extension.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is a suite of analyzers that target the NUnit testing framework. Right now,
 
 ## Download ##
 
-The latest stable release of the NUnit Analyzers is [available on NuGet](https://www.nuget.org/packages/NUnit.Analyzers/) or can be [downloaded from GitHub](https://github.com/nunit/nunit.analyzers/releases).
+The latest stable release of the NUnit Analyzers is [available on NuGet](https://www.nuget.org/packages/NUnit.Analyzers/) or can be [downloaded from GitHub](https://github.com/nunit/nunit.analyzers/releases). Note that for Visual Studio 2017 one must use versions below 3.0. Version 3.0 and upwards require Visual Studio 2019, these versions also enables supression of compiler errors such as errors arising from nullable reference types.
+
 Prerelease nuget packages can be found on [MyGet](https://www.myget.org/feed/nunit-analyzers/package/nuget/NUnit.Analyzers). Please try out the package and report bugs and feature requests.
 
 ## Analyzers ##

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,15 @@
 image: Visual Studio 2019
 
 build_script:
-  - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"
+  - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release" -TargetFramework "netstandard1.6"
+  - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release" -TargetFramework "netstandard2.0"
 
 # disable built-in tests.
 test: off
 
 artifacts:
-  - path: 'package\Release\NUnit.Analyzers*.nupkg'
+  - path: 'package\Release\netstandard1.6\NUnit.Analyzers*.nupkg'
+  - path: 'package\Release\netstandard2.0\NUnit.Analyzers*.nupkg'
 
 deploy:
   - provider: NuGet

--- a/build.cake
+++ b/build.cake
@@ -4,13 +4,18 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
-var targetFramework = Argument("targetFramework", "netstandard1.6");
+var targetFramework = Argument("targetFramework", "netstandard2.0");
 
 //////////////////////////////////////////////////////////////////////
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "0.7.0";
+var isNetstandard16Build = targetFramework == "netstandard1.6";
+var isNetstandard20Build = targetFramework == "netstandard2.0";
+
+var version = isNetstandard20Build
+    ? "3.0.0"
+    : "2.0.0";
 
 var isAppveyor = BuildSystem.IsRunningOnAppVeyor;
 var dbgSuffix = configuration == "Debug" ? "-dbg" : "";
@@ -53,8 +58,14 @@ Setup(context =>
 
         if (tag.IsTag)
         {
-            packageVersion = tag.Name;
-            packageVersionString = tag.Name;
+            var tagName = tag.Name;
+            if (isNetstandard16Build && tagName.StartsWith("3"))
+            {
+                tagName = '2' + tagName.Substring(1);
+            }
+
+            packageVersion = tagName;
+            packageVersionString = tagName;
         }
         else
         {
@@ -181,7 +192,7 @@ Task("Pack")
         NuGetPack("./src/nunit.analyzers/nunit.analyzers.nuspec", new NuGetPackSettings()
         {
             Version = packageVersionString,
-            OutputDirectory = PACKAGE_DIR,
+            OutputDirectory = PACKAGE_DIR + "/" + targetFramework,
             Properties = new Dictionary<string, string>()
             {
                 {"Configuration", configuration},

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -100,7 +100,7 @@ Rules which improve assertions in the test code.
 
 ### Suppressor Rules (NUnit3001 - )
 
-Rules which suppress compiler errors based on context.
+Rules which suppress compiler errors based on context. Note that these rules are only available in the .NET Standard 2.0 builds (version 3.0.0 and above) which require Visual Studio 2019.
 
 | Id       | Title       | :mag: | :memo: | :bulb: |
 | :--      | :--         | :--:  | :--:   | :--:   |

--- a/src/nunit.analyzers/Properties/AssemblyInfo.cs
+++ b/src/nunit.analyzers/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCompany("NUnit Project")]
 
 [assembly: AssemblyProduct("NUnit Analyzers")]
-[assembly: AssemblyCopyright("Copyright © 2018-2020 NUnit project")]
+[assembly: AssemblyCopyright("Copyright © 2018-2021 NUnit project")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/nunit.analyzers/nunit.analyzers.nuspec
+++ b/src/nunit.analyzers/nunit.analyzers.nuspec
@@ -14,9 +14,12 @@
     <summary>Code analyzers and fixes for NUnit 3</summary>
     <description>
       This package includes analyzers and code fixes for test projects using NUnit 3. The analyzers will mark wrong usages when writing tests, and the code fixes can be used to used to correct these usages.
+
+      Version 3.0 and upwards works in Visual Studio 2019 and also enables supression of compiler errors such as errors arising from nullable reference types.
+      For Visual Studio 2017 one must use versions below 3.0.
     </description>
     <releaseNotes>See the release notes on https://github.com/nunit/nunit.analyzers/blob/master/CHANGES.txt.</releaseNotes>
-    <copyright>Copyright (c) 2018-2020 NUnit project</copyright>
+    <copyright>Copyright (c) 2018-2021 NUnit project</copyright>
     <tags>nunit, analyzers, roslyn-analyzers</tags>
   </metadata>
   <!-- The convention for analyzers is to put language agnostic dlls in analyzers\portable50 and language specific analyzers in either analyzers\portable50\cs or analyzers\portable50\vb -->


### PR DESCRIPTION
Fixes #336

We need to build twice, as we currently update `AssemblyVersion` and `AssemblyFileVersion` attributes before we build.