### PR TITLE
Remove null message in AreEqual code fix

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -57,6 +57,22 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyAreEqualFixWithNullMessage()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.AreEqual(2d, 3d, null);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(3d, Is.EqualTo(2d));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyAreEqualFixWithMessageAndParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -137,6 +137,22 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyAreEqualFixWhenToleranceExistsWithNullMessage()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.AreEqual(2d, 3d, 0.1, null);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(3d, Is.EqualTo(2d).Within(0.1));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyAreEqualFixWhenToleranceExistsWithMessageAndParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -55,6 +55,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             // Now, replace the arguments.
             List<ArgumentSyntax> arguments = invocationNode.ArgumentList.Arguments.ToList();
 
+            // Remove null message to avoid ambiguous calls.
+            if (arguments.Count == 3 && arguments[2].Expression.Kind() == SyntaxKind.NullLiteralExpression)
+            {
+                arguments.RemoveAt(2);
+            }
+
             // See if we need to cast the arguments when they were using a specific classic overload.
             arguments[0] = CastIfNecessary(arguments[0]);
             if (arguments.Count > 1)

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFix.cs
@@ -55,12 +55,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             // Now, replace the arguments.
             List<ArgumentSyntax> arguments = invocationNode.ArgumentList.Arguments.ToList();
 
-            // Remove null message to avoid ambiguous calls.
-            if (arguments.Count == 3 && arguments[2].Expression.Kind() == SyntaxKind.NullLiteralExpression)
-            {
-                arguments.RemoveAt(2);
-            }
-
             // See if we need to cast the arguments when they were using a specific classic overload.
             arguments[0] = CastIfNecessary(arguments[0]);
             if (arguments.Count > 1)
@@ -71,6 +65,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 this.UpdateArguments(diagnostic, arguments);
             else
                 this.UpdateArguments(diagnostic, arguments, typeArguments);
+
+            // Remove null message to avoid ambiguous calls.
+            if (arguments.Count == 3 && arguments[2].Expression.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                arguments.RemoveAt(2);
+            }
 
             // Do the format spec, params to formattable string conversion
             CodeFixHelper.UpdateStringFormatToFormattableString(arguments, this.MinimumNumberOfParameters);


### PR DESCRIPTION
```
Assert.AreEqual(2d, 3d, null);
```
would generate
```
Assert.That(3d, Is.EqualTo(2d), null);
```
which does not compile
```
The call is ambiguous between the following methods or properties:
'Assert.That<TActual>(TActual, IResolveConstraint, FormattableString,
string, string)' and 'Assert.That<TActual>(TActual, IResolveConstraint,
Func<string>, string, string)'
```