### PR TITLE
Issue 420: Prevent IndexOutOfRangeException

### DIFF
--- a/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
@@ -75,5 +75,29 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
         }");
             RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenNoParameterIsUsedInFirstCall()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            Assert.Fail();
+            Assert.That(string.Empty, Has.Count.EqualTo(1));
+        }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenNoParameterIsUsedInSecondCall()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            Assert.That(string.Empty, Has.Count.EqualTo(1));
+            Assert.Fail();
+        }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleAnalyzer.cs
+++ b/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleAnalyzer.cs
@@ -73,7 +73,7 @@ namespace NUnit.Analyzers.UseAssertMultiple
 
         protected override void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation)
         {
-            if (assertOperation.TargetMethod.Name == NUnitFrameworkConstants.NameOfMultiple ||
+            if (assertOperation.TargetMethod.Name != NUnitFrameworkConstants.NameOfAssertThat ||
                 AssertHelper.IsInsideAssertMultiple(assertOperation.Syntax))
             {
                 return;
@@ -84,6 +84,8 @@ namespace NUnit.Analyzers.UseAssertMultiple
             {
                 // Check if the next operation is also an Assert invocation.
                 var previousArguments = new HashSet<string>(StringComparer.Ordinal);
+
+                // No need to check argument count as Assert.That needs at least one argument.
                 Add(previousArguments, assertOperation.Arguments[0].Syntax.ToString());
 
                 int firstAssert = -1;
@@ -103,9 +105,10 @@ namespace NUnit.Analyzers.UseAssertMultiple
                         IInvocationOperation? currentAssertOperation = TryGetAssertThatOperation(statement);
                         if (currentAssertOperation is not null)
                         {
-                            // Check if test is independent
+                            // No need to check argument count as Assert.That needs at least one argument.
                             string currentArgument = currentAssertOperation.Arguments[0].Syntax.ToString();
 
+                            // Check if test is independent
                             if (IsIndependent(previousArguments, currentArgument))
                             {
                                 lastAssert = i;


### PR DESCRIPTION
Fixes #420 

The fix simply ignores all methods except 'Assert.That' for the first call.
It was already only supporting that for the next methods.