### PR TITLE
chore: markdownlint-cli2-config is removed use flag instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: "18"
       - run: npm install -g markdownlint-cli2
         name: Install markdownlint-cli2
-      - run: markdownlint-cli2-config ".github/linters/.markdownlint.yml" "documentation/*.md"
+      - run: markdownlint-cli2 --config ".github/linters/.markdownlint.yml" "documentation/*.md"
         name: run Markdownlint
   spellcheck:
     name: "Spell check"


### PR DESCRIPTION
The entry point `markdownlint-cli2-config` was removed in markdownlint-cli2 version 0.12.0

See https://github.com/DavidAnson/markdownlint-cli2/blob/82c791e94c2e2ab2119437d61c722c8e0c20d6c9/CHANGELOG.md?plain=1#L11-L12