### PR TITLE
FP NUnit1001: CustomTypeConverters could convert from anything

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -279,25 +279,6 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         }
 
         [Test]
-        public void AnalyzeArgumentIsSomeConvertedToTypeWithCustomConverter()
-        {
-            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-    using System.ComponentModel;
-
-    class C
-    {
-        [TestCase(17)]
-        public void Test(CustomType p) { }
-    }
-
-    [TypeConverter(typeof(CustomTypeConverter))]
-    struct CustomType { }
-    class CustomTypeConverter : TypeConverter { }");
-
-            RoslynAssert.Valid(this.analyzer, testCode);
-        }
-
-        [Test]
         public void AnalyzeArgumentIsNullConvertedToTypeWithCustomConverter()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
@@ -344,7 +325,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
 
     class C
     {
-        [TestCase(↓2)]
+        [TestCase(2)]
         public void Test(CustomType p) { }
     }
 
@@ -352,9 +333,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
     struct CustomType { }
     class CustomTypeConverter : TypeConverter { }");
 
-            RoslynAssert.Diagnostics(this.analyzer,
-                ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
-                testCode);
+            RoslynAssert.Valid(this.analyzer, testCode);
         }
 
         [Test]

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -279,6 +279,25 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         }
 
         [Test]
+        public void AnalyzeArgumentIsSomeConvertedToTypeWithCustomConverter()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    using System.ComponentModel;
+
+    class C
+    {
+        [TestCase(17)]
+        public void Test(CustomType p) { }
+    }
+
+    [TypeConverter(typeof(CustomTypeConverter))]
+    struct CustomType { }
+    class CustomTypeConverter : TypeConverter { }");
+
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
         public void AnalyzeArgumentIsNullConvertedToTypeWithCustomConverter()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"

--- a/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
@@ -210,15 +210,12 @@ namespace NUnit.Analyzers.Extensions
                     }
                 }
             }
-            else if (targetTypeSymbol.GetAttributes().Any(att => att.AttributeClass?.GetFullMetadataName() == typeof(TypeConverterAttribute).FullName))
-            {
-                return true;
-            }
-            else if (argumentValue is null || argumentValue is string)
+            else
             {
                 if (compilation.GetTypeByMetadataName(typeof(TypeConverterAttribute).FullName!) is { } typeConverterAttribute
                     && targetTypeSymbol.GetAllAttributes().Any(data => SymbolEqualityComparer.Default.Equals(typeConverterAttribute, data.AttributeClass)))
                 {
+                    // If there is an explicit listed TypeConverter, we assume it can convert anything.
                     return true;
                 }
             }

--- a/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
@@ -191,7 +191,7 @@ namespace NUnit.Analyzers.Extensions
                 {
                     if (targetType.typeConverter is null)
                     {
-                        return argumentValue.GetType() == typeof(string);
+                        return argumentValue is string;
                     }
 
                     var typeConverter = targetType.typeConverter.Value;
@@ -209,6 +209,10 @@ namespace NUnit.Analyzers.Extensions
                         }
                     }
                 }
+            }
+            else if (targetTypeSymbol.GetAttributes().Any(att => att.AttributeClass?.GetFullMetadataName() == typeof(TypeConverterAttribute).FullName))
+            {
+                return true;
             }
             else if (argumentValue is null || argumentValue is string)
             {


### PR DESCRIPTION
I stumbled into this, as I use this feature quite often:

``` C#
[TestCase(23.00)]
pulic void TestSomething(Qowaiv.Financial.Amount amount)
{
  // ...
}
```

Where [`Qowaiv.Financial.Amount`](https://github.com/Qowaiv/Qowaiv#amount) is a value type that has its own type converter that not only can convert from string, but also from `int`, `long`, `double`, `float`, and `decimal`. This works like a charm, so it too bad that this falsely flags NUnit1001.

I've provided a fix, But if the implementation should be changed, just let me no.

Note that none existing test started to fail with this changed behavior.