### PR TITLE
Do not raise diagnostics when using == etc on 'ref struct'

### DIFF
--- a/src/nunit.analyzers.tests/ConstraintsUsage/ComparisonConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/ComparisonConstraintUsageAnalyzerTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.ConstraintUsage;
@@ -106,7 +109,10 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         }}
     }}");
 
-            RoslynAssert.Valid(analyzer, testCode);
+            IEnumerable<MetadataReference> spanMetadata = MetadataReferences.Transitive(typeof(Span<>));
+            IEnumerable<MetadataReference> metadataReferences = (Settings.Default.MetadataReferences ?? Enumerable.Empty<MetadataReference>()).Concat(spanMetadata);
+
+            RoslynAssert.Valid(analyzer, testCode, Settings.Default.WithMetadataReferences(metadataReferences));
         }
     }
 }

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.ConstraintUsage;
@@ -227,7 +230,10 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
                 var span2 = new[] {{ 1 }}.AsSpan();
                 Assert.That(span1 {operatorToken} span2, Is.True);");
 
-            RoslynAssert.Valid(analyzer, testCode);
+            IEnumerable<MetadataReference> spanMetadata = MetadataReferences.Transitive(typeof(Span<>));
+            IEnumerable<MetadataReference> metadataReferences = (Settings.Default.MetadataReferences ?? Enumerable.Empty<MetadataReference>()).Concat(spanMetadata);
+
+            RoslynAssert.Valid(analyzer, testCode, Settings.Default.WithMetadataReferences(metadataReferences));
         }
 
         [Test]
@@ -251,7 +257,10 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         public static bool Equals<T>(this Span<T> left, Span<T> right) => left == right;
     }");
 
-            RoslynAssert.Valid(analyzer, testCode);
+            IEnumerable<MetadataReference> spanMetadata = MetadataReferences.Transitive(typeof(Span<>));
+            IEnumerable<MetadataReference> metadataReferences = (Settings.Default.MetadataReferences ?? Enumerable.Empty<MetadataReference>()).Concat(spanMetadata);
+
+            RoslynAssert.Valid(analyzer, testCode, Settings.Default.WithMetadataReferences(metadataReferences));
         }
     }
 }

--- a/src/nunit.analyzers.tests/UseCollectionConstraint/UseCollectionConstraintAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseCollectionConstraint/UseCollectionConstraintAnalyzerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -95,6 +97,20 @@ namespace NUnit.Analyzers.Tests.UseCollectionConstraint
                 public double Diameter { get; set; }
                 public int Length { get; set; }
             }
+        }");
+
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenRefStructIsUsed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            const int Length = 8;
+            var span = new byte[Length].AsSpan();
+            Assert.That(span.Length, Is.EqualTo(Length));
         }");
 
             RoslynAssert.Valid(this.analyzer, testCode);

--- a/src/nunit.analyzers.tests/UseCollectionConstraint/UseCollectionConstraintAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseCollectionConstraint/UseCollectionConstraintAnalyzerTests.cs
@@ -1,6 +1,8 @@
 using System;
-using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.UseCollectionConstraint;
@@ -113,7 +115,10 @@ namespace NUnit.Analyzers.Tests.UseCollectionConstraint
             Assert.That(span.Length, Is.EqualTo(Length));
         }");
 
-            RoslynAssert.Valid(this.analyzer, testCode);
+            IEnumerable<MetadataReference> spanMetadata = MetadataReferences.Transitive(typeof(Span<>));
+            IEnumerable<MetadataReference> metadataReferences = (Settings.Default.MetadataReferences ?? Enumerable.Empty<MetadataReference>()).Concat(spanMetadata);
+
+            RoslynAssert.Valid(this.analyzer, testCode, Settings.Default.WithMetadataReferences(metadataReferences));
         }
     }
 }

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
@@ -28,6 +28,23 @@ namespace NUnit.Analyzers.ConstraintUsage
             NameOfAssertIsFalse
         };
 
+        protected static bool IsRefStruct(IOperation operation)
+        {
+#if NETSTANDARD2_0_OR_GREATER
+            return operation.Type?.TypeKind == TypeKind.Struct && operation.Type.IsRefLikeType;
+#else
+            return false;
+#endif
+        }
+
+        protected static bool IsBinaryOperationNotUsingRefStructOperands(IOperation actual, BinaryOperatorKind binaryOperator)
+        {
+            return actual is IBinaryOperation binaryOperation &&
+                binaryOperation.OperatorKind == binaryOperator &&
+                !IsRefStruct(binaryOperation.LeftOperand) &&
+                !IsRefStruct(binaryOperation.RightOperand);
+        }
+
         protected virtual (DiagnosticDescriptor? descriptor, string? suggestedConstraint, bool swapOperands) GetDiagnosticDataWithPossibleSwapOperands(
             OperationAnalysisContext context, IOperation actual, bool negated)
         {

--- a/src/nunit.analyzers/ConstraintUsage/ComparisonConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/ComparisonConstraintUsageAnalyzer.cs
@@ -26,7 +26,8 @@ namespace NUnit.Analyzers.ConstraintUsage
         {
             // 'actual >= expected', 'actual > expected'
             // 'actual <= expected', 'actual < expected'
-            if (actual is IBinaryOperation binaryOperation)
+            if (actual is IBinaryOperation binaryOperation &&
+                !IsRefStruct(binaryOperation.LeftOperand) && !IsRefStruct(binaryOperation.RightOperand))
             {
                 bool swapOperands = false;
 

--- a/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/EqualConstraintUsageAnalyzer.cs
@@ -29,7 +29,7 @@ namespace NUnit.Analyzers.ConstraintUsage
             var shouldReport = false;
 
             // 'actual == expected', 'Equals(actual, expected)' or 'actual.Equals(expected)'
-            if (actual is IBinaryOperation { OperatorKind: BinaryOperatorKind.Equals }
+            if (IsBinaryOperationNotUsingRefStructOperands(actual, BinaryOperatorKind.Equals)
                 || IsStaticObjectEquals(actual)
                 || IsInstanceObjectEquals(actual))
             {
@@ -37,7 +37,7 @@ namespace NUnit.Analyzers.ConstraintUsage
             }
 
             // 'actual != expected'
-            else if (actual is IBinaryOperation { OperatorKind: BinaryOperatorKind.NotEquals })
+            else if (IsBinaryOperationNotUsingRefStructOperands(actual, BinaryOperatorKind.NotEquals))
             {
                 shouldReport = true;
                 negated = !negated;
@@ -76,7 +76,9 @@ namespace NUnit.Analyzers.ConstraintUsage
             return methodSymbol is not null
                 && !methodSymbol.IsStatic
                 && methodSymbol.Parameters.Length == 1
-                && methodSymbol.Name == nameof(object.Equals);
+                && methodSymbol.Name == nameof(object.Equals)
+                && invocation.Arguments.Length == 1
+                && !IsRefStruct(invocation.Arguments[0]);
         }
     }
 }


### PR DESCRIPTION
Fixes #475