### PR TITLE
[add] GitHub Actions workflow for running test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Setup .NET
+        uses: actions/setup-dotnet@main
+        with:
+          global-json-file: ./global.json
+      - name: dotnet test
+        run: dotnet test ./src/nunit.analyzers.tests/


### PR DESCRIPTION
I wrote a patch to run nunit.analyzers's tests on GitHub Actions. 
This enables automated testing with CI.

see also:
CI's log
  - https://github.com/get-me-power/nunit.analyzers/actions/runs/3032762761