### PR TITLE
Throws.Equals type is not related to actual delegate.

### DIFF
--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -59,7 +59,12 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfHasNo), nameof(Has.No)),
 
             (nameof(NUnitFrameworkConstants.NameOfMultiple), nameof(Assert.Multiple)),
-            (nameof(NUnitFrameworkConstants.NameOfThrows), nameof(Assert.Throws)),
+
+            (nameof(NUnitFrameworkConstants.NameOfThrows), nameof(Throws)),
+            (nameof(NUnitFrameworkConstants.NameOfThrowsArgumentException), nameof(Throws.ArgumentException)),
+            (nameof(NUnitFrameworkConstants.NameOfThrowsArgumentNullException), nameof(Throws.ArgumentNullException)),
+            (nameof(NUnitFrameworkConstants.NameOfThrowsInvalidOperationException), nameof(Throws.InvalidOperationException)),
+            (nameof(NUnitFrameworkConstants.NameOfThrowsTargetInvocationException), nameof(Throws.TargetInvocationException)),
 
             (nameof(NUnitFrameworkConstants.NameOfAssert), nameof(Assert)),
             (nameof(NUnitFrameworkConstants.NameOfAssertIsTrue), nameof(Assert.IsTrue)),
@@ -155,6 +160,7 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.FullNameOfActualValueDelegate), typeof(ActualValueDelegate<>)),
             (nameof(NUnitFrameworkConstants.FullNameOfDelayedConstraint), typeof(DelayedConstraint)),
             (nameof(NUnitFrameworkConstants.FullNameOfTestDelegate), typeof(TestDelegate)),
+            (nameof(NUnitFrameworkConstants.FullNameOfThrows), typeof(Throws)),
         };
 
         [TestCaseSource(nameof(NameOfSource))]

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -49,6 +49,10 @@ namespace NUnit.Analyzers.Constants
 
         public const string NameOfMultiple = "Multiple";
         public const string NameOfThrows = "Throws";
+        public const string NameOfThrowsArgumentException = "ArgumentException";
+        public const string NameOfThrowsArgumentNullException = "ArgumentNullException";
+        public const string NameOfThrowsInvalidOperationException = "InvalidOperationException";
+        public const string NameOfThrowsTargetInvocationException = "TargetInvocationException";
 
         public const string NameOfAssert = "Assert";
         public const string NameOfAssertIsTrue = "IsTrue";
@@ -126,6 +130,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfActualValueDelegate = "NUnit.Framework.Constraints.ActualValueDelegate`1";
         public const string FullNameOfDelayedConstraint = "NUnit.Framework.Constraints.DelayedConstraint";
         public const string FullNameOfTestDelegate = "NUnit.Framework.TestDelegate";
+        public const string FullNameOfThrows = "NUnit.Framework.Throws";
 
         public const string NameOfTestCaseAttribute = "TestCaseAttribute";
         public const string NameOfTestCaseSourceAttribute = "TestCaseSourceAttribute";


### PR DESCRIPTION
Fixes #465 

If Throws is used, inspects TypeOf/InstanceOf methods and properties to determine type to compare against.