### PR TITLE
Add note about works with unity3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The other analyzer looks for classic model assertions (e.g. `Assert.AreEqual()`,
 
 <img src="https://user-images.githubusercontent.com/1007631/44311791-213d2780-a3ee-11e8-90b8-6d144c0e3dbd.gif" alt="classic model assertions analyzers" width="1000"/>
 
-## Which version works with Unity Test Framework
+## Which version works with Unity Test Framework ##
 
-If your Unity project is made by Unity under 2021.2, Use NUnit.Analyzers v2.x
+If your Unity project is made by Unity under 2021.2, then use NUnit.Analyzers v2.x.
 
-If your Unity project is made by Unity 2021.2 or later, Use NUnit.Analyzers v3.3 (does not work v3.4 or later)
+If your Unity project is made by Unity 2021.2 or later, then use NUnit.Analyzers v3.3 (v3.4 or later of the analyzers does not work with Unity).
 
-You should use an analyzer built with the same version as Microsoft.CodeAnalysis.CSharp embedded in the Unity Editor.
+You should use an analyzer built with the same version of Microsoft.CodeAnalysis.CSharp as the one embedded in the Unity Editor.
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ The other analyzer looks for classic model assertions (e.g. `Assert.AreEqual()`,
 
 <img src="https://user-images.githubusercontent.com/1007631/44311791-213d2780-a3ee-11e8-90b8-6d144c0e3dbd.gif" alt="classic model assertions analyzers" width="1000"/>
 
+## Which version works with Unity Test Framework
+
+If your Unity project is made by Unity under 2021.2, Use NUnit.Analyzers v2.x
+
+If your Unity project is made by Unity 2021.2 or later, Use NUnit.Analyzers v3.3 (does not work v3.4 or later)
+
+You should use an analyzer built with the same version as Microsoft.CodeAnalysis.CSharp embedded in the Unity Editor.
+
 ## License ##
 
 NUnit analyzers are Open Source software and released under the [MIT license](http://www.nunit.org/nuget/nunit3-license.txt), which allow the use of the analyzers in free and commercial applications and libraries without restrictions.


### PR DESCRIPTION
Unity Test Framework (standard testing framework of unity3d) is based on NUnit3.
Therefore, this analyzer is very useful.

But, the user should use an analyzer built with the same version as Microsoft.CodeAnalysis.CSharp embedded in the Unity Editor follows:

- Unity under 2021.2: Microsoft.CodeAnalysis.CSharp v3.5.0
- Unity 2021.2 or later: Microsoft.CodeAnalysis.CSharp v3.9.0

I added a caution about this in the README.md