### PR TITLE
Suppress ValuesUsageAnalyzer when using null-forgiving operator

### DIFF
--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -476,6 +476,32 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         }
 
         [Test]
+        public void AnalyzeWhenArgumentPassesNullToNonNullableParamsReferenceType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenArgumentPassesSuppressedNullToNonNullableType
+    {
+        [TestCase(""Hello"", null)]
+        public void Test(params string[] a) { }
+    }");
+            RoslynAssert.Diagnostics(this.analyzer,
+                ExpectedDiagnostic.Create(AnalyzerIdentifiers.TestCaseParameterTypeMismatchUsage),
+                testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenArgumentPassesSuppressedNullToNonNullableParamsReferenceType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenArgumentPassesSuppressedNullToNonNullableType
+    {
+        [TestCase(""Hello"", null!)]
+        public void Test(params string[] a) { }
+    }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenArgumentPassesValueToNullableType()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -464,6 +464,18 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
         }
 
         [Test]
+        public void AnalyzeWhenArgumentPassesSuppressedNullToNonNullableReferenceType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenArgumentPassesSuppressedNullToNonNullableType
+    {
+        [TestCase(null!)]
+        public void Test(object a) { }
+    }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenArgumentPassesValueToNullableType()
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"

--- a/src/nunit.analyzers.tests/ValuesUsage/ValuesUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ValuesUsage/ValuesUsageAnalyzerTests.cs
@@ -410,5 +410,16 @@ namespace NUnit.Analyzers.Tests.ValuesUsage
     }");
             RoslynAssert.Diagnostics(this.analyzer, expectedDiagnostic, testCode);
         }
+
+        [Test]
+        public void AnalyzeWhenSuppressedNullIsPassedToAReferenceType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenSuppressedNullIsPassedToAReferenceType
+    {
+        public void Test([Values(null!)] string s) { }
+    }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ValuesUsage/ValuesUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ValuesUsage/ValuesUsageAnalyzerTests.cs
@@ -404,7 +404,7 @@ namespace NUnit.Analyzers.Tests.ValuesUsage
                                                                              0, "<null>", "a", "object"));
 
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
-    public sealed class AnalyzeWhenArgumentPassesNullToNullableType
+    public sealed class AnalyzeWhenArgumentPassesNullToNonNullableType
     {
         public void Test([Values(↓null)] object a) { }
     }");
@@ -420,6 +420,28 @@ namespace NUnit.Analyzers.Tests.ValuesUsage
         public void Test([Values(null!)] string s) { }
     }");
             RoslynAssert.Valid(this.analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenSuppressedNullIsPassedToANonReferenceType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenSuppressedNullIsPassedToAReferenceType
+    {
+        public void Test([Values(↓null!)] int i) { }
+    }");
+            RoslynAssert.Diagnostics(this.analyzer, ExpectedDiagnostic.Create(AnalyzerIdentifiers.ValuesParameterTypeMismatchUsage), testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenSuppressedConstantIsPassedToANonNullableReferenceType()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public sealed class AnalyzeWhenSuppressedNullIsPassedToAReferenceType
+    {
+        public void Test([Values(↓2!)] string s) { }
+    }");
+            RoslynAssert.Diagnostics(this.analyzer, ExpectedDiagnostic.Create(AnalyzerIdentifiers.ValuesParameterTypeMismatchUsage), testCode);
         }
     }
 }

--- a/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeArgumentTypedConstantExtensions.cs
@@ -56,7 +56,8 @@ namespace NUnit.Analyzers.Extensions
 
         internal static bool CanAssignTo(this TypedConstant @this, ITypeSymbol target, Compilation compilation,
             bool allowImplicitConversion = false,
-            bool allowEnumToUnderlyingTypeConversion = false)
+            bool allowEnumToUnderlyingTypeConversion = false,
+            bool suppressNullableWarning = false)
         {
             // See https://github.com/nunit/nunit/blob/f16d12d6fa9e5c879601ad57b4b24ec805c66054/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs#L396
             // for the reasoning behind this implementation.
@@ -78,7 +79,7 @@ namespace NUnit.Analyzers.Extensions
 #if NETSTANDARD1_6
                     target.IsReferenceType
 #else
-                    (target.IsReferenceType && target.NullableAnnotation != NullableAnnotation.NotAnnotated)
+                    (target.IsReferenceType && (target.NullableAnnotation != NullableAnnotation.NotAnnotated || suppressNullableWarning))
 #endif
                     || target.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
                 {

--- a/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ExpressionSyntaxExtensions.cs
@@ -48,5 +48,14 @@ namespace NUnit.Analyzers.Extensions
                     return null;
             }
         }
+
+        public static bool IsSuppressNullableWarning(this ExpressionSyntax expression)
+        {
+#if NETSTANDARD1_6
+            return false;
+#else
+            return expression.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SuppressNullableWarningExpression);
+#endif
+        }
     }
 }

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -180,27 +180,32 @@ namespace NUnit.Analyzers.TestCaseUsage
 
                 ITypeSymbol? argumentType = attributeArgument.Type;
 
-                var argumentTypeMatchesParameterType = attributeArgument.CanAssignTo(
-                    methodParameterType,
-                    context.Compilation,
-                    allowImplicitConversion: true,
-                    allowEnumToUnderlyingTypeConversion: true,
-                    suppressNullableWarning: argumentSyntax.IsSuppressNullableWarning());
+                if (i < methodParameters.Length)
+                {
+                    // Test against the actual parameter definition.
+                    // In case an array is passed to a params parameter.
+                    var argumentTypeMatchesParameterType = attributeArgument.CanAssignTo(
+                        methodParameterType,
+                        context.Compilation,
+                        allowImplicitConversion: true,
+                        allowEnumToUnderlyingTypeConversion: true,
+                        suppressNullableWarning: argumentSyntax.IsSuppressNullableWarning());
 
-                if (methodParameterParamsType is null && argumentTypeMatchesParameterType)
-                    continue;
+                    if (argumentTypeMatchesParameterType)
+                        continue;
+                }
 
                 if (methodParameterParamsType is not null)
                 {
+                    // Test against the element type of the params parameter.
                     var argumentTypeMatchesElementType = attributeArgument.CanAssignTo(
                         methodParameterParamsType,
                         context.Compilation,
                         allowImplicitConversion: true,
                         allowEnumToUnderlyingTypeConversion: true,
-                        suppressNullableWarning: false);
+                        suppressNullableWarning: argumentSyntax.IsSuppressNullableWarning());
 
-                    if (argumentTypeMatchesElementType ||
-                        (argumentTypeMatchesParameterType && (argumentType is not null || !methodParameterParamsType.IsValueType)))
+                    if (argumentTypeMatchesElementType)
                     {
                         continue;
                     }

--- a/src/nunit.analyzers/ValuesUsage/ValuesUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ValuesUsage/ValuesUsageAnalyzer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
@@ -83,6 +84,12 @@ namespace NUnit.Analyzers.ValuesUsage
                         continue;
                     }
 
+#if NETSTANDARD2_0_OR_GREATER
+                    if (argumentSyntax.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+                    {
+                        continue;
+                    }
+#endif
                     var diagnostic = Diagnostic.Create(parameterTypeMismatch,
                                                        argumentSyntax.GetLocation(),
                                                        index,


### PR DESCRIPTION
Fixes #631 

This teaches the `ValuesUsageAnalyzer` to respect the null-forgiving operator.

The test passes when using .NET 8, however I wasn't able to build locally with the current setup, so it would be great if someone who is able to run the tests as-is could try it out.