### PR TITLE
Do not suppress CA1001 if Fixture uses LifeCycle.InstancePerTestCase

### DIFF
--- a/documentation/NUnit3003.md
+++ b/documentation/NUnit3003.md
@@ -8,7 +8,7 @@
 | Severity | Info
 | Enabled  | True
 | Category | Suppressor
-| Code     | [TestFixtureSuppressor](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/TestFixtureSuppressor.cs)
+| Code     | [AvoidUninstantiatedInternalClassSuppressor](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/AvoidUninstantiatedInternalClassSuppressor.cs)
 
 ## Description
 

--- a/documentation/NUnit3004.md
+++ b/documentation/NUnit3004.md
@@ -8,7 +8,7 @@
 | Severity | Info
 | Enabled  | True
 | Category | Suppressor
-| Code     | [TestFixtureSuppressor](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/TestFixtureSuppressor.cs)
+| Code     | [TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/DiagnosticSuppressors/TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor.cs)
 
 ## Description
 

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -155,6 +155,9 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.FullNameOfTypeSetUpAttribute), typeof(SetUpAttribute)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeTearDownAttribute), typeof(TearDownAttribute)),
 
+            (nameof(NUnitFrameworkConstants.FullNameOfFixtureLifeCycleAttribute), typeof(FixtureLifeCycleAttribute)),
+            (nameof(NUnitFrameworkConstants.FullNameOfLifeCycle), typeof(LifeCycle)),
+
             (nameof(NUnitFrameworkConstants.FullNameOfSameAsConstraint), typeof(SameAsConstraint)),
             (nameof(NUnitFrameworkConstants.FullNameOfSomeItemsConstraint), typeof(SomeItemsConstraint)),
             (nameof(NUnitFrameworkConstants.FullNameOfEqualToConstraint), typeof(EqualConstraint)),

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/AvoidUninstantiatedInternalClassesSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/AvoidUninstantiatedInternalClassesSuppressorTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
             }
         ";
 
-        private static readonly DiagnosticSuppressor suppressor = new TestFixtureSuppressor();
+        private static readonly DiagnosticSuppressor suppressor = new AvoidUninstantiatedInternalClassSuppressor();
         private DiagnosticAnalyzer analyzer;
 
         [OneTimeSetUp]

--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
@@ -742,5 +743,33 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
             RoslynAssert.Valid(analyzer, testCode);
         }
 #endif
+
+        [Test]
+        public void ShouldNotAnalyzeWhenInstancePerTestCase()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@$"
+            [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+            public class TestClass
+            {{
+                private readonly IDisposable? field;
+
+                public TestClass()
+                {{
+                    field = new DummyDisposable();
+                }}
+
+                [Test]
+                public void Test()
+                {{
+                    Assert.That(field, Is.Not.Null);
+                }}
+
+                {DummyDisposable}
+            }}
+            ");
+
+            // InstancePerTestCase mean test should use IDisposable
+            RoslynAssert.Valid(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -117,6 +117,9 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfTypeSetUpAttribute = "NUnit.Framework.SetUpAttribute";
         public const string FullNameOfTypeTearDownAttribute = "NUnit.Framework.TearDownAttribute";
 
+        public const string FullNameOfFixtureLifeCycleAttribute = "NUnit.Framework.FixtureLifeCycleAttribute";
+        public const string FullNameOfLifeCycle = "NUnit.Framework.LifeCycle";
+
         public const string NameOfConstraint = "Constraint";
 
         public const string FullNameOfSameAsConstraint = "NUnit.Framework.Constraints.SameAsConstraint";

--- a/src/nunit.analyzers/DiagnosticSuppressors/TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor.cs
@@ -1,0 +1,72 @@
+#if !NETSTANDARD1_6
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.DiagnosticSuppressors
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor : DiagnosticSuppressor
+    {
+        internal static readonly SuppressionDescriptor TypesThatOwnDisposableFieldsShouldHaveATearDown = new(
+            id: AnalyzerIdentifiers.TypesThatOwnDisposableFieldsShouldBeDisposable,
+            suppressedDiagnosticId: "CA1001",
+            justification: "Field should be Disposed in TearDown or OneTimeTearDown method");
+
+        public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
+            ImmutableArray.Create(TypesThatOwnDisposableFieldsShouldHaveATearDown);
+
+        public override void ReportSuppressions(SuppressionAnalysisContext context)
+        {
+            foreach (var diagnostic in context.ReportedDiagnostics)
+            {
+                SyntaxTree? sourceTree = diagnostic.Location.SourceTree;
+
+                if (sourceTree is null)
+                {
+                    continue;
+                }
+
+                SyntaxNode node = sourceTree.GetRoot(context.CancellationToken)
+                                            .FindNode(diagnostic.Location.SourceSpan);
+
+                if (node is not ClassDeclarationSyntax classDeclaration)
+                {
+                    continue;
+                }
+
+                SemanticModel semanticModel = context.GetSemanticModel(sourceTree);
+                INamedTypeSymbol? typeSymbol = (INamedTypeSymbol?)semanticModel.GetDeclaredSymbol(classDeclaration, context.CancellationToken);
+
+                if (typeSymbol is not null)
+                {
+                    // Is the class set up for a InstancePerTestCase
+                    AttributeData? fixtureLifeCycleAttribute = typeSymbol.GetAllAttributes().FirstOrDefault(x => x.IsFixtureLifeCycleAttribute(context.Compilation));
+                    if (fixtureLifeCycleAttribute is not null &&
+                        fixtureLifeCycleAttribute.ConstructorArguments.Length == 1 &&
+                        fixtureLifeCycleAttribute.ConstructorArguments[0] is TypedConstant typeConstant &&
+                        typeConstant.Kind == TypedConstantKind.Enum &&
+                        typeConstant.Type.IsType(NUnitFrameworkConstants.FullNameOfLifeCycle, context.Compilation) &&
+                        typeConstant.Value is 1 /* LifeCycle.InstancePerTestCase */)
+                    {
+                        // If a TestFixture used InstancePerTestCase, it should be IDisposable
+                        if (diagnostic.Descriptor.Id == TypesThatOwnDisposableFieldsShouldHaveATearDown.SuppressedDiagnosticId)
+                            continue;
+                    }
+
+                    if (typeSymbol.IsTestFixture(context.Compilation))
+                    {
+                        context.ReportSuppression(Suppression.Create(TypesThatOwnDisposableFieldsShouldHaveATearDown, diagnostic));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/nunit.analyzers/DiagnosticSuppressors/TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/TypesThatOwnDisposableFieldsShouldBeDisposableSuppressor.cs
@@ -45,18 +45,10 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
 
                 if (typeSymbol is not null)
                 {
-                    // Is the class set up for a InstancePerTestCase
-                    AttributeData? fixtureLifeCycleAttribute = typeSymbol.GetAllAttributes().FirstOrDefault(x => x.IsFixtureLifeCycleAttribute(context.Compilation));
-                    if (fixtureLifeCycleAttribute is not null &&
-                        fixtureLifeCycleAttribute.ConstructorArguments.Length == 1 &&
-                        fixtureLifeCycleAttribute.ConstructorArguments[0] is TypedConstant typeConstant &&
-                        typeConstant.Kind == TypedConstantKind.Enum &&
-                        typeConstant.Type.IsType(NUnitFrameworkConstants.FullNameOfLifeCycle, context.Compilation) &&
-                        typeConstant.Value is 1 /* LifeCycle.InstancePerTestCase */)
+                    if (typeSymbol.IsInstancePerTestCaseFixture(context.Compilation))
                     {
                         // If a TestFixture used InstancePerTestCase, it should be IDisposable
-                        if (diagnostic.Descriptor.Id == TypesThatOwnDisposableFieldsShouldHaveATearDown.SuppressedDiagnosticId)
-                            continue;
+                        continue;
                     }
 
                     if (typeSymbol.IsTestFixture(context.Compilation))

--- a/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
+++ b/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
@@ -69,9 +69,10 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
                 return;
             }
 
-            if (!typeSymbol.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsTestRelatedMethod(context.Compilation)))
+            if (typeSymbol.IsInstancePerTestCaseFixture(context.Compilation) ||
+                !typeSymbol.IsTestFixture(context.Compilation))
             {
-                // Not a TestFixture, CA1812 should have picked this up.
+                // CA1001 should picked this up. Assuming it is enabled.
                 return;
             }
 

--- a/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
@@ -43,6 +43,16 @@ namespace NUnit.Analyzers.Extensions
                 || attributeType.IsType(NUnitFrameworkConstants.FullNameOfTypeTearDownAttribute, compilation);
         }
 
+        public static bool IsFixtureLifeCycleAttribute(this AttributeData @this, Compilation compilation)
+        {
+            var attributeType = @this.AttributeClass;
+
+            if (attributeType is null)
+                return false;
+
+            return attributeType.IsType(NUnitFrameworkConstants.FullNameOfFixtureLifeCycleAttribute, compilation);
+        }
+
         public static AttributeArgumentSyntax? GetConstructorArgumentSyntax(this AttributeData @this, int position,
             CancellationToken cancellationToken = default)
         {

--- a/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -67,5 +67,10 @@ namespace NUnit.Analyzers.Extensions
             return methodSymbol.GetAttributes().Any(
                 a => a.IsTestMethodAttribute(compilation) || a.IsSetUpOrTearDownMethodAttribute(compilation));
         }
+
+        internal static bool IsTestFixture(this ITypeSymbol typeSymbol, Compilation compilation)
+        {
+            return typeSymbol.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsTestRelatedMethod(compilation));
+        }
     }
 }

--- a/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using NUnit.Analyzers.Constants;
 
 namespace NUnit.Analyzers.Extensions
 {
@@ -71,6 +72,18 @@ namespace NUnit.Analyzers.Extensions
         internal static bool IsTestFixture(this ITypeSymbol typeSymbol, Compilation compilation)
         {
             return typeSymbol.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsTestRelatedMethod(compilation));
+        }
+
+        internal static bool IsInstancePerTestCaseFixture(this ITypeSymbol typeSymbol, Compilation compilation)
+        {
+            // Is there a FixtureLifeCycleAttribute?
+            AttributeData? fixtureLifeCycleAttribute = typeSymbol.GetAllAttributes().FirstOrDefault(x => x.IsFixtureLifeCycleAttribute(compilation));
+            return fixtureLifeCycleAttribute is not null &&
+                fixtureLifeCycleAttribute.ConstructorArguments.Length == 1 &&
+                fixtureLifeCycleAttribute.ConstructorArguments[0] is TypedConstant typeConstant &&
+                typeConstant.Kind == TypedConstantKind.Enum &&
+                typeConstant.Type.IsType(NUnitFrameworkConstants.FullNameOfLifeCycle, compilation) &&
+                typeConstant.Value is 1 /* LifeCycle.InstancePerTestCase */;
         }
     }
 }


### PR DESCRIPTION
Fixes #595 

When a TestFixture uses `LifeCycle.InstancePerTestCase` it can use an `IDispose` implementation.

Fields can be initialized in the constructor and disposed in the `Dispose` method.
