### PR TITLE
Disabled NUnit2025 by default.

### DIFF
--- a/documentation/NUnit2025.md
+++ b/documentation/NUnit2025.md
@@ -5,8 +5,8 @@
 | Topic    | Value
 | :--      | :--
 | Id       | NUnit2025
-| Severity | Error
-| Enabled  | True
+| Severity | Hidden
+| Enabled  | False
 | Category | Assertion
 | Code     | [ContainsConstraintWrongActualTypeAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzer.cs)
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -82,7 +82,7 @@ Rules which improve assertions in the test code.
 | [NUnit2022](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2022.md) | Missing property required for constraint | :white_check_mark: | :exclamation: | :white_check_mark: |
 | [NUnit2023](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2023.md) | Invalid NullConstraint usage | :white_check_mark: | :exclamation: | :x: |
 | [NUnit2024](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2024.md) | Wrong actual type used with String Constraint | :white_check_mark: | :exclamation: | :x: |
-| [NUnit2025](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2025.md) | Wrong actual type used with ContainsConstraint | :white_check_mark: | :exclamation: | :x: |
+| [NUnit2025](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2025.md) | Wrong actual type used with ContainsConstraint | :x: | :thought_balloon: | :x: |
 | [NUnit2026](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2026.md) | Wrong actual type used with the SomeItemsConstraint with EqualConstraint | :white_check_mark: | :exclamation: | :x: |
 | [NUnit2027](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2027.md) | Consider using Assert.That(actual, Is.GreaterThan(expected)) instead of ClassicAssert.Greater(actual, expected) | :white_check_mark: | :information_source: | :white_check_mark: |
 | [NUnit2028](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2028.md) | Consider using Assert.That(actual, Is.GreaterThanOrEqualTo(expected)) instead of ClassicAssert.GreaterOrEqual(actual, expected) | :white_check_mark: | :information_source: | :white_check_mark: |

--- a/src/nunit.analyzers/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzer.cs
+++ b/src/nunit.analyzers/ContainsConstraintWrongActualType/ContainsConstraintWrongActualTypeAnalyzer.cs
@@ -16,7 +16,8 @@ namespace NUnit.Analyzers.ContainsConstraintWrongActualType
             title: ContainsConstraintWrongActualTypeConstants.Title,
             messageFormat: ContainsConstraintWrongActualTypeConstants.Message,
             category: Categories.Assertion,
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Hidden,
+            isEnabledByDefault: false,
             description: ContainsConstraintWrongActualTypeConstants.Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }


### PR DESCRIPTION
Left the rule in, in case someone wants to restrict Does.Contains to strings.

Fixes #621 