### PR TITLE
Add README.md to NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerelease nuget packages can be found on [MyGet](https://www.myget.org/feed/nun
 
 ## Analyzers ##
 
-The full list of analyzers can be found in the [documentation](documentation/index.md).
+The full list of analyzers can be found in the [documentation](https://github.com/nunit/nunit.analyzers/blob/master/documentation/index.md).
 
 Below we give two examples of analyzers. One will look for methods with the `[TestCase]` attribute and makes sure the argument values are correct for the types of the method parameters along with the `ExpectedResult` value if it is provided.
 

--- a/src/nunit.analyzers/nunit.analyzers.nuspec
+++ b/src/nunit.analyzers/nunit.analyzers.nuspec
@@ -12,6 +12,7 @@
     <repository type="git" url="https://github.com/nunit/nunit.analyzers"/>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Code analyzers and fixes for NUnit 3</summary>
+    <readme>docs/readme.md</readme>
     <description>
 This package includes analyzers and code fixes for test projects using NUnit 3. The analyzers will mark wrong usages when writing tests, and the code fixes can be used to used to correct these usages.
 
@@ -27,5 +28,6 @@ Version 3.0 and upwards works in Visual Studio 2019 and also enables supression 
     <file src="tools\*.ps1" target="tools\" />
     <file src="..\..\license.txt" target="" />
     <file src="..\..\nunit_256.png" target="images" />
+    <file src="..\..\README.md" target="docs" />
   </files>
 </package>


### PR DESCRIPTION
Fixes #418 

@mikkelbu Not sure if we should include this "README.md" as this one contains the build status and also references the documentation on github using a relative path.

I'll see what it does on the myget feed.
