### PR TITLE
DisposableFieldsSuppressor and Analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -54,6 +54,7 @@ csharp_space_between_square_brackets = false
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 

--- a/documentation/NUnit1032.md
+++ b/documentation/NUnit1032.md
@@ -1,6 +1,6 @@
 # NUnit1032
 
-## An IDisposable field should be Disposed in a TearDown method
+## An IDisposable field/property should be Disposed in a TearDown method
 
 | Topic    | Value
 | :--      | :--
@@ -8,20 +8,21 @@
 | Severity | Error
 | Enabled  | True
 | Category | Structure
-| Code     | [DisposeFieldsInTearDownAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownAnalyzer.cs)
+| Code     | [DisposeFieldsAndPropertiesInTearDownAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs)
 
 ## Description
 
-An IDisposable field should be Disposed in a TearDown method.
+An IDisposable field/property should be Disposed in a TearDown method.
 
 ## Motivation
 
-Not Diposing fields can cause memory leaks or failing tests.
+Not Diposing fields/properties can cause memory leaks or failing tests.
 
 ## How to fix violations
 
-Dispose any fields that are initialized in `SetUp` or `Test` methods in a `TearDown` method.
-Fields that are initialized in `OneTimeSetUp` must be disposed in `OneTimeTearDown`.
+Dispose any fields/properties that are initialized in `SetUp` or `Test` methods in a `TearDown` method.
+Fields/Properties that are initialized in `OneTimeSetUp`, or with initializers or in constructors
+must be disposed in `OneTimeTearDown`.
 
 <!-- start generated config severity -->
 ## Configure severity
@@ -33,7 +34,7 @@ Configure the severity per project, for more info see [MSDN](https://learn.micro
 ### Via .editorconfig file
 
 ```ini
-# NUnit1032: An IDisposable field should be Disposed in a TearDown method
+# NUnit1032: An IDisposable field/property should be Disposed in a TearDown method
 dotnet_diagnostic.NUnit1032.severity = chosenSeverity
 ```
 
@@ -42,22 +43,22 @@ where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, 
 ### Via #pragma directive
 
 ```csharp
-#pragma warning disable NUnit1032 // An IDisposable field should be Disposed in a TearDown method
+#pragma warning disable NUnit1032 // An IDisposable field/property should be Disposed in a TearDown method
 Code violating the rule here
-#pragma warning restore NUnit1032 // An IDisposable field should be Disposed in a TearDown method
+#pragma warning restore NUnit1032 // An IDisposable field/property should be Disposed in a TearDown method
 ```
 
 Or put this at the top of the file to disable all instances.
 
 ```csharp
-#pragma warning disable NUnit1032 // An IDisposable field should be Disposed in a TearDown method
+#pragma warning disable NUnit1032 // An IDisposable field/property should be Disposed in a TearDown method
 ```
 
 ### Via attribute `[SuppressMessage]`
 
 ```csharp
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Structure",
-    "NUnit1032:An IDisposable field should be Disposed in a TearDown method",
+    "NUnit1032:An IDisposable field/property should be Disposed in a TearDown method",
     Justification = "Reason...")]
 ```
 <!-- end generated config severity -->

--- a/documentation/NUnit1032.md
+++ b/documentation/NUnit1032.md
@@ -1,0 +1,63 @@
+# NUnit1032
+
+## An IDisposable field should be Disposed in a TearDown method
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1032
+| Severity | Error
+| Enabled  | True
+| Category | Structure
+| Code     | [DisposeFieldsInTearDownAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownAnalyzer.cs)
+
+## Description
+
+An IDisposable field should be Disposed in a TearDown method.
+
+## Motivation
+
+Not Diposing fields can cause memory leaks or failing tests.
+
+## How to fix violations
+
+Dispose any fields that are initialized in `SetUp` or `Test` methods in a `TearDown` method.
+Fields that are initialized in `OneTimeSetUp` must be disposed in `OneTimeTearDown`.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file
+
+Configure the severity per project, for more info see [MSDN](https://learn.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2022).
+
+### Via .editorconfig file
+
+```ini
+# NUnit1032: An IDisposable field should be Disposed in a TearDown method
+dotnet_diagnostic.NUnit1032.severity = chosenSeverity
+```
+
+where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, or `error`.
+
+### Via #pragma directive
+
+```csharp
+#pragma warning disable NUnit1032 // An IDisposable field should be Disposed in a TearDown method
+Code violating the rule here
+#pragma warning restore NUnit1032 // An IDisposable field should be Disposed in a TearDown method
+```
+
+Or put this at the top of the file to disable all instances.
+
+```csharp
+#pragma warning disable NUnit1032 // An IDisposable field should be Disposed in a TearDown method
+```
+
+### Via attribute `[SuppressMessage]`
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure",
+    "NUnit1032:An IDisposable field should be Disposed in a TearDown method",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/NUnit3001.md
+++ b/documentation/NUnit3001.md
@@ -99,6 +99,7 @@ To disable the rule for a project, you need to add a
     <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
     <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField/Property is Uninitialized -->
     <Rule Id="NUnit3003" Action="Info" /> <!-- Avoid Uninstantiated Internal Classes -->
+    <Rule Id="NUnit3004" Action="Info" /> <!-- Types that own disposable fields should be disposable -->
   </Rules>
 </RuleSet>
 ```

--- a/documentation/NUnit3002.md
+++ b/documentation/NUnit3002.md
@@ -69,6 +69,7 @@ To disable the rule for a project, you need to add a
     <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
     <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField/Property is Uninitialized -->
     <Rule Id="NUnit3003" Action="Info" /> <!-- Avoid Uninstantiated Internal Classes -->
+    <Rule Id="NUnit3004" Action="Info" /> <!-- Types that own disposable fields should be disposable -->
   </Rules>
 </RuleSet>
 ```

--- a/documentation/NUnit3004.md
+++ b/documentation/NUnit3004.md
@@ -1,10 +1,10 @@
-# NUnit3003
+# NUnit3004
 
-## Class is an NUnit TestFixture and is instantiated using reflection
+## Field should be Disposed in TearDown or OneTimeTearDown method
 
 | Topic    | Value
 | :--      | :--
-| Id       | NUnit3003
+| Id       | NUnit3004
 | Severity | Info
 | Enabled  | True
 | Category | Suppressor
@@ -12,14 +12,18 @@
 
 ## Description
 
-Class is a NUnit TestFixture and called by reflection
+Field/Property is Disposed in TearDown or OneTimeTearDown method
 
 ## Motivation
 
-The default roslyn analyzer has rule [CA1812](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812)
-which warns about internal classes not being used.
-That analyzer doesn't know about NUnit test classes.
-This suppressor catches the error, verifies the class is an NUnit TestFixture and if so suppresses the error.
+The Roslyn analyzer fires [CA1001](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001)
+for classes that have [`IDisposable`](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable) members, but itself is not `IDisposable`.
+
+Many NUnit tests initialize fields in tests or a `SetUp` method and then `Dispose` them in the `TearDown` method.
+
+## How to fix violations
+
+Ensure that all `IDisposable` fields have a `Dispose` call in the `TearDown` method.
 
 <!-- start generated config severity -->
 ## Configure severity
@@ -58,7 +62,7 @@ For more info about rulesets see [MSDN](https://learn.microsoft.com/en-us/visual
 This is currently not working. Waiting for [Roslyn](https://github.com/dotnet/roslyn/issues/49727)
 
 ```ini
-# NUnit3003: Class is an NUnit TestFixture and is instantiated using reflection
-dotnet_diagnostic.NUnit3003.severity = none
+# NUnit3004: Field should be Disposed in TearDown or OneTimeTearDown method
+dotnet_diagnostic.NUnit3004.severity = none
 ```
 <!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -50,6 +50,7 @@ Rules which enforce structural requirements on the test code.
 | [NUnit1029](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1029.md) | The number of parameters provided by the TestCaseSource does not match the number of parameters in the Test method | :white_check_mark: | :exclamation: | :x: |
 | [NUnit1030](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1030.md) | The type of parameter provided by the TestCaseSource does not match the type of the parameter in the Test method | :white_check_mark: | :exclamation: | :x: |
 | [NUnit1031](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1031.md) | The individual arguments provided by a ValuesAttribute must match the type of the corresponding parameter of the method | :white_check_mark: | :exclamation: | :x: |
+| [NUnit1032](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1032.md) | An IDisposable field should be Disposed in a TearDown method | :white_check_mark: | :exclamation: | :x: |
 
 ### Assertion Rules (NUnit2001 - )
 
@@ -113,4 +114,5 @@ Rules which suppress compiler errors based on context. Note that these rules are
 | :--      | :--         | :--:  | :--:   | :--:   |
 | [NUnit3001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3001.md) | Expression was checked in an Assert.NotNull, Assert.IsNotNull or Assert.That call | :white_check_mark: | :information_source: | :x: |
 | [NUnit3002](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3002.md) | Field/Property is initialized in SetUp or OneTimeSetUp method | :white_check_mark: | :information_source: | :x: |
-| [NUnit3003](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3003.md) | Class is a NUnit TestFixture and called by reflection | :white_check_mark: | :information_source: | :x: |
+| [NUnit3003](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3003.md) | Class is an NUnit TestFixture and is instantiated using reflection | :white_check_mark: | :information_source: | :x: |
+| [NUnit3004](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit3004.md) | Field should be Disposed in TearDown or OneTimeTearDown method | :white_check_mark: | :information_source: | :x: |

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -50,7 +50,7 @@ Rules which enforce structural requirements on the test code.
 | [NUnit1029](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1029.md) | The number of parameters provided by the TestCaseSource does not match the number of parameters in the Test method | :white_check_mark: | :exclamation: | :x: |
 | [NUnit1030](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1030.md) | The type of parameter provided by the TestCaseSource does not match the type of the parameter in the Test method | :white_check_mark: | :exclamation: | :x: |
 | [NUnit1031](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1031.md) | The individual arguments provided by a ValuesAttribute must match the type of the corresponding parameter of the method | :white_check_mark: | :exclamation: | :x: |
-| [NUnit1032](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1032.md) | An IDisposable field should be Disposed in a TearDown method | :white_check_mark: | :exclamation: | :x: |
+| [NUnit1032](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1032.md) | An IDisposable field/property should be Disposed in a TearDown method | :white_check_mark: | :exclamation: | :x: |
 
 ### Assertion Rules (NUnit2001 - )
 

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -43,6 +43,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		..\documentation\NUnit1029.md = ..\documentation\NUnit1029.md
 		..\documentation\NUnit1030.md = ..\documentation\NUnit1030.md
 		..\documentation\NUnit1031.md = ..\documentation\NUnit1031.md
+		..\documentation\NUnit1032.md = ..\documentation\NUnit1032.md
 		..\documentation\NUnit2001.md = ..\documentation\NUnit2001.md
 		..\documentation\NUnit2002.md = ..\documentation\NUnit2002.md
 		..\documentation\NUnit2003.md = ..\documentation\NUnit2003.md
@@ -93,6 +94,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		..\documentation\NUnit3001.md = ..\documentation\NUnit3001.md
 		..\documentation\NUnit3002.md = ..\documentation\NUnit3002.md
 		..\documentation\NUnit3003.md = ..\documentation\NUnit3003.md
+		..\documentation\NUnit3004.md = ..\documentation\NUnit3004.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -120,6 +120,11 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfValueSourceAttribute), nameof(ValueSourceAttribute)),
             (nameof(NUnitFrameworkConstants.NameOfValuesAttribute), nameof(ValuesAttribute)),
 
+            (nameof(NUnitFrameworkConstants.NameOfOneTimeSetUpAttribute), nameof(OneTimeSetUpAttribute)),
+            (nameof(NUnitFrameworkConstants.NameOfOneTimeTearDownAttribute), nameof(OneTimeTearDownAttribute)),
+            (nameof(NUnitFrameworkConstants.NameOfSetUpAttribute), nameof(SetUpAttribute)),
+            (nameof(NUnitFrameworkConstants.NameOfTearDownAttribute), nameof(TearDownAttribute)),
+
             (nameof(NUnitFrameworkConstants.NameOfExpectedResult), nameof(TestAttribute.ExpectedResult)),
 
             (nameof(NUnitFrameworkConstants.NameOfConstraintExpressionAnd), nameof(EqualConstraint.And)),

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/AvoidUninstantiatedInternalClassesSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/AvoidUninstantiatedInternalClassesSuppressorTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
             }
         ";
 
-        private static readonly DiagnosticSuppressor suppressor = new AvoidUninstantiatedInternalClassesSuppressor();
+        private static readonly DiagnosticSuppressor suppressor = new TestFixtureSuppressor();
         private DiagnosticAnalyzer analyzer;
 
         [OneTimeSetUp]

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DisposableFieldsSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DisposableFieldsSuppressorTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.DiagnosticSuppressors;
 using NUnit.Framework;
 
@@ -49,8 +50,8 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
             await TestHelpers.Suppressed(this.analyzer, suppressor, testCode).ConfigureAwait(true);
         }
 
-        [TestCase("TearDown", "")]
-        [TestCase("OneTimeTearDown", "this.")]
+        [TestCase(NUnitFrameworkConstants.NameOfTearDownAttribute, "")]
+        [TestCase(NUnitFrameworkConstants.NameOfOneTimeTearDownAttribute, "this.")]
         public async Task FieldDisposed(string attribute, string prefix)
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DisposableFieldsSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DisposableFieldsSuppressorTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.DiagnosticSuppressors;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
+{
+    public class DisposableFieldsSuppressorTests
+    {
+        private static readonly DiagnosticSuppressor suppressor = new TestFixtureSuppressor();
+        private DiagnosticAnalyzer analyzer;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // Find the NetAnalyzers assembly (note version should match the one referenced)
+            string netAnalyzersPath = Path.Combine(PathHelper.GetNuGetPackageDirectory(),
+                "microsoft.codeanalysis.netanalyzers/7.0.4/analyzers/dotnet/cs/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll");
+            Assembly netAnalyzerAssembly = Assembly.LoadFrom(netAnalyzersPath);
+            Type analyzerType = netAnalyzerAssembly.GetType("Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer", true)!;
+            this.analyzer = (DiagnosticAnalyzer)Activator.CreateInstance(analyzerType)!;
+
+            this.analyzer = new DefaultEnabledAnalyzer(this.analyzer);
+        }
+
+        [Test]
+        public async Task FieldNotDisposed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                private IDisposable? field;
+
+                [Test]
+                public void Test()
+                {
+                    field = new DummyDisposable();
+                    Assert.That(field, Is.Not.Null);
+                }
+
+                private sealed class DummyDisposable : IDisposable
+                {
+                    public void Dispose() {}
+                }
+            ");
+
+            // This rule doesn't care. Actual checking is done in DisposeFieldsInTearDownAnalyzer
+            await TestHelpers.Suppressed(this.analyzer, suppressor, testCode).ConfigureAwait(true);
+        }
+
+        [TestCase("TearDown", "")]
+        [TestCase("OneTimeTearDown", "this.")]
+        public async Task FieldDisposed(string attribute, string prefix)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                private IDisposable? field1;
+                private IDisposable? field2;
+
+                [{attribute}]
+                public void CleanUp()
+                {{
+                    {prefix}field1?.Dispose();
+                    if ({prefix}field2 is not null)
+                    {{
+                        {prefix}field2.Dispose();
+                    }}
+                }}
+
+                [Test]
+                public void Test1()
+                {{
+                    {prefix}field1 = new DummyDisposable();
+                    Assert.That({prefix}field1, Is.Not.Null);
+                }}
+
+                [Test]
+                public void Test2()
+                {{
+                    {prefix}field2 = new DummyDisposable();
+                    Assert.That({prefix}field2, Is.Not.Null);
+                }}
+
+                private sealed class DummyDisposable : IDisposable
+                {{
+                    public void Dispose() {{}}
+                }}
+            ");
+
+            await TestHelpers.Suppressed(this.analyzer, suppressor, testCode).ConfigureAwait(true);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -226,6 +226,37 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
         }
 
         [Test]
+        public void AnalyzeWhenPropertyBackingFieldIsDisposed(
+            [Values("field", "Property")] string fieldOrProperty)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private IDisposable? field;
+
+        private IDisposable? Property
+        {{
+            get => field;
+            set => this.field = value;
+        }}
+
+        [SetUp]
+        public void SetUpMethod()
+        {{
+            {fieldOrProperty} = new DummyDisposable();
+        }}
+
+        [TearDown]
+        public void TearDownMethod()
+        {{
+            {fieldOrProperty}?.Dispose();
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenPropertyIsDisposedInCorrectMethod(
             [Values("", "OneTime")] string attributePrefix,
             [Values("", "this.")] string prefix)

--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -164,6 +164,29 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
             RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
         }
 
+        [TestCase("SetUp")]
+        [TestCase("Test")]
+        public void AnalyzeWhenFieldTypeParameterIsNotDisposed(string attribute)
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
+        public class TestClass<T>
+            where T : IDisposable, new()
+        {{
+            private T? ↓field;
+
+            [{attribute}]
+            public void SomeMethod()
+            {{
+                field = new T();
+            }}
+
+            {DummyDisposable}
+        }}
+        ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
         [Test]
         public void AnalyzeWhenFieldWithInitializerIsNotDisposed()
         {

--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -55,6 +55,25 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
         }
 
         [Test]
+        public void AnalyzeWhenFieldIsConditionallyDisposed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private object field = new DummyDisposable();
+
+        [OneTimeTearDown]
+        public void TearDownMethod()
+        {{
+            if (field is IDisposable disposable)
+                disposable.Dispose();
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenFieldWithInitializerIsDisposedInOneTimeTearDownMethod()
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers.tests/DisposeFieldsInTearDown/DisposeFieldsInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsInTearDown/DisposeFieldsInTearDownAnalyzerTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.DisposeFieldsInTearDown;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
+{
+    public class DisposeFieldsInTearDownAnalyzerTests
+    {
+        private const string DummyDisposable = @"
+        private sealed class DummyDisposable : IDisposable
+        {
+            public void Dispose() {}
+        }";
+
+        // CA2000 allows transfer of ownership using ICollection<IDisposable>.Add
+        private const string Disposer = @"
+        private sealed class Disposer : IDisposable
+        {
+            public void Dispose() {}
+
+            public T? Add<T>(T? resource) => resource;
+        }
+        ";
+
+        private static readonly DiagnosticAnalyzer analyzer = new DisposeFieldsInTearDownAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.FieldIsNotDisposedInTearDown);
+
+        [Test]
+        public void AnalyzeWhenFieldIsDisposedInCorrectMethod(
+            [Values("", "OneTime")] string attributePrefix,
+            [Values("", "this.")] string prefix)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private IDisposable? field;
+
+        [{attributePrefix}SetUp]
+        public void SetUpMethod()
+        {{
+            {prefix}field = new DummyDisposable();
+        }}
+
+        [{attributePrefix}TearDown]
+        public void TearDownMethod()
+        {{
+            {prefix}field?.Dispose();
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [TestCase("", "OneTime")]
+        [TestCase("OneTime", "")]
+        public void AnalyzeWhenFieldIsDisposedInWrongMethod(string attributePrefix1, string attributePrefix2)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private IDisposable? ↓field;
+
+        [{attributePrefix1}SetUp]
+        public void SetUpMethod()
+        {{
+            field = new DummyDisposable();
+        }}
+
+        [{attributePrefix2}TearDown]
+        public void TearDownMethod()
+        {{
+            field?.Dispose();
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [TestCase("SetUp")]
+        [TestCase("Test")]
+        public void AnalyzeWhenFieldIsNotDisposed(string attribute)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private object? ↓field;
+
+        [{attribute}]
+        public void SomeMethod()
+        {{
+            field = new DummyDisposable();
+        }}
+
+        [TearDown]
+        public void TearDownMethod()
+        {{
+            field = null;
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [TestCase("")]
+        [TestCase("OneTime")]
+        public void AnalyzeWhenFieldIsDisposedUsingDisposer(string attributePrefix)
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private Disposer? disposer;
+        private object? field;
+
+        [{attributePrefix}SetUp]
+        public void SetUpMethod()
+        {{
+            disposer = new Disposer();
+            field = disposer.Add(new DummyDisposable());
+        }}
+
+        [{attributePrefix}TearDown]
+        public void TearDownMethod()
+        {{
+            disposer?.Dispose();
+        }}
+
+        {DummyDisposable}
+
+        {Disposer}
+        ");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -514,6 +514,7 @@ To disable the rule for a project, you need to add a
     <Rule Id=""NUnit3001"" Action=""Info"" /> <!-- Possible Null Reference -->
     <Rule Id=""NUnit3002"" Action=""Info"" /> <!-- NonNullableField/Property is Uninitialized -->
     <Rule Id=""NUnit3003"" Action=""Info"" /> <!-- Avoid Uninstantiated Internal Classes -->
+    <Rule Id=""NUnit3004"" Action=""Info"" /> <!-- Types that own disposable fields should be disposable -->
   </Rules>
 </RuleSet>
 ```

--- a/src/nunit.analyzers.tests/TestHelpers.cs
+++ b/src/nunit.analyzers.tests/TestHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
@@ -28,7 +29,7 @@ namespace NUnit.Analyzers.Tests
         internal static async Task SuppressedOrNot(DiagnosticAnalyzer analyzer, DiagnosticSuppressor suppressor, string code, bool isSuppressed, Settings? settings = null)
         {
             string id = analyzer.SupportedDiagnostics[0].Id;
-            Assert.That(suppressor.SupportedSuppressions[0].SuppressedDiagnosticId, Is.EqualTo(id));
+            Assert.That(suppressor.SupportedSuppressions.Select(x => x.SuppressedDiagnosticId), Does.Contain(id));
 
             settings ??= Settings.Default;
             settings = settings.WithCompilationOptions(Settings.Default.CompilationOptions.WithWarningOrError(analyzer.SupportedDiagnostics));

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -35,6 +35,7 @@ namespace NUnit.Analyzers.Constants
         internal const string TestCaseSourceMismatchInNumberOfTestMethodParameters = "NUnit1029";
         internal const string TestCaseSourceMismatchWithTestMethodParameterType = "NUnit1030";
         internal const string ValuesParameterTypeMismatchUsage = "NUnit1031";
+        internal const string FieldIsNotDisposedInTearDown = "NUnit1032";
 
         #endregion Structure
 
@@ -95,6 +96,7 @@ namespace NUnit.Analyzers.Constants
         internal const string DereferencePossibleNullReference = "NUnit3001";
         internal const string NonNullableFieldOrPropertyIsUninitialized = "NUnit3002";
         internal const string AvoidUninstantiatedInternalClasses = "NUnit3003";
+        internal const string TypesThatOwnDisposableFieldsShouldBeDisposable = "NUnit3004";
 
         #endregion
     }

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -107,6 +107,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfTypeISimpleTestBuilder = "NUnit.Framework.Interfaces.ISimpleTestBuilder";
         public const string FullNameOfTypeValuesAttribute = "NUnit.Framework.ValuesAttribute";
         public const string FullNameOfTypeValueSourceAttribute = "NUnit.Framework.ValueSourceAttribute";
+
         public const string FullNameOfTypeIParameterDataSource = "NUnit.Framework.Interfaces.IParameterDataSource";
         public const string FullNameOfTypeTestCaseData = "NUnit.Framework.TestCaseData";
         public const string FullNameOfTypeTestCaseParameters = "NUnit.Framework.Internal.TestCaseParameters";
@@ -141,6 +142,11 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfParallelizableAttribute = "ParallelizableAttribute";
         public const string NameOfValuesAttribute = "ValuesAttribute";
         public const string NameOfValueSourceAttribute = "ValueSourceAttribute";
+
+        public const string NameOfOneTimeSetUpAttribute = "OneTimeSetUpAttribute";
+        public const string NameOfOneTimeTearDownAttribute = "OneTimeTearDownAttribute";
+        public const string NameOfSetUpAttribute = "SetUpAttribute";
+        public const string NameOfTearDownAttribute = "TearDownAttribute";
 
         public const string NameOfExpectedResult = "ExpectedResult";
 

--- a/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset
+++ b/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset
@@ -4,5 +4,6 @@
     <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
     <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField/Property is Uninitialized -->
     <Rule Id="NUnit3003" Action="Info" /> <!-- Avoid Uninstantiated Internal Classes -->
+    <Rule Id="NUnit3004" Action="Info" /> <!-- Types that own disposable fields should be disposable -->
   </Rules>
 </RuleSet>

--- a/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
+++ b/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
@@ -543,7 +543,7 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
 
                 if (arguments.Count == 0 && (target is not null || conditionalTarget is not null))
                 {
-                    // This muse be `diposable(?).DisposeMethod()`
+                    // This must be `diposable(?).DisposeMethod()`
                     symbol = GetIdentifier(target ?? conditionalTarget!);
                 }
                 else if (arguments.Count == 1)

--- a/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownConstants.cs
+++ b/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.DisposeFieldsInTearDown
+{
+    internal static class DisposeFieldsAndPropertiesInTearDownConstants
+    {
+        internal const string FieldOrPropertyIsNotDisposedInTearDownTitle = "An IDisposable field/property should be Disposed in a TearDown method";
+        internal const string FieldOrPropertyIsNotDisposedInTearDownDescription = "An IDisposable field/property should be Disposed in a TearDown method.";
+        internal const string FieldOrPropertyIsNotDisposedInTearDownMessageFormat = "The {0} {1} should be Disposed in a method annotated with [{2}]";
+    }
+}

--- a/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownAnalyzer.cs
+++ b/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownAnalyzer.cs
@@ -1,0 +1,442 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.DisposeFieldsInTearDown
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DisposeFieldsInTearDownAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor fieldIsNotDisposedInTearDown = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.FieldIsNotDisposedInTearDown,
+            title: DisposeFieldsInTearDownConstants.FieldIsNotDisposedInTearDownTitle,
+            messageFormat: DisposeFieldsInTearDownConstants.FieldIsNotDisposedInTearDownMessageFormat,
+            category: Categories.Structure,
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: DisposeFieldsInTearDownConstants.FieldIsNotDisposedInTearDownDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(fieldIsNotDisposedInTearDown);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeDisposableFields, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeDisposableFields(SyntaxNodeAnalysisContext context)
+        {
+            var classDeclaration = (ClassDeclarationSyntax)context.Node;
+
+            SemanticModel? model = context.SemanticModel;
+
+            var typeSymbol = model.GetDeclaredSymbol(classDeclaration, context.CancellationToken);
+            if (typeSymbol is null)
+            {
+                return;
+            }
+
+            if (typeSymbol.IsDisposable())
+            {
+                // If the type is Disposable, the MS Analyzer will conflict, so bail out.
+                return;
+            }
+
+            var fieldDeclarations = classDeclaration.Members
+                                                    .OfType<FieldDeclarationSyntax>()
+                                                    .Select(x => x.Declaration)
+                                                    .SelectMany(x => x.Variables);
+
+            Dictionary<string, VariableDeclaratorSyntax> fields = fieldDeclarations.ToDictionary(x => x.Identifier.Text);
+            HashSet<string> fieldNames = new HashSet<string>(fields.Keys);
+
+            ImmutableArray<ISymbol> members = typeSymbol.GetMembers();
+            var methods = members.OfType<IMethodSymbol>().Where(m => !m.IsStatic).ToArray();
+            var oneTimeTearDownMethods = methods.Where(m => HasAttribute(m, "OneTimeTearDownAttribute")).ToImmutableHashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            var oneTimeSetUpMethods = methods.Where(m => HasAttribute(m, "OneTimeSetUpAttribute")).ToImmutableHashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            var setUpMethods = methods.Where(m => HasAttribute(m, "SetUpAttribute")).ToImmutableHashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            var tearDownMethods = methods.Where(m => HasAttribute(m, "TearDownAttribute")).ToImmutableHashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+
+            var setUpAndTearDownMethods = oneTimeSetUpMethods.Union(oneTimeTearDownMethods).Union(setUpMethods).Union(tearDownMethods);
+            var otherMethods = methods.Where(m => m.DeclaredAccessibility != Accessibility.Private && !setUpAndTearDownMethods.Contains(m));
+
+            // Fields assigned in a OneTimeSetUp method must be disposed in a OneTimeTearDown method
+            AnalyzeAssignedButNotDisposed(context, model, typeSymbol, fields, fieldNames,
+                "OneTimeTearDown", oneTimeSetUpMethods, oneTimeTearDownMethods);
+
+            // Fields assigned in a SetUp method must be disposed in a TearDown method
+            AnalyzeAssignedButNotDisposed(context, model, typeSymbol, fields, fieldNames,
+                "TearDown", setUpMethods, tearDownMethods);
+
+            // Fields assignd in any method, must be (conditionally) disposed in TearDown method.
+            // If the field is disposed in the method itself, why is it a field?
+            AnalyzeAssignedButNotDisposed(context, model, typeSymbol, fields, fieldNames,
+                "TearDown", otherMethods, tearDownMethods);
+        }
+
+        private static bool HasAttribute(IMethodSymbol method, string attributeName)
+        {
+            // Look for attribute not only on the method itself but
+            // also on the base method in case this is an override.
+            IEnumerable<AttributeData> attributes = Enumerable.Empty<AttributeData>();
+            for (IMethodSymbol? declaredMethod = method;
+                declaredMethod is not null;
+                declaredMethod = declaredMethod.OverriddenMethod)
+            {
+                attributes = attributes.Concat(declaredMethod.GetAttributes());
+            }
+
+            return attributes.Any(x => x.AttributeClass?.Name == attributeName);
+        }
+
+        private static void AnalyzeAssignedButNotDisposed(
+            SyntaxNodeAnalysisContext context,
+            SemanticModel model,
+            INamedTypeSymbol type,
+            Dictionary<string, VariableDeclaratorSyntax> fields,
+            HashSet<string> names,
+            string where,
+            IEnumerable<IMethodSymbol> setUpMethods,
+            IEnumerable<IMethodSymbol> tearDownMethods)
+        {
+            var assignedInSetUpMethods = AssignedIn(model, type, names, setUpMethods);
+            var disposedInTearDownMethods = DisposedIn(model, type, names, tearDownMethods);
+            assignedInSetUpMethods.ExceptWith(disposedInTearDownMethods);
+
+            foreach (var assignedButNotDisposed in assignedInSetUpMethods)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    fieldIsNotDisposedInTearDown,
+                    fields[assignedButNotDisposed].GetLocation(),
+                    assignedButNotDisposed,
+                    where));
+            }
+        }
+
+        #region AssignedIn
+
+        private static HashSet<string> AssignedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, IEnumerable<IMethodSymbol> methods)
+        {
+            var assignedSymbols = new HashSet<string>();
+
+            foreach (var method in methods)
+            {
+                HashSet<string> assignedSymbolsInMethod = AssignedIn(model, type, symbols, method);
+                assignedSymbols.UnionWith(assignedSymbolsInMethod);
+            }
+
+            return assignedSymbols;
+        }
+
+        /// <summary>
+        /// Returns a hash set of the fields assigned in <paramref name="symbol"/>.
+        /// </summary>
+        /// <param name="symbol">The method to look for.</param>
+        /// <param name="symbols">The symbols to check for assignment.</param>
+        /// <returns>HashSet of <paramref name="symbols"/> that are assigned in <paramref name="symbol"/>.</returns>
+        private static HashSet<string> AssignedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, IMethodSymbol symbol)
+        {
+            MethodDeclarationSyntax? method =
+                symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as MethodDeclarationSyntax;
+
+            return method is null ? new HashSet<string>() : AssignedIn(model, type, symbols, method);
+        }
+
+        private static HashSet<string> AssignedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, MethodDeclarationSyntax method)
+        {
+            if (method.ExpressionBody is not null)
+            {
+                return AssignedIn(model, type, symbols, method.ExpressionBody.Expression);
+            }
+
+            if (method.Body is not null)
+            {
+                return AssignedIn(model, type, symbols, method.Body);
+            }
+
+            return new HashSet<string>();
+        }
+
+        private static HashSet<string> AssignedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, ExpressionSyntax expression)
+        {
+            var assignedSymbols = new HashSet<string>();
+            if (expression is AssignmentExpressionSyntax assignmentExpression)
+            {
+                // We only deal with simple assignments, not tuple or deconstruct
+                string? name = GetIdentifier(assignmentExpression.Left);
+                if (name is not null && symbols.Contains(name))
+                {
+                    TypeInfo typeInfo = model.GetTypeInfo(assignmentExpression.Right);
+                    if (typeInfo.Type?.IsDisposable() == true)
+                    {
+                        // Make one exemption, if the value is returned from a 'xxx.Add()' call.
+                        // It is then assumed that owner ship is transferred to that 'collection'.
+                        // This matches the (undocumented) CA2000 behaviour.
+                        if (assignmentExpression.Right is not InvocationExpressionSyntax invocationExpression ||
+                            invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression ||
+                            memberAccessExpression.Name.Identifier.Text != "Add")
+                        {
+                            assignedSymbols.Add(name);
+                        }
+                    }
+                }
+            }
+            else if (expression is InvocationExpressionSyntax invocationExpression)
+            {
+                string? method = GetIdentifier(invocationExpression.Expression);
+                if (method is not null)
+                {
+                    IMethodSymbol? calledMethod = model.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
+                    if (calledMethod is not null && SymbolEqualityComparer.Default.Equals(calledMethod.ContainingType, type))
+                    {
+                        // We are calling a local method on our class, keep looking for assignments.
+                        return AssignedIn(model, type, symbols, calledMethod);
+                    }
+                }
+            }
+
+            return assignedSymbols;
+        }
+
+        private static HashSet<string> AssignedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, StatementSyntax statement)
+        {
+            switch (statement)
+            {
+                case ExpressionStatementSyntax expressionStatement:
+                    return AssignedIn(model, type, symbols, expressionStatement.Expression);
+
+                case IfStatementSyntax ifStatement:
+                {
+                    // We don't care about the condition
+                    HashSet<string> assignedSymbolsInStatement = AssignedIn(model, type, symbols, ifStatement.Statement);
+                    if (ifStatement.Else is not null)
+                        assignedSymbolsInStatement.UnionWith(AssignedIn(model, type, symbols, ifStatement.Else.Statement));
+
+                    return assignedSymbolsInStatement;
+                }
+
+                case BlockSyntax block:
+                    return AssignedIn(model, type, symbols, block.Statements);
+
+                case SwitchStatementSyntax switchStatement:
+                {
+                    var assignedSymbols = new HashSet<string>();
+
+                    foreach (var caseStatements in switchStatement.Sections.Select(x => x.Statements))
+                    {
+                        HashSet<string> assignedSymbolsInStatement = AssignedIn(model, type, symbols, caseStatements);
+                        assignedSymbols.UnionWith(assignedSymbolsInStatement);
+                    }
+
+                    return assignedSymbols;
+                }
+
+                default:
+                    // Anything assigned in a loop is bad as it overrides previous assignments.
+                    return new HashSet<string>();
+            }
+        }
+
+        private static HashSet<string> AssignedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, SyntaxList<StatementSyntax> statements)
+        {
+            var assignedSymbols = new HashSet<string>();
+
+            foreach (var statement in statements)
+            {
+                HashSet<string> assignedSymbolsInStatement = AssignedIn(model, type, symbols, statement);
+                assignedSymbols.UnionWith(assignedSymbolsInStatement);
+            }
+
+            return assignedSymbols;
+        }
+
+        #endregion
+
+        #region DisposedIn
+
+        private static HashSet<string> DisposedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, IEnumerable<IMethodSymbol> methods)
+        {
+            var disposedSymbols = new HashSet<string>();
+
+            foreach (var method in methods)
+            {
+                HashSet<string> disposedSymbolsInMethod = DisposedIn(model, type, symbols, method);
+                disposedSymbols.UnionWith(disposedSymbolsInMethod);
+            }
+
+            return disposedSymbols;
+        }
+
+        /// <summary>
+        /// Returns a hash set of the fields disposed in <paramref name="symbol"/>.
+        /// </summary>
+        /// <param name="symbol">The method to look for.</param>
+        /// <param name="symbols">The symbols to check for assignment.</param>
+        /// <returns>HashSet of <paramref name="symbols"/> that are disposed in <paramref name="symbol"/>.</returns>
+        private static HashSet<string> DisposedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, IMethodSymbol symbol)
+        {
+            MethodDeclarationSyntax? method =
+                symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as MethodDeclarationSyntax;
+
+            return method is null ? new HashSet<string>() : DisposedIn(model, type, symbols, method);
+        }
+
+        private static HashSet<string> DisposedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, MethodDeclarationSyntax method)
+        {
+            if (method.ExpressionBody is not null)
+            {
+                return DisposedIn(model, type, symbols, method.ExpressionBody.Expression);
+            }
+
+            if (method.Body is not null)
+            {
+                return DisposedIn(model, type, symbols, method.Body);
+            }
+
+            return new HashSet<string>();
+        }
+
+        private static HashSet<string> DisposedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, ExpressionSyntax expression)
+        {
+            var disposedSymbols = new HashSet<string>();
+            if (expression is InvocationExpressionSyntax invocationExpression)
+            {
+                if (invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression &&
+                    memberAccessExpression.Expression is not ThisExpressionSyntax)
+                {
+                    if (IsDispose(memberAccessExpression.Name))
+                    {
+                        string? target = GetTargetName(memberAccessExpression.Expression);
+                        if (target is not null && symbols.Contains(target))
+                        {
+                            disposedSymbols.Add(target);
+                        }
+
+                        return disposedSymbols;
+                    }
+                }
+
+                string? method = GetIdentifier(invocationExpression.Expression);
+                if (method is not null)
+                {
+                    IMethodSymbol? calledMethod = model.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
+                    if (calledMethod is not null)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(calledMethod.ContainingType, type))
+                        {
+                            // We are calling a local method on our class, keep looking for assignments.
+                            return DisposedIn(model, type, symbols, calledMethod);
+                        }
+                    }
+                }
+            }
+            else if (expression is ConditionalAccessExpressionSyntax conditionalAccessExpression &&
+                conditionalAccessExpression.WhenNotNull is InvocationExpressionSyntax conditionalInvocationExpression &&
+                conditionalInvocationExpression.Expression is MemberBindingExpressionSyntax memberBindingExpression &&
+                IsDispose(memberBindingExpression.Name))
+            {
+                string? target = GetTargetName(conditionalAccessExpression.Expression);
+                if (target is not null && symbols.Contains(target))
+                {
+                    disposedSymbols.Add(target);
+                }
+            }
+
+            return disposedSymbols;
+        }
+
+        private static HashSet<string> DisposedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, StatementSyntax statement)
+        {
+            switch (statement)
+            {
+                case ExpressionStatementSyntax expressionStatement:
+                    return DisposedIn(model, type, symbols, expressionStatement.Expression);
+
+                case IfStatementSyntax ifStatement:
+                    {
+                        // We don't care about the condition
+                        HashSet<string> disposedSymbolsInStatement = DisposedIn(model, type, symbols, ifStatement.Statement);
+                        if (ifStatement.Else is not null)
+                            disposedSymbolsInStatement.UnionWith(DisposedIn(model, type, symbols, ifStatement.Else.Statement));
+
+                        return disposedSymbolsInStatement;
+                    }
+
+                case BlockSyntax block:
+                    return DisposedIn(model, type, symbols, block.Statements);
+
+                case SwitchStatementSyntax switchStatement:
+                    {
+                        var disposedSymbols = new HashSet<string>();
+
+                        foreach (var caseStatements in switchStatement.Sections.Select(x => x.Statements))
+                        {
+                            HashSet<string> disposedSymbolsInStatement = DisposedIn(model, type, symbols, caseStatements);
+                            disposedSymbols.UnionWith(disposedSymbolsInStatement);
+                        }
+
+                        return disposedSymbols;
+                    }
+
+                default:
+                    return new HashSet<string>();
+            }
+        }
+
+        private static HashSet<string> DisposedIn(SemanticModel model, INamedTypeSymbol type, HashSet<string> symbols, SyntaxList<StatementSyntax> statements)
+        {
+            var disposedSymbols = new HashSet<string>();
+
+            foreach (var statement in statements)
+            {
+                HashSet<string> disposedSymbolsInStatement = DisposedIn(model, type, symbols, statement);
+                disposedSymbols.UnionWith(disposedSymbolsInStatement);
+            }
+
+            return disposedSymbols;
+        }
+
+        private static bool IsDispose(SimpleNameSyntax name) => name.Identifier.Text is "Dispose" or "DisposeAsync";
+
+        private static string? GetTargetName(ExpressionSyntax expression)
+        {
+            if (expression is MemberAccessExpressionSyntax memberAccessExpression &&
+               memberAccessExpression.Expression is ThisExpressionSyntax)
+            {
+                expression = memberAccessExpression.Name;
+            }
+
+            if (expression is SimpleNameSyntax simpleName)
+            {
+                return simpleName.Identifier.Text;
+            }
+
+            return null;
+        }
+
+        #endregion
+
+        private static string? GetIdentifier(ExpressionSyntax expression)
+        {
+            if (expression is IdentifierNameSyntax identifierName)
+            {
+                return identifierName.Identifier.Text;
+            }
+            else if (expression is MemberAccessExpressionSyntax memberAccessExpression &&
+                memberAccessExpression.Expression is ThisExpressionSyntax)
+            {
+                return memberAccessExpression.Name.Identifier.Text;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownConstants.cs
+++ b/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.DisposeFieldsInTearDown
+{
+    internal static class DisposeFieldsInTearDownConstants
+    {
+        internal const string FieldIsNotDisposedInTearDownTitle = "An IDisposable field should be Disposed in a TearDown method";
+        internal const string FieldIsNotDisposedInTearDownDescription = "An IDisposable field should be Disposed in a TearDown method.";
+        internal const string FieldIsNotDisposedInTearDownMessageFormat = "The field {0} should be Disposed in the {1} method";
+    }
+}

--- a/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownConstants.cs
+++ b/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownConstants.cs
@@ -4,6 +4,6 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
     {
         internal const string FieldIsNotDisposedInTearDownTitle = "An IDisposable field should be Disposed in a TearDown method";
         internal const string FieldIsNotDisposedInTearDownDescription = "An IDisposable field should be Disposed in a TearDown method.";
-        internal const string FieldIsNotDisposedInTearDownMessageFormat = "The field {0} should be Disposed in the {1} method";
+        internal const string FieldIsNotDisposedInTearDownMessageFormat = "The field {0} should be Disposed in a method annotated with [{1}]";
     }
 }

--- a/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownConstants.cs
+++ b/src/nunit.analyzers/DisposeFieldsInTearDown/DisposeFieldsInTearDownConstants.cs
@@ -1,9 +1,0 @@
-namespace NUnit.Analyzers.DisposeFieldsInTearDown
-{
-    internal static class DisposeFieldsInTearDownConstants
-    {
-        internal const string FieldIsNotDisposedInTearDownTitle = "An IDisposable field should be Disposed in a TearDown method";
-        internal const string FieldIsNotDisposedInTearDownDescription = "An IDisposable field should be Disposed in a TearDown method.";
-        internal const string FieldIsNotDisposedInTearDownMessageFormat = "The field {0} should be Disposed in a method annotated with [{1}]";
-    }
-}

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -198,8 +198,6 @@ namespace NUnit.Analyzers.Extensions
         /// <summary>
         /// Return value indicates whether type implements IDisposable.
         /// </summary>
-        /// <param name="elementType">Contains IEnumerable generic argument, or null, if type implements
-        /// only non-generic IEnumerable interface, or no IEnumerable interface at all.</param>
         internal static bool IsDisposable(this ITypeSymbol @this)
         {
             return @this.AllInterfaces.Any(i => i.GetFullMetadataName() is "System.IDisposable" or "System.IAsyncDisposable");

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -194,5 +194,15 @@ namespace NUnit.Analyzers.Extensions
 
             return false;
         }
+
+        /// <summary>
+        /// Return value indicates whether type implements IDisposable.
+        /// </summary>
+        /// <param name="elementType">Contains IEnumerable generic argument, or null, if type implements
+        /// only non-generic IEnumerable interface, or no IEnumerable interface at all.</param>
+        internal static bool IsDisposable(this ITypeSymbol @this)
+        {
+            return @this.AllInterfaces.Any(i => i.GetFullMetadataName() is "System.IDisposable" or "System.IAsyncDisposable");
+        }
     }
 }

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -200,7 +200,13 @@ namespace NUnit.Analyzers.Extensions
         /// </summary>
         internal static bool IsDisposable(this ITypeSymbol @this)
         {
-            return @this.AllInterfaces.Any(i => i.GetFullMetadataName() is "System.IDisposable" or "System.IAsyncDisposable");
+            return @this.GetFullMetadataName().IsDisposable() ||
+                   @this.AllInterfaces.Any(i => i.GetFullMetadataName().IsDisposable());
+        }
+
+        internal static bool IsDisposable(this string fullName)
+        {
+            return fullName is "System.IDisposable" or "System.IAsyncDisposable";
         }
     }
 }

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -200,6 +200,9 @@ namespace NUnit.Analyzers.Extensions
         /// </summary>
         internal static bool IsDisposable(this ITypeSymbol @this)
         {
+            if (@this is ITypeParameterSymbol typeParameter)
+                return typeParameter.ConstraintTypes.Any(t => t.IsDisposable());
+
             return @this.GetFullMetadataName().IsDisposable() ||
                    @this.AllInterfaces.Any(i => i.GetFullMetadataName().IsDisposable());
         }


### PR DESCRIPTION
Fixes #568  

There is a new `DiagnosticSuppressor` that suppresses the CA1001 error if the class is a `TestFixture`.
There is also a new `DiagnosticsAnalyzer` which analyzes fields.

1. If an `IDisposable` field is set in the `OneTimeSetUp` method it is only `Disposed` in the `OneTimeTearDown` method.
2. All other `IDisposable` fields must be disposed in `TearDown` method.
3. Add support for `IAsyncDisposable`

Disposal detection is limited, but I think probably sufficient for a `TearDown` method.
As long as `field.Dispose()` or `field?.Dispose()` is called, it is deemed disposed.
It could be that the field is conditionally assigned and therefore conditionally Disposed.
It is way beyond the scope to find out that the conditions are different.
