### PR TITLE
Add DelegateRequiredAnalyzer

### DIFF
--- a/documentation/NUnit2044.md
+++ b/documentation/NUnit2044.md
@@ -1,0 +1,65 @@
+# NUnit2044
+
+## Non-delegate actual parameter
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit2044
+| Severity | Error
+| Enabled  | True
+| Category | Assertion
+| Code     | [DelegateRequiredAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DelegateRequired/DelegateRequiredAnalyzer.cs)
+
+## Description
+
+The actual argument needs to be evaluated by the Assert to catch any exceptions.
+
+## Motivation
+
+In order for the `Assert.That` to catch an exception or a timeout, the code must be
+a delegate so it can be evaluated by the method. If the parameter is not a
+delegate, it will be evaluated before the call to `Assert.That` and stop further
+execution.
+
+## How to fix violations
+
+Convert the call into a delegate using a lambda expression or method group.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via .editorconfig file
+
+```ini
+# NUnit2044: Non-delegate actual parameter
+dotnet_diagnostic.NUnit2044.severity = chosenSeverity
+```
+
+where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, or `error`.
+
+### Via #pragma directive
+
+```csharp
+#pragma warning disable NUnit2044 // Non-delegate actual parameter
+Code violating the rule here
+#pragma warning restore NUnit2044 // Non-delegate actual parameter
+```
+
+Or put this at the top of the file to disable all instances.
+
+```csharp
+#pragma warning disable NUnit2044 // Non-delegate actual parameter
+```
+
+### Via attribute `[SuppressMessage]`
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion",
+    "NUnit2044:Non-delegate actual parameter",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -97,6 +97,7 @@ Rules which improve assertions in the test code.
 | [NUnit2041](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2041.md) | Incompatible types for comparison constraint | :white_check_mark: | :exclamation: | :x: |
 | [NUnit2042](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2042.md) | Comparison constraint on object | :white_check_mark: | :information_source: | :x: |
 | [NUnit2043](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2043.md) | Use ComparisonConstraint for better assertion messages in case of failure | :white_check_mark: | :information_source: | :white_check_mark: |
+| [NUnit2044](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2044.md) | Non-delegate actual parameter | :white_check_mark: | :exclamation: | :white_check_mark: |
 
 ### Suppressor Rules (NUnit3001 - )
 

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -83,6 +83,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2F501E14-3
 		..\documentation\NUnit2041.md = ..\documentation\NUnit2041.md
 		..\documentation\NUnit2042.md = ..\documentation\NUnit2042.md
 		..\documentation\NUnit2043.md = ..\documentation\NUnit2043.md
+		..\documentation\NUnit2044.md = ..\documentation\NUnit2044.md
 		..\documentation\NUnit3001.md = ..\documentation\NUnit3001.md
 		..\documentation\NUnit3002.md = ..\documentation\NUnit3002.md
 		..\README.md = ..\README.md

--- a/src/nunit.analyzers.tests/DelegateRequired/DelegateRequiredAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DelegateRequired/DelegateRequiredAnalyzerTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading.Tasks;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.DelegateRequired;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.DelegateRequired
+{
+    public class DelegateRequiredAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new DelegateRequiredAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.DelegateRequired);
+
+        [Test]
+        public void AnalyzeWhenLambdaProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(() => throw new InvalidOperationException(), Throws.InstanceOf<InvalidOperationException>());
+            ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenAsyncLambdaProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(() => Task.Delay(-2), Throws.InstanceOf<ArgumentException>());
+            ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenDelegateProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(MyOperation, Throws.InstanceOf<InvalidOperationException>());
+
+                void MyOperation() => throw new InvalidOperationException();
+            ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenAsyncDelegateProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(MyAsyncOperation, Throws.InstanceOf<InvalidOperationException>());
+
+                Task MyAsyncOperation() => throw new InvalidOperationException();
+            ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNoDelegateProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(↓MyOperation(), Throws.InstanceOf<InvalidOperationException>());
+
+                int MyOperation() => throw new InvalidOperationException();
+            ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNoAsyncDelegateProvided()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(↓MyAsyncOperation(), Throws.InstanceOf<InvalidOperationException>());
+
+                Task MyAsyncOperation() => throw new InvalidOperationException();
+            ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenDelayedConstraint()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                int i = 0;
+                int actualFunc() => i++;
+                Assert.That(↓actualFunc(), Is.EqualTo(5).After(1000, 10));
+            ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenDelayedConstraintWithDimensionedDelayInterval()
+        {
+            var testCode = TestUtility.WrapInTestMethod(@"
+                int i = 0;
+                int actualFunc() => i++;
+                Assert.That(↓actualFunc(), Is.EqualTo(5).After(1).Minutes);
+            ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/DelegateRequired/DelegateRequiredCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/DelegateRequired/DelegateRequiredCodeFixTests.cs
@@ -1,0 +1,94 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.DelegateRequired;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.DelegateRequired
+{
+    [TestFixture]
+    public sealed class DelegateRequiredCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new DelegateRequiredAnalyzer();
+        private static readonly CodeFixProvider fix = new DelegateRequiredCodeFix();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.DelegateRequired);
+
+        [Test]
+        public void VerifyGetFixableDiagnosticIds()
+        {
+            var fix = new DelegateRequiredCodeFix();
+            var ids = fix.FixableDiagnosticIds;
+
+            Assert.That(ids, Is.EquivalentTo(new[] { AnalyzerIdentifiers.DelegateRequired }));
+        }
+
+        [Test]
+        public void VerifyNonDelegateFix()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+                Assert.That(↓MyOperation(1), Throws.InstanceOf<InvalidOperationException>());
+
+                int MyOperation(int n) => throw new InvalidOperationException();
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(() => MyOperation(1), Throws.InstanceOf<InvalidOperationException>());
+
+                int MyOperation(int n) => throw new InvalidOperationException();
+            ");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: DelegateRequiredCodeFix.UseAnonymousLambdaDescription);
+        }
+
+        [Test]
+        public void VerifyNonDelegateFixWithMessage()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+                Assert.That(↓MyOperation(), Throws.InstanceOf<InvalidOperationException>(), ""message"");
+
+                int MyOperation() => throw new InvalidOperationException();
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(MyOperation, Throws.InstanceOf<InvalidOperationException>(), ""message"");
+
+                int MyOperation() => throw new InvalidOperationException();
+            ");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: DelegateRequiredCodeFix.UseMethodGroupDescription);
+        }
+
+        [Test]
+        public void VerifyNonDelegateFixWithMessageAndParams()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+                Assert.That(↓MyOperation() + MyOtherOperation(), Throws.InstanceOf<InvalidOperationException>(), ""message"", Guid.NewGuid());
+
+                int MyOperation() => throw new InvalidOperationException();
+                int MyOtherOperation() => throw new InvalidOperationException();
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+                Assert.That(() => MyOperation() + MyOtherOperation(), Throws.InstanceOf<InvalidOperationException>(), ""message"", Guid.NewGuid());
+
+                int MyOperation() => throw new InvalidOperationException();
+                int MyOtherOperation() => throw new InvalidOperationException();
+            ");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: DelegateRequiredCodeFix.UseAnonymousLambdaDescription);
+        }
+
+        [Test]
+        public void AnalyzeWhenDelayedConstraintWithDimensionedDelayInterval()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+                int i = 0;
+                int actualFunc() => i++;
+                Assert.That(↓actualFunc(), Is.EqualTo(5).After(1).Minutes);
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+                int i = 0;
+                int actualFunc() => i++;
+                Assert.That(actualFunc, Is.EqualTo(5).After(1).Minutes);
+            ");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: DelegateRequiredCodeFix.UseMethodGroupDescription);
+        }
+    }
+}

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -80,6 +80,7 @@ namespace NUnit.Analyzers.Constants
         internal const string ComparableTypes = "NUnit2041";
         internal const string ComparableOnObject = "NUnit2042";
         internal const string ComparisonConstraintUsage = "NUnit2043";
+        internal const string DelegateRequired = "NUnit2044";
 
         #endregion Assertion
 

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -110,6 +110,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfSubstringConstraint = "NUnit.Framework.Constraints.SubstringConstraint";
         public const string FullNameOfContainsConstraint = "NUnit.Framework.Constraints.ContainsConstraint";
         public const string FullNameOfActualValueDelegate = "NUnit.Framework.Constraints.ActualValueDelegate`1";
+        public const string FullNameOfDelayedConstraint = "NUnit.Framework.Constraints.DelayedConstraint";
         public const string FullNameOfTestDelegate = "NUnit.Framework.TestDelegate";
 
         public const string NameOfTestCaseAttribute = "TestCaseAttribute";

--- a/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NunitFrameworkConstants.cs
@@ -46,6 +46,8 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfHasInnerException = "InnerException";
         public const string NameOfHasNo = "No";
 
+        public const string NameOfThrows = "Throws";
+
         public const string NameOfAssert = "Assert";
         public const string NameOfAssertIsTrue = "IsTrue";
         public const string NameOfAssertTrue = "True";
@@ -72,6 +74,11 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfAssertContains = "Contains";
         public const string NameOfAssertIsInstanceOf = "IsInstanceOf";
         public const string NameOfAssertIsNotInstanceOf = "IsNotInstanceOf";
+
+        public const string NameOfAssertCatch = "Catch";
+        public const string NameOfAssertCatchAsync = "CatchAsync";
+        public const string NameOfAssertThrows = "Throws";
+        public const string NameOfAssertThrowsAsync = "ThrowsAsync";
 
         public const string FullNameOfTypeIs = "NUnit.Framework.Is";
         public const string FullNameOfTypeTestCaseAttribute = "NUnit.Framework.TestCaseAttribute";

--- a/src/nunit.analyzers/DelegateRequired/DelegateRequiredAnalyzer.cs
+++ b/src/nunit.analyzers/DelegateRequired/DelegateRequiredAnalyzer.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+using NUnit.Analyzers.Helpers;
+
+namespace NUnit.Analyzers.DelegateRequired
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DelegateRequiredAnalyzer : BaseAssertionAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Descriptor = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.DelegateRequired,
+            title: DelegateRequiredConstants.Title,
+            messageFormat: DelegateRequiredConstants.Message,
+            category: Categories.Assertion,
+            defaultSeverity: DiagnosticSeverity.Error,
+            description: DelegateRequiredConstants.Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        protected override void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation)
+        {
+            if (!AssertHelper.TryGetActualAndConstraintOperations(assertOperation,
+                out var actualOperation, out var constraintExpression))
+            {
+                return;
+            }
+
+            if (actualOperation is IDelegateCreationOperation)
+            {
+                return;
+            }
+
+            foreach (var constraintPart in constraintExpression.ConstraintParts)
+            {
+                if (constraintPart.HelperClass?.Name == NunitFrameworkConstants.NameOfThrows ||
+                    constraintPart.Suffixes.Any(IsDelayedConstraint))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Descriptor,
+                        actualOperation.Syntax.GetLocation(),
+                        actualOperation.ToString()));
+                }
+            }
+        }
+
+        private static bool IsDelayedConstraint(IOperation operation)
+        {
+            return operation.Type is INamedTypeSymbol namedType &&
+                namedType.GetFullMetadataName().StartsWith(NunitFrameworkConstants.FullNameOfDelayedConstraint, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/nunit.analyzers/DelegateRequired/DelegateRequiredCodeFix.cs
+++ b/src/nunit.analyzers/DelegateRequired/DelegateRequiredCodeFix.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.DelegateRequired
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public class DelegateRequiredCodeFix : CodeFixProvider
+    {
+        internal const string UseAnonymousLambdaDescription = "Use an anonymous lambda so the Assert does the evaluation";
+        internal const string UseMethodGroupDescription = "Use a method group delegate so the Assert does the evaluation";
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(AnalyzerIdentifiers.DelegateRequired);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            if (root is null)
+            {
+                return;
+            }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var diagnostic = context.Diagnostics.First();
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            var argumentNode = node as ArgumentSyntax;
+            if (argumentNode is null)
+                return;
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            ArgumentSyntax original = argumentNode;
+            ArgumentSyntax replacement = argumentNode.WithExpression(SyntaxFactory.ParenthesizedLambdaExpression(argumentNode.Expression));
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    UseAnonymousLambdaDescription,
+                    _ => Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(original, replacement))),
+                    UseAnonymousLambdaDescription), diagnostic);
+
+            if (argumentNode.Expression is InvocationExpressionSyntax invocationNode &&
+                invocationNode.ArgumentList.Arguments.Count == 0)
+            {
+                var methodGroup = SyntaxFactory.IdentifierName(invocationNode.Expression.ToString());
+                replacement = argumentNode.WithExpression(methodGroup);
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        UseMethodGroupDescription,
+                        _ => Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(original, replacement))),
+                        UseMethodGroupDescription), diagnostic);
+            }
+        }
+    }
+}

--- a/src/nunit.analyzers/DelegateRequired/DelegateRequiredConstants.cs
+++ b/src/nunit.analyzers/DelegateRequired/DelegateRequiredConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.DelegateRequired
+{
+    internal static class DelegateRequiredConstants
+    {
+        internal const string Title = "Non-delegate actual parameter";
+        internal const string Message = "The type of the actual argument must be a delegate";
+        internal const string Description = "The actual argument needs to be evaluated by the Assert to catch any exceptions.";
+    }
+}

--- a/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
@@ -143,9 +143,11 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
                     // Check if this is Assert.NotNull or Assert.IsNotNull for the same symbol
                     if (IsAssert(expressionStatement.Expression, out string member, out ArgumentListSyntax? argumentList))
                     {
-                        if (member == "NotNull" || member == "IsNotNull" || member == "That")
+                        if (member == NunitFrameworkConstants.NameOfAssertNotNull ||
+                            member == NunitFrameworkConstants.NameOfAssertIsNotNull ||
+                            member == NunitFrameworkConstants.NameOfAssertThat)
                         {
-                            if (member == "That")
+                            if (member == NunitFrameworkConstants.NameOfAssertThat)
                             {
                                 // We must check the 2nd argument for anything but "Is.Null"
                                 // E.g.: Is.Not.Null.And.Not.Empty.
@@ -189,7 +191,11 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
         private static bool IsKnownToBeNotNull(ExpressionSyntax? expression)
         {
             // For now, we only know that Assert.Throws either returns not-null or throws
-            return IsAssert(expression, "Throws", "Catch", "ThrowsAsync", "CatchAsync");
+            return IsAssert(expression,
+                NunitFrameworkConstants.NameOfAssertThrows,
+                NunitFrameworkConstants.NameOfAssertCatch,
+                NunitFrameworkConstants.NameOfAssertThrowsAsync,
+                NunitFrameworkConstants.NameOfAssertCatchAsync);
         }
 
         private static bool IsAssert(ExpressionSyntax? expression, params string[] requestedMembers)
@@ -204,7 +210,7 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
             if (expression is InvocationExpressionSyntax invocationExpression &&
                 invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression &&
                 memberAccessExpression.Expression is IdentifierNameSyntax identifierName &&
-                identifierName.Identifier.Text == "Assert")
+                identifierName.Identifier.Text == NunitFrameworkConstants.NameOfAssert)
             {
                 member = memberAccessExpression.Name.Identifier.Text;
                 argumentList = invocationExpression.ArgumentList;

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -44,20 +44,26 @@ namespace NUnit.Analyzers.Extensions
         {
             // e.g. System.Collections.Generic.IEnumerable`1
 
-            if (@this.ContainingNamespace == null)
-                return @this.MetadataName;
+            var names = new Stack<string>();
+            var type = @this.ContainingType;
 
-            var namespaces = new Stack<string>();
-
-            var @namespace = @this.ContainingNamespace;
-
-            while (!@namespace.IsGlobalNamespace)
+            while (type != null)
             {
-                namespaces.Push(@namespace.Name);
-                @namespace = @namespace.ContainingNamespace;
+                names.Push(type.Name);
+                type = type.ContainingType;
             }
 
-            return $"{string.Join(".", namespaces)}.{@this.MetadataName}";
+            var @namespace = @this.ContainingNamespace;
+            if (@namespace != null)
+            {
+                while (!@namespace.IsGlobalNamespace)
+                {
+                    names.Push(@namespace.Name);
+                    @namespace = @namespace.ContainingNamespace;
+                }
+            }
+
+            return $"{string.Join(".", names)}.{@this.MetadataName}";
         }
 
         internal static IEnumerable<INamedTypeSymbol> GetAllBaseTypes(this ITypeSymbol @this)


### PR DESCRIPTION
Fixes #357 
Fixes #149 

There is no need to check classic method Assert.Throw etc as the argument definition already specifies a delegate.
