### PR TITLE
Do not consider Assert.That with TestDelegate to be a candidate for Assert.Multiple

### DIFF
--- a/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
@@ -99,5 +99,39 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
         }");
             RoslynAssert.Valid(this.analyzer, testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenUsingAnonymousLambda()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            object? actualDeserialized = null;
+
+            Assert.That(() => actualDeserialized = Calculate(), Throws.Nothing);
+            Assert.That(actualDeserialized, Is.Not.Null);
+
+            static object? Calculate() => new object();
+        }");
+
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenUsingTestDelegate()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            object? actualDeserialized = null;
+
+            Assert.That(Calculate, Throws.Nothing);
+            Assert.That(actualDeserialized, Is.Not.Null);
+
+            void Calculate() => actualDeserialized = new object();
+        }");
+
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
     }
 }


### PR DESCRIPTION
Fixes #614 

The analyzer will not try to delve into `TestDelegate` to see if it is independent or not.
It will consider this `Assert` to be not mergeable inside an `Assert.Multiple`