### PR TITLE
Markdown fixes

### DIFF
--- a/documentation/NUnit1030.md
+++ b/documentation/NUnit1030.md
@@ -33,7 +33,6 @@ public void IsNUnit(int n)
 
 Match the type of parameters between the test data and the test method.
 
-
 <!-- start generated config severity -->
 ## Configure severity
 

--- a/documentation/NUnit2046.md
+++ b/documentation/NUnit2046.md
@@ -24,7 +24,7 @@ Assert.That(array.Length, Is.EqualTo(1));
 Assert.That(array, Has.Length.EqualTo(1));
 ```
 
-The first gives: `Expected: 1, But was: 2`, the second: `Expected: property Length equal to 1, But was: 2` 
+The first gives: `Expected: 1, But was: 2`, the second: `Expected: property Length equal to 1, But was: 2`
 making it clear we talking about number of elements, not just a number.
 
 The next example:

--- a/documentation/NUnit3001.md
+++ b/documentation/NUnit3001.md
@@ -17,6 +17,7 @@ This rule check diagnostics reported by the CS8601-CS8607 and CS8629 compiler er
 `CS8602: Dereference of a possibly null reference.`
 
 It then checks the previous statements for one of:
+
 * `Assert.NotNull(...)`
 * `Assert.IsNotNull(...)`
 * `Assert.That(..., Is.Not.Null)`
@@ -27,6 +28,7 @@ If found, the compiler error is suppressed.
 The rule also covers `CS8629: Nullable value type may be null`
 
 In this case, the previous statement is allowed to be one of:
+
 * `Assert.That(...HasValue)`
 * `Assert.That(...HasValue, Is.True)`
 * `Assert.True(...HasValue)`
@@ -119,4 +121,3 @@ This is currently not working. Waiting for [Roslyn](https://github.com/dotnet/ro
 dotnet_diagnostic.NUnit3001.severity = none
 ```
 <!-- end generated config severity -->
-

--- a/documentation/NUnit3002.md
+++ b/documentation/NUnit3002.md
@@ -91,4 +91,3 @@ This is currently not working. Waiting for [Roslyn](https://github.com/dotnet/ro
 dotnet_diagnostic.NUnit3002.severity = none
 ```
 <!-- end generated config severity -->
-


### PR DESCRIPTION
The analyzer docs flow into the NUnit docs, and the NUnit docs showed some markdown linting issues (which I didn't catch because of https://github.com/nunit/docs/issues/746. 

This PR should fix those items at the source.

PS if you want the markdown linting built directly into the GitHub CI here, let me know and I can make that happen.