### PR TITLE
Use RegisterCompilationStartAction to avoid repeated calls to GetTypeByMetadataName

### DIFF
--- a/src/nunit.analyzers/SourceCommon/SourceHelpers.cs
+++ b/src/nunit.analyzers/SourceCommon/SourceHelpers.cs
@@ -49,15 +49,9 @@ namespace NUnit.Analyzers.SourceCommon
 
         public static SourceAttributeInformation? GetSourceAttributeInformation(
             SyntaxNodeAnalysisContext context,
-            string fullyQualifiedMetadataName,
+            INamedTypeSymbol valueSourceType,
             string typeName)
         {
-            var valueSourceType = context.SemanticModel.Compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
-            if (valueSourceType is null)
-            {
-                return null;
-            }
-
             var attributeNode = (AttributeSyntax)context.Node;
             var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeNode).Symbol;
 

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -112,11 +112,9 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterCompilationStartAction(AnalyzeCompilationStart);
-
         }
 
         private static void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
-
         {
             var testCaseSourceAttribute = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseSourceAttribute);
             if (testCaseSourceAttribute is null)

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -111,10 +111,12 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterCompilationStartAction(AnalyzeCompilation);
+            context.RegisterCompilationStartAction(AnalyzeCompilationStart);
+
         }
 
-        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
+        private static void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
+
         {
             var testCaseSourceAttribute = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseSourceAttribute);
             if (testCaseSourceAttribute is null)

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -111,14 +111,25 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(x => AnalyzeAttribute(x), SyntaxKind.Attribute);
+            context.RegisterCompilationStartAction(AnalyzeCompilation);
         }
 
-        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
+        {
+            var testCaseSourceAttribute = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseSourceAttribute);
+            if (testCaseSourceAttribute is null)
+            {
+                return;
+            }
+
+            context.RegisterSyntaxNodeAction(syntaxContext => AnalyzeAttribute(syntaxContext, testCaseSourceAttribute), SyntaxKind.Attribute);
+        }
+
+        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context, INamedTypeSymbol testCaseSourceAttribute)
         {
             var attributeInfo = SourceHelpers.GetSourceAttributeInformation(
                 context,
-                NUnitFrameworkConstants.FullNameOfTypeTestCaseSourceAttribute,
+                testCaseSourceAttribute,
                 NUnitFrameworkConstants.NameOfTestCaseSourceAttribute);
 
             if (attributeInfo is null)

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -43,10 +43,10 @@ namespace NUnit.Analyzers.TestCaseUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterCompilationStartAction(AnalyzeCompilation);
+            context.RegisterCompilationStartAction(AnalyzeCompilationStart);
         }
 
-        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
+        private static void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
         {
             var testCaseType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
             if (testCaseType is null)

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -78,18 +78,23 @@ namespace NUnit.Analyzers.TestMethodUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+            context.RegisterCompilationStartAction(AnalyzeCompilation);
         }
 
-        private static void AnalyzeMethod(SymbolAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
         {
-            var methodSymbol = (IMethodSymbol)context.Symbol;
-
-            var testCaseType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
-            var testType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestAttribute);
+            INamedTypeSymbol? testCaseType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
+            INamedTypeSymbol? testType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestAttribute);
 
             if (testCaseType is null || testType is null)
                 return;
+
+            context.RegisterSymbolAction(symbolContext => AnalyzeMethod(symbolContext, testCaseType, testType), SymbolKind.Method);
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext context, INamedTypeSymbol testCaseType, INamedTypeSymbol testType)
+        {
+            var methodSymbol = (IMethodSymbol)context.Symbol;
 
             var methodAttributes = methodSymbol.GetAttributes();
 

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -78,10 +78,10 @@ namespace NUnit.Analyzers.TestMethodUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterCompilationStartAction(AnalyzeCompilation);
+            context.RegisterCompilationStartAction(AnalyzeCompilationStart);
         }
 
-        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
+        private static void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
         {
             INamedTypeSymbol? testCaseType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestCaseAttribute);
             INamedTypeSymbol? testType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeTestAttribute);

--- a/src/nunit.analyzers/ValueSourceUsage/ValueSourceUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ValueSourceUsage/ValueSourceUsageAnalyzer.cs
@@ -62,10 +62,10 @@ namespace NUnit.Analyzers.ValueSourceUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterCompilationStartAction(AnalyzeCompilation);
+            context.RegisterCompilationStartAction(AnalyzeCompilationStart);
         }
 
-        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
+        private static void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
         {
             var typeValueSourceAttribute = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeValueSourceAttribute);
             if (typeValueSourceAttribute is null)

--- a/src/nunit.analyzers/ValueSourceUsage/ValueSourceUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ValueSourceUsage/ValueSourceUsageAnalyzer.cs
@@ -62,14 +62,25 @@ namespace NUnit.Analyzers.ValueSourceUsage
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(x => AnalyzeAttribute(x), SyntaxKind.Attribute);
+            context.RegisterCompilationStartAction(AnalyzeCompilation);
         }
 
-        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
+        {
+            var typeValueSourceAttribute = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfTypeValueSourceAttribute);
+            if (typeValueSourceAttribute is null)
+            {
+                return;
+            }
+
+            context.RegisterSyntaxNodeAction(syntaxContext => AnalyzeAttribute(syntaxContext, typeValueSourceAttribute), SyntaxKind.Attribute);
+        }
+
+        private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context, INamedTypeSymbol valueSourceType)
         {
             var attributeInfo = SourceHelpers.GetSourceAttributeInformation(
                 context,
-                NUnitFrameworkConstants.FullNameOfTypeValueSourceAttribute,
+                valueSourceType,
                 NUnitFrameworkConstants.NameOfValueSourceAttribute);
 
             if (attributeInfo is null)


### PR DESCRIPTION
I noticed a number of places where there are repeated calls to GetTypeByMetadataName as the first thing an analyzer does, but not in a CompilationStartAction. By restructuring these calls, we can run that call just once for the entire compilation, avoiding repeated lookups and avoiding doing any more work on the entire compilation if those types aren't found. The compilation object does maintain a small cache of string->symbol for recent lookups, but it's best not to rely on this cache. The cache was put in as a crutch to help particularly egregious analyzers, and it's not hard to blow the limit on it. Additionally, the cache can't get skipping entire swaths of actions benefit that using CompilationStartAction can.

There's more opportunity to make this better; for example, nearly every analyzer derived from BaseAssertionAnalyzer could take advantage of this. That is a significantly more involved refactoring though, and I didn't have time to take that on at this point. This would also benefit from using the WellKnownTypesProvider in Microsoft.CodeAnalysis.AnalyzerUtilities to manage caching, and avoid comparing types by name.
