### PR TITLE
Keep leading and trailing trivia when replacing statements with Assert.Multiple

### DIFF
--- a/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleCodeFixTests.cs
@@ -135,12 +135,11 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
 
-        [TestCase("            // ", "")]
-        [TestCase("\r\n            // ", "")]
-        [TestCase("\r\n            ", "")]
-        [TestCase("\r\n            ", " // Same line Comment")]
-        [TestCase("\r\n            ", "\r\n            // Final Comment on next line")]
-        public void VerifyKeepsTrivia(string separation, string comment)
+        [Test]
+        public void VerifyKeepsTrivia(
+            [Values("", "\r\n")] string newline,
+            [Values("", "// ")] string preComment,
+            [Values("", "// Same line Comment", "\r\n            // Final Comment on next line")] string postComment)
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
         public void TestMethod()
@@ -150,8 +149,8 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
 
             // Verify that our bool constants are correct
             ↓Assert.That(True, Is.True);
-            Assert.That(False, Is.False);
-{separation}Console.WriteLine(""Next Statement"");{comment}
+            Assert.That(False, Is.False);{newline}
+            {preComment}Console.WriteLine(""Next Statement"");{postComment}
         }}");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
         public void TestMethod()
@@ -164,8 +163,8 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
                 // Verify that our bool constants are correct
                 Assert.That(True, Is.True);
                 Assert.That(False, Is.False);
-            }});
-{separation}Console.WriteLine(""Next Statement"");{comment}
+            }});{newline}
+            {preComment}Console.WriteLine(""Next Statement"");{postComment}
         }}");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }

--- a/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleCodeFix.cs
+++ b/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleCodeFix.cs
@@ -127,16 +127,15 @@ namespace NUnit.Analyzers.UseAssertMultiple
                         SyntaxFactory.SeparatedList(new[]
                         {
                             SyntaxFactory.Argument(parenthesizedLambdaExpression)
-                        })))).WithAdditionalAnnotations(Formatter.Annotation);
+                        }))))
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed)
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
             if (endOfLineTrivia is not null)
             {
-                // Add the remembered blank line.
+                // Add the remembered blank line to go before the Assert.Multiple statement.
                 assertMultiple = assertMultiple.WithLeadingTrivia(endOfLineTrivia.Value);
             }
-
-            // Add new line after the Assert.Multiple statement.
-            assertMultiple = assertMultiple.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
 
             // Comments at the end of a block are not associated with the last statement but with the closing brace
             // Keep the exising block's open and close braces with associated trivia in our updated block.


### PR DESCRIPTION
Fixes #534 

The empty line before the first Assert that can be merged is part of that statement. It needs to be moved to the new Assert.Multiple call.

Comment at the end of the block are part of block's closing brace, maintain that to keep the comments.