### PR TITLE
Add support for Assert.MultipleAsync

### DIFF
--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -69,6 +69,11 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfHasMember), nameof(Has.Member)),
 
             (nameof(NUnitFrameworkConstants.NameOfMultiple), nameof(Assert.Multiple)),
+#if NUNIT4
+            (nameof(NUnitFrameworkConstants.NameOfMultipleAsync), nameof(Assert.MultipleAsync)),
+#else
+            (nameof(NUnitFrameworkConstants.NameOfMultipleAsync), "MultipleAsync"),
+#endif
 
             (nameof(NUnitFrameworkConstants.NameOfThrows), nameof(Throws)),
             (nameof(NUnitFrameworkConstants.NameOfThrowsArgumentException), nameof(Throws.ArgumentException)),

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -362,6 +362,29 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 testCode);
         }
 
+#if NUNIT4
+        [Test]
+        public void InsideAssertMultipleAsync()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+                [TestCase("""")]
+                public async Task Test(string? s)
+                {{
+                    await Assert.MultipleAsync(async () =>
+                    {{
+                        await Task.Yield();
+                        ClassicAssert.NotNull(s);
+                        Assert.That(↓s.Length, Is.GreaterThan(0));
+                    }});
+                }}
+            ");
+
+            RoslynAssert.NotSuppressed(suppressor,
+                ExpectedDiagnostic.Create(DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"]),
+                testCode);
+        }
+#endif
+
         [TestCase("ClassicAssert.True(nullable.HasValue)")]
         [TestCase("ClassicAssert.IsTrue(nullable.HasValue)")]
         [TestCase("Assert.That(nullable.HasValue, \"Ensure Value is set\")")]

--- a/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
@@ -27,6 +27,26 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             RoslynAssert.Valid(this.analyzer, testCode);
         }
 
+#if NUNIT4
+        [Test]
+        public void AnalyzeWhenMultipleAsyncIsUsed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public async Task Test()
+        {
+            await Assert.MultipleAsync(async () =>
+            {
+                Assert.That(await Get1(), Is.Not.Null);
+                Assert.That(await Get2(), Is.Not.Null);
+            });
+
+            static Task<string?> Get1() => Task.FromResult(default(string));
+            static Task<string?> Get2() => Task.FromResult(default(string));
+        }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+#endif
+
         [Test]
         public void AnalyzeWhenDependent()
         {

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -50,6 +50,7 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfHasMember = "Member";
 
         public const string NameOfMultiple = "Multiple";
+        public const string NameOfMultipleAsync = "MultipleAsync";
 
         public const string NameOfThrows = "Throws";
         public const string NameOfThrowsArgumentException = "ArgumentException";

--- a/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
@@ -357,7 +357,7 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
                         return true;
                     }
                 }
-                else if (member == NUnitFrameworkConstants.NameOfMultiple)
+                else if (member is NUnitFrameworkConstants.NameOfMultiple or NUnitFrameworkConstants.NameOfMultipleAsync)
                 {
                     // Look up into the actual asserted parameter
                     if (argumentList.Arguments.FirstOrDefault()?.Expression is AnonymousFunctionExpressionSyntax anonymousFunction)

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Helpers
             while ((possibleAssertMultiple = node.Ancestors().OfType<InvocationExpressionSyntax>().FirstOrDefault()) is not null)
             {
                 // Is the statement inside a Block which is part of an Assert.Multiple.
-                if (IsAssert(possibleAssertMultiple, NUnitFrameworkConstants.NameOfMultiple))
+                if (IsAssert(possibleAssertMultiple, NUnitFrameworkConstants.NameOfMultiple, NUnitFrameworkConstants.NameOfMultipleAsync))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes #615 

This affects:
- DereferencePossiblyNullReferenceSuppressor
- UseAssertMultipleAnalyzer