### PR TITLE
Detect path for conditional/coalescing expression for null suppression

### DIFF
--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -626,10 +626,10 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
         [TestCase("string fatal; if (line2 is not null) fatal = line2; else fatal = line1;")]
         [TestCase("string fatal; if (line2 is not null) { fatal = line2; } else { fatal = line1; }")]
         [TestCase("string fatal; if (line2 != null) fatal = line2; else fatal = line1;")]
-        [TestCase("string fatal; if (line2 != null) { fatal = line2; } else { fatal = line1; }")]
+        [TestCase("string fatal; if (null != line2) { fatal = line2; } else { fatal = line1; }")]
         [TestCase("string fatal; if (line2 is null) fatal = line1; else fatal = line2;")]
         [TestCase("string fatal; if (line2 is null) { fatal = line1; } else { fatal = line2; }")]
-        [TestCase("string fatal; if (line2 == null) fatal = line1; else fatal = line2;")]
+        [TestCase("string fatal; if (null == line2) fatal = line1; else fatal = line2;")]
         [TestCase("string fatal; if (line2 == null) { fatal = line1; } else { fatal = line2; }")]
         public void TestIssue503SimpleIdentifier(string expression)
         {
@@ -656,6 +656,8 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
         [TestCase("string fatal = lines.Line2 is null ? lines.Line1 : lines.Line2;")]
         [TestCase("string fatal = lines.Line2 != null ? lines.Line2 : lines.Line1;")]
         [TestCase("string fatal = lines.Line2 == null ? lines.Line1 : lines.Line2;")]
+        [TestCase("string fatal = null != lines.Line2 ? lines.Line2 : lines.Line1;")]
+        [TestCase("string fatal = null == lines.Line2 ? lines.Line1 : lines.Line2;")]
         public void TestIssue503Properties(string expression)
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"


### PR DESCRIPTION
Fixes #503 

The compiler raises the error on the whole statement, not on the part that is possibly `null`.
Simple for coalescing operator as we need to check the right hand side.
Harder for conditional operator. Code tries to detect the side, but only for simple expressions against `null`.

This PR also contains a fix for when the if/else parts are not contained in a block.
