### PR TITLE
Support classic StringAssert in ConstActualValueUsage analyzer and code fix

### DIFF
--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -311,5 +311,162 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
 
             RoslynAssert.Valid(analyzer, testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenLiteralArgumentIsProvidedForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string expected = ""exp"";
+                    StringAssert.Contains(expected, ↓""act"");
+                }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLiteralNamedArgumentIsProvidedForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string expected = ""exp"";
+                    StringAssert.Contains(actual: ↓""act"", expected: expected);
+                }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLocalConstArgumentIsProvidedForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    string expected = ""exp"";
+                    StringAssert.Contains(expected, ↓actual);
+                }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenLocalConstNamedArgumentIsProvidedForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    string expected = ""exp"";
+                    StringAssert.Contains(actual: ↓actual, expected: expected);
+                }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenConstFieldArgumentIsProvidedForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixture
+            {
+                private const string actual = ""act"";
+
+                public void Test()
+                {
+                    string expected = ""exp"";
+                    StringAssert.Contains(expected, ↓actual);
+                }
+            }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenStringEmptyArgumentIsProvidedForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string actual = ""act"";
+                    StringAssert.Contains(actual, string.Empty);
+                }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void ValidWhenNonConstValueIsProvidedAsActualArgumentForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixture
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    string actual = ""act"";
+                    StringAssert.Contains(expected, actual);
+                }
+            }");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenConstValueIsProvidedAsActualAndExpectedArgumentForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixture
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    StringAssert.Contains(expected, actual);
+                }
+            }");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenNonConstValueIsProvidedAsActualNamedArgumentForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixture
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    string actual = ""act"";
+                    StringAssert.Contains(actual: actual, expected: expected);
+                }
+            }");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void ValidWhenConstValueIsProvidedAsActualAndExpectedNamedArgumentForStringAssertContains()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+            public class TestFixture
+            {
+                private const string expected = ""exp"";
+
+                public void Test()
+                {
+                    const string actual = ""act"";
+                    StringAssert.Contains(actual: actual, expected: expected);
+                }
+            }");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -391,7 +391,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     string actual = ""act"";
-                    StringAssert.Contains(actual, string.Empty);
+                    StringAssert.Contains(actual, ↓string.Empty);
                 }");
 
             RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageCodeFixTests.cs
@@ -112,5 +112,56 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
 
             RoslynAssert.NoFix(analyzer, fix, expectedDiagnostic, code);
         }
+
+        [TestCase(nameof(StringAssert.AreEqualIgnoringCase))]
+        [TestCase(nameof(StringAssert.AreNotEqualIgnoringCase))]
+        [TestCase(nameof(StringAssert.Contains))]
+        [TestCase(nameof(StringAssert.EndsWith))]
+        [TestCase(nameof(StringAssert.IsMatch))]
+        [TestCase(nameof(StringAssert.StartsWith))]
+        [TestCase(nameof(StringAssert.DoesNotContain))]
+        [TestCase(nameof(StringAssert.DoesNotMatch))]
+        [TestCase(nameof(StringAssert.DoesNotEndWith))]
+        [TestCase(nameof(StringAssert.DoesNotStartWith))]
+        public void LiteralArgumentIsProvidedForClassicStringAssertCodeFix(string classicAssertMethod)
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+                public void Test()
+                {{
+                    string actual = ""act"";
+                    StringAssert.{classicAssertMethod}(actual, ↓""exp"");
+                }}");
+
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+                public void Test()
+                {{
+                    string actual = ""act"";
+                    StringAssert.{classicAssertMethod}(""exp"", actual);
+                }}");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: ConstActualValueUsageCodeFix.SwapArgumentsDescription);
+        }
+
+        [Test]
+        public void LiteralNamedArgumentIsProvidedForStringAssertContainsCodeFix()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string actual = ""act"";
+                    StringAssert.Contains(actual: ↓""exp"", expected: actual);
+                }");
+
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                public void Test()
+                {
+                    string actual = ""act"";
+                    StringAssert.Contains(actual: actual, expected: ""exp"");
+                }");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: ConstActualValueUsageCodeFix.SwapArgumentsDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -94,6 +94,16 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfAssertThrowsAsync), nameof(Assert.ThrowsAsync)),
 
             (nameof(NUnitFrameworkConstants.NameOfStringAssert), nameof(StringAssert)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertAreEqualIgnoringCase), nameof(StringAssert.AreEqualIgnoringCase)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertAreNotEqualIgnoringCase), nameof(StringAssert.AreNotEqualIgnoringCase)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertContains), nameof(StringAssert.Contains)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotContain), nameof(StringAssert.DoesNotContain)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotEndWith), nameof(StringAssert.DoesNotEndWith)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotMatch), nameof(StringAssert.DoesNotMatch)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotStartWith), nameof(StringAssert.DoesNotStartWith)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertEndsWith), nameof(StringAssert.EndsWith)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertIsMatch), nameof(StringAssert.IsMatch)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssertStartsWith), nameof(StringAssert.StartsWith)),
 
             (nameof(NUnitFrameworkConstants.NameOfConstraint), nameof(Constraint)),
 

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -93,6 +93,11 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfAssertThrows), nameof(Assert.Throws)),
             (nameof(NUnitFrameworkConstants.NameOfAssertThrowsAsync), nameof(Assert.ThrowsAsync)),
 
+            (nameof(NUnitFrameworkConstants.NameOfCollectionAssert), nameof(CollectionAssert)),
+            (nameof(NUnitFrameworkConstants.NameOfDirectoryAssert), nameof(DirectoryAssert)),
+            (nameof(NUnitFrameworkConstants.NameOfFileAssert), nameof(FileAssert)),
+            (nameof(NUnitFrameworkConstants.NameOfStringAssert), nameof(StringAssert)),
+
             (nameof(NUnitFrameworkConstants.NameOfConstraint), nameof(Constraint)),
 
             (nameof(NUnitFrameworkConstants.NameOfTestCaseAttribute), nameof(TestCaseAttribute)),

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -93,9 +93,6 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfAssertThrows), nameof(Assert.Throws)),
             (nameof(NUnitFrameworkConstants.NameOfAssertThrowsAsync), nameof(Assert.ThrowsAsync)),
 
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssert), nameof(CollectionAssert)),
-            (nameof(NUnitFrameworkConstants.NameOfDirectoryAssert), nameof(DirectoryAssert)),
-            (nameof(NUnitFrameworkConstants.NameOfFileAssert), nameof(FileAssert)),
             (nameof(NUnitFrameworkConstants.NameOfStringAssert), nameof(StringAssert)),
 
             (nameof(NUnitFrameworkConstants.NameOfConstraint), nameof(Constraint)),

--- a/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
@@ -201,9 +201,6 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
         }
 
         [TestCase("Assert")]
-        [TestCase("CollectionAssert")]
-        [TestCase("DirectoryAssert")]
-        [TestCase("FileAssert")]
         [TestCase("StringAssert")]
         public async Task IsAnyAssertWhenSymbolIsAnyAssertType(string assertType)
         {

--- a/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
@@ -200,6 +200,27 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
             Assert.That(typeSymbol.IsAssert(), Is.True);
         }
 
+        [TestCase("Assert")]
+        [TestCase("CollectionAssert")]
+        [TestCase("DirectoryAssert")]
+        [TestCase("FileAssert")]
+        [TestCase("StringAssert")]
+        public async Task IsAnyAssertWhenSymbolIsAnyAssertType(string assertType)
+        {
+            var testCode = $@"
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.Targets.Extensions
+{{
+    public sealed class IsAnyAssertWhenSymbolIsAnyAssertType
+    {{
+        public {assertType} x;
+    }}
+}}";
+            var typeSymbol = await GetTypeSymbolFromFieldAsync(testCode, "IsAnyAssertWhenSymbolIsAnyAssertType").ConfigureAwait(false);
+            Assert.That(typeSymbol.IsAnyAssert(), Is.True);
+        }
+
         private static async Task<ImmutableArray<ITypeSymbol>> GetTypeSymbolAsync(string code, string[] typeNames)
         {
             var rootAndModel = await TestHelpers.GetRootAndModel(code).ConfigureAwait(false);

--- a/src/nunit.analyzers/BaseAssertionAnalyzer.cs
+++ b/src/nunit.analyzers/BaseAssertionAnalyzer.cs
@@ -16,14 +16,7 @@ namespace NUnit.Analyzers
 
         protected abstract void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation);
 
-        protected static bool IsAssert(IOperation operation)
-        {
-            return operation is IExpressionStatementOperation expressionOperation &&
-                expressionOperation.Operation is IInvocationOperation invocationOperation &&
-                IsAssert(invocationOperation);
-        }
-
-        protected static bool IsAssert(IInvocationOperation invocationOperation)
+        protected virtual bool IsAssert(IInvocationOperation invocationOperation)
         {
             return invocationOperation.TargetMethod.ContainingType.IsAssert();
         }
@@ -33,7 +26,7 @@ namespace NUnit.Analyzers
             if (context.Operation is not IInvocationOperation invocationOperation)
                 return;
 
-            if (!IsAssert(invocationOperation))
+            if (!this.IsAssert(invocationOperation))
                 return;
 
             context.CancellationToken.ThrowIfCancellationRequested();

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageAnalyzer.cs
@@ -22,6 +22,11 @@ namespace NUnit.Analyzers.ConstActualValueUsage
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
+        protected override bool IsAssert(IInvocationOperation invocationOperation)
+        {
+            return invocationOperation.TargetMethod.ContainingType.IsAnyAssert();
+        }
+
         protected override void AnalyzeAssertInvocation(OperationAnalysisContext context, IInvocationOperation assertOperation)
         {
             static bool IsStringEmpty(IOperation operation)

--- a/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageCodeFix.cs
+++ b/src/nunit.analyzers/ConstActualValueUsage/ConstActualValueUsageCodeFix.cs
@@ -23,7 +23,21 @@ namespace NUnit.Analyzers.ConstActualValueUsage
             NUnitFrameworkConstants.NameOfAssertAreEqual,
             NUnitFrameworkConstants.NameOfAssertAreNotEqual,
             NUnitFrameworkConstants.NameOfAssertAreSame,
-            NUnitFrameworkConstants.NameOfAssertAreNotSame
+            NUnitFrameworkConstants.NameOfAssertAreNotSame,
+        };
+
+        private static readonly string[] SupportedStringAsserts = new[]
+        {
+            NUnitFrameworkConstants.NameOfStringAssertAreEqualIgnoringCase,
+            NUnitFrameworkConstants.NameOfStringAssertAreNotEqualIgnoringCase,
+            NUnitFrameworkConstants.NameOfStringAssertContains,
+            NUnitFrameworkConstants.NameOfStringAssertDoesNotContain,
+            NUnitFrameworkConstants.NameOfStringAssertDoesNotEndWith,
+            NUnitFrameworkConstants.NameOfStringAssertDoesNotMatch,
+            NUnitFrameworkConstants.NameOfStringAssertDoesNotStartWith,
+            NUnitFrameworkConstants.NameOfStringAssertEndsWith,
+            NUnitFrameworkConstants.NameOfStringAssertIsMatch,
+            NUnitFrameworkConstants.NameOfStringAssertStartsWith,
         };
 
         private static readonly string[] SupportedIsConstraints = new[]
@@ -88,11 +102,12 @@ namespace NUnit.Analyzers.ConstActualValueUsage
 
             var methodSymbol = semanticModel.GetSymbolInfo(invocationSyntax).Symbol as IMethodSymbol;
 
-            if (methodSymbol is null || !methodSymbol.ContainingType.IsAssert())
+            if (methodSymbol is null || !methodSymbol.ContainingType.IsAnyAssert())
                 return false;
 
             // option 1: Classic assert (e.g. Assert.AreEqual(expected, actual) )
-            if (SupportedClassicAsserts.Contains(methodSymbol.Name) && methodSymbol.Parameters.Length >= 2)
+            if ((IsSupportedAssert(methodSymbol) || IsSupportedStringAssert(methodSymbol))
+                && methodSymbol.Parameters.Length >= 2)
             {
                 expectedArgument = invocationSyntax.ArgumentList.Arguments[0].Expression;
                 actualArgument = invocationSyntax.ArgumentList.Arguments[1].Expression;
@@ -134,6 +149,16 @@ namespace NUnit.Analyzers.ConstActualValueUsage
             }
 
             return false;
+        }
+
+        private static bool IsSupportedAssert(IMethodSymbol methodSymbol)
+        {
+            return methodSymbol.ContainingType.Name == NUnitFrameworkConstants.NameOfAssert && SupportedClassicAsserts.Contains(methodSymbol.Name);
+        }
+
+        private static bool IsSupportedStringAssert(IMethodSymbol methodSymbol)
+        {
+            return methodSymbol.ContainingType.Name == NUnitFrameworkConstants.NameOfStringAssert && SupportedStringAsserts.Contains(methodSymbol.Name);
         }
     }
 }

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -83,6 +83,16 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfAssertThrowsAsync = "ThrowsAsync";
 
         public const string NameOfStringAssert = "StringAssert";
+        public const string NameOfStringAssertAreEqualIgnoringCase = "AreEqualIgnoringCase";
+        public const string NameOfStringAssertAreNotEqualIgnoringCase = "AreNotEqualIgnoringCase";
+        public const string NameOfStringAssertContains = "Contains";
+        public const string NameOfStringAssertDoesNotContain = "DoesNotContain";
+        public const string NameOfStringAssertDoesNotEndWith = "DoesNotEndWith";
+        public const string NameOfStringAssertDoesNotMatch = "DoesNotMatch";
+        public const string NameOfStringAssertDoesNotStartWith = "DoesNotStartWith";
+        public const string NameOfStringAssertEndsWith = "EndsWith";
+        public const string NameOfStringAssertIsMatch = "IsMatch";
+        public const string NameOfStringAssertStartsWith = "StartsWith";
 
         public const string FullNameOfTypeIs = "NUnit.Framework.Is";
         public const string FullNameOfTypeTestCaseAttribute = "NUnit.Framework.TestCaseAttribute";

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -82,6 +82,11 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfAssertThrows = "Throws";
         public const string NameOfAssertThrowsAsync = "ThrowsAsync";
 
+        public const string NameOfCollectionAssert = "CollectionAssert";
+        public const string NameOfDirectoryAssert = "DirectoryAssert";
+        public const string NameOfFileAssert = "FileAssert";
+        public const string NameOfStringAssert = "StringAssert";
+
         public const string FullNameOfTypeIs = "NUnit.Framework.Is";
         public const string FullNameOfTypeTestCaseAttribute = "NUnit.Framework.TestCaseAttribute";
         public const string FullNameOfTypeTestCaseSourceAttribute = "NUnit.Framework.TestCaseSourceAttribute";
@@ -136,5 +141,10 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfUsing = "Using";
 
         public const string NUnitFrameworkAssemblyName = "nunit.framework";
+
+        public static readonly string[] AllAsserts =
+        {
+            NameOfAssert, NameOfCollectionAssert, NameOfDirectoryAssert, NameOfFileAssert, NameOfStringAssert
+        };
     }
 }

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -82,9 +82,6 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfAssertThrows = "Throws";
         public const string NameOfAssertThrowsAsync = "ThrowsAsync";
 
-        public const string NameOfCollectionAssert = "CollectionAssert";
-        public const string NameOfDirectoryAssert = "DirectoryAssert";
-        public const string NameOfFileAssert = "FileAssert";
         public const string NameOfStringAssert = "StringAssert";
 
         public const string FullNameOfTypeIs = "NUnit.Framework.Is";
@@ -144,7 +141,7 @@ namespace NUnit.Analyzers.Constants
 
         public static readonly string[] AllAsserts =
         {
-            NameOfAssert, NameOfCollectionAssert, NameOfDirectoryAssert, NameOfFileAssert, NameOfStringAssert
+            NameOfAssert, NameOfStringAssert
         };
     }
 }

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -26,6 +26,13 @@ namespace NUnit.Analyzers.Extensions
                 @this.Name == NUnitFrameworkConstants.NameOfAssert;
         }
 
+        internal static bool IsAnyAssert(this ITypeSymbol? @this)
+        {
+            return @this is not null &&
+                   @this.ContainingAssembly.Name == NUnitFrameworkConstants.NUnitFrameworkAssemblyName &&
+                   NUnitFrameworkConstants.AllAsserts.Contains(@this.Name);
+        }
+
         internal static bool IsConstraint(this ITypeSymbol? @this)
         {
             return @this is not null && @this.GetAllBaseTypes()

--- a/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleAnalyzer.cs
+++ b/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleAnalyzer.cs
@@ -136,7 +136,7 @@ namespace NUnit.Analyzers.UseAssertMultiple
         {
             return (operation is IExpressionStatementOperation expressionOperation &&
                 expressionOperation.Operation is IInvocationOperation invocationOperation &&
-                IsAssert(invocationOperation) &&
+                invocationOperation.TargetMethod.ContainingType.IsAssert() &&
                 invocationOperation.TargetMethod.Name == NUnitFrameworkConstants.NameOfAssertThat)
                 ? invocationOperation : null;
         }


### PR DESCRIPTION
This adds support for `StringAssert` to `ConstActualValueUsageAnalyzer` and `ConstActualValueUsageCodeFix`.

The analyzers already support "classic" assertions in many places, but only ones that are defined on `Assert`. I have an existing codebase that frequently uses `StringAssert` and the other classic Assert classes, and I recently found a case where a `StringAssert.Contains` call started failing incorrectly after a refactoring because the arguments were reversed. I have tested that this change correctly flags that case.

This change is narrowly focused on `StringAssert` and `ConstActualValueUsage`; but if the general approach is acceptable, I can add more classic Asserts to more analyzers. I am probably going to do it anyway to use on my own code.

Also, I noticed that the existing code fix only supports the classic assertions specifically related to equality; but I saw no reason not to support all of the asserts on `StringAssert`, as they all follow the same format.