### PR TITLE
Ignore null suppression operator when matching Is.Not.Null

### DIFF
--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -997,5 +997,32 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 ExpectedDiagnostic.Create(DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"]),
                 testCode);
         }
+
+        [Test]
+        public void TestNullSuppressionOperator()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                [TestCase(default(string))]
+                public void Test(string ?possibleNullString)
+                {
+                    HasString str = new(possibleNullString);
+
+                    string nonNullString = GetStringSuppress(str);
+                    Assert.That(nonNullString, Is.Not.Null);
+                }
+
+                private static string GetStringSuppress(HasString? str) // argument is nullable
+                {
+                    Assert.That(str!.Inner, Is.Not.Null);
+                    return str.Inner; // warning: possible null reference return
+                }
+
+                private record HasString(string? Inner);
+            ");
+
+            RoslynAssert.Suppressed(suppressor,
+                ExpectedDiagnostic.Create(DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8603"]),
+                testCode);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -1017,7 +1017,15 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                     return str.Inner; // warning: possible null reference return
                 }
 
-                private record HasString(string? Inner);
+                private sealed class HasString
+                {
+                    public HasString(string? inner)
+                    {                   
+                        Inner = inner;
+                    }
+
+                    public string? Inner { get; }
+                }
             ");
 
             RoslynAssert.Suppressed(suppressor,

--- a/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
@@ -407,6 +407,12 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
 
         private static bool CoveredBy(string assertedNotNull, string possibleNullReference)
         {
+            int exclamation = assertedNotNull.IndexOf('!');
+            if (exclamation >= 0)
+            {
+                assertedNotNull = assertedNotNull.Replace("!", string.Empty);
+            }
+
             if (possibleNullReference == assertedNotNull)
             {
                 return true;


### PR DESCRIPTION
Fixes #679 