### PR TITLE
Do not report errors on TestCase parameters types that are invalid.

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -356,6 +356,18 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         }
 
         [Test]
+        public void AnalyzeArgumentHasTypeNotAllowedInAttributes()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    class AnalyzeArgumentHasTypeNotAllowedInAttributes
+    {
+        [TestCase(1.0m)]
+        public void Test(decimal d) { }
+    }");
+            RoslynAssert.Valid(this.analyzer, testCode, Settings.Default.WithAllowedCompilerDiagnostics(AllowedCompilerDiagnostics.WarningsAndErrors));
+        }
+
+        [Test]
         public void AnalyzeWhenArgumentPassesNullToValueType()
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -179,6 +179,12 @@ namespace NUnit.Analyzers.TestCaseUsage
             for (var i = 0; i < attributePositionalArguments.Length; i++)
             {
                 var attributeArgument = attributePositionalArguments[i];
+
+                // If the compiler detects an illegal constant, we shouldn't check it.
+                // Unfortunately the constant 'null' is marked as Error with a null type.
+                if (attributeArgument.Kind == TypedConstantKind.Error && attributeArgument.Type is not null)
+                    continue;
+
                 var (methodParameterType, methodParameterName, methodParameterParamsType) =
                     TestCaseUsageAnalyzer.GetParameterType(methodParameters, i);
 


### PR DESCRIPTION
Fixes #509
Fixes #510 

If the attribute argument has a type, but is marked as Error, do not report it.
The compiler already report the invalid argument.