### PR TITLE
Fix logic around out-of-order arguments for classic assertions (#712)

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -43,11 +43,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFixWhenToleranceExistsWithNamedArgumentButInNonstandardOrder()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(delta: 0.0000001d, actual: 3d, expected: 2d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -59,11 +59,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFixWithNamedParametersInNonstandardOrder()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(actual: 3d, expected: 2d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -117,6 +117,24 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             Assert.That(3d, Is.EqualTo(2d), $""message-id: {Guid.NewGuid()}"");
         }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyAreEqualFixWithMessageAnd2ParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var actual = 3d;
+            ↓ClassicAssert.AreEqual(delta: 0.0000001d, expected: 2d, actual: actual, args: new[] { ""Guid.NewGuid()"", Guid.NewGuid().ToString() }, message: ""message-id: {0}, {1}"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var actual = 3d;
+            Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid().ToString() }"");
+        }"); // TODO: Fix whitespace
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
 
@@ -196,6 +214,22 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d), $""message-id: {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyAreEqualFixWhenToleranceExistsWithMessageAndParamsLiteralExpressionSyntax()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d, ""message-id: {0}"", ""mystring"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d), $""message-id: {""mystring""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -139,6 +139,24 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyAreEqualFixWithMessageAnd2ParamsInStandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var actual = 3d;
+            ↓ClassicAssert.AreEqual(expected: 2d, actual: actual, delta: 0.0000001d, ""message-id: {0}, {1}"", ""Guid.NewGuid()"", Guid.NewGuid());
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var actual = 3d;
+            Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyAreEqualFixWhenToleranceExists()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 3d, Is.EqualTo(expected: 2d).Within(0.0000001d));
+            Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d));
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -67,7 +67,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 3d, Is.EqualTo(expected: 2d));
+            Assert.That(3d, Is.EqualTo(2d));
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -133,7 +133,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             var actual = 3d;
-            Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid().ToString()}"");
+            Assert.That(actual, Is.EqualTo(2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid().ToString()}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -151,7 +151,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             var actual = 3d;
-            Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid()}"");
+            Assert.That(actual, Is.EqualTo(2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid()}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -183,7 +183,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 3d, Is.EqualTo(expected: 2d).Within(0.0000001d));
+            Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d));
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -27,11 +27,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(2d, 3d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -75,11 +75,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(2d, 3d, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -105,13 +105,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreEqualFixWithMessageAndParams()
+        public void VerifyAreEqualFixWithMessageAndOneArgumentForParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-            ↓ClassicAssert.AreEqual(2d, 3d, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+        {
+            ↓ClassicAssert.AreEqual(2d, 3d, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -159,11 +159,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFixWhenToleranceExists()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -175,11 +175,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFixWhenToleranceExistsWithNamedArgument()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(expected: 2d, actual: 3d, delta: 0.0000001d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -191,11 +191,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreEqualFixWhenToleranceExistsWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -221,13 +221,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreEqualFixWhenToleranceExistsWithMessageAndParams()
+        public void VerifyAreEqualFixWhenToleranceExistsWithMessageAndOneArgumentForParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-            ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+        {
+            ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -237,17 +237,17 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreEqualFixWhenToleranceExistsWithMessageAndParamsLiteralExpressionSyntax()
+        public void VerifyAreEqualFixWhenToleranceExistsWithMessageAndTwoArgumentsForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d, ""message-id: {0}"", ""mystring"");
+            ↓ClassicAssert.AreEqual(2d, 3d, 0.0000001d, ""{0}, {1}"", ""first"", ""second"");
         }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d), $""message-id: {""mystring""}"");
+            Assert.That(3d, Is.EqualTo(2d).Within(0.0000001d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -255,7 +255,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             ClassicAssert.AreEqual(2d, 3d, 0.0000001d,
                 ""message"");");
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -134,7 +134,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var actual = 3d;
             Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid().ToString() }"");
-        }"); // TODO: Fix whitespace
+        }"); // TODO: Fix trailing trivia if possible
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -41,6 +41,22 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyAreEqualFixWithNamedParametersInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.AreEqual(actual: 3d, expected: 2d);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: 3d, Is.EqualTo(expected: 2d));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyAreEqualFixWithMessage()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -133,8 +133,8 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             var actual = 3d;
-            Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid().ToString() }"");
-        }"); // TODO: Fix trailing trivia if possible
+            Assert.That(actual: actual, Is.EqualTo(expected: 2d).Within(0.0000001d), $""message-id: {""Guid.NewGuid()""}, {Guid.NewGuid().ToString()}"");
+        }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFixTests.cs
@@ -41,6 +41,22 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyAreEqualFixWhenToleranceExistsWithNamedArgumentButInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.AreEqual(delta: 0.0000001d, actual: 3d, expected: 2d);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: 3d, Is.EqualTo(expected: 2d).Within(0.0000001d));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyAreEqualFixWithNamedParametersInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: ""actual"", Is.Not.EqualTo(expected: ""expected""), $""{""first""}, {""second""}"");
+            Assert.That(""actual"", Is.Not.EqualTo(""expected""), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
@@ -27,11 +27,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreNotEqualFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreNotEqual(2d, 3d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -43,11 +43,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreNotEqualFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.AreNotEqual(2d, 3d, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -57,13 +57,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreNotEqualFixWithMessageAndParams()
+        public void VerifyAreNotEqualFixWithMessageAndOneArgumentForParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-            ↓ClassicAssert.AreNotEqual(2d, 3d, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+        {
+            ↓ClassicAssert.AreNotEqual(2d, 3d, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -73,7 +73,23 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreNotEqualFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyAreNotEqualFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.AreNotEqual(2d, 3d, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(3d, Is.Not.EqualTo(2d), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyAreNotEqualFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
@@ -71,5 +71,21 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyAreNotEqualFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.AreNotEqual(args: new[] { ""first"", ""second"" }, actual: ""actual"", message: ""{0}, {1}"", expected: ""expected"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: ""actual"", Is.Not.EqualTo(expected: ""expected""), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: ""actual"", Is.Not.EqualTo(expected: ""expected""), $""{""first""}, {""second"" }"");
+            Assert.That(actual: ""actual"", Is.Not.EqualTo(expected: ""expected""), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
@@ -89,5 +89,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyAreNotSameFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            ↓ClassicAssert.AreNotSame(args: new[] { ""first"", ""second"" }, actual: actual, message: ""{0}, {1}"", expected: expected);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            Assert.That(actual: actual, Is.Not.SameAs(expected: expected), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
@@ -27,14 +27,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreNotSameFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = new object();
             var actual = new object();
 
             ↓ClassicAssert.AreNotSame(expected, actual);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -49,14 +49,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreNotSameFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = new object();
             var actual = new object();
 
             ↓ClassicAssert.AreNotSame(expected, actual, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -69,16 +69,16 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreNotSameFixWithMessageAndParams()
+        public void VerifyAreNotSameFixWithMessageAndOneArgumentForParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = new object();
             var actual = new object();
 
-            ↓ClassicAssert.AreNotSame(expected, actual, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.AreNotSame(expected, actual, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -91,7 +91,29 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreNotSameFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyAreNotSameFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            ↓ClassicAssert.AreNotSame(expected, actual, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            Assert.That(actual, Is.Not.SameAs(expected), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyAreNotSameFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = new object();
             var actual = new object();
 
-            Assert.That(actual: actual, Is.Not.SameAs(expected: expected), $""{""first""}, {""second"" }"");
+            Assert.That(actual: actual, Is.Not.SameAs(expected: expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFixTests.cs
@@ -129,7 +129,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = new object();
             var actual = new object();
 
-            Assert.That(actual: actual, Is.Not.SameAs(expected: expected), $""{""first""}, {""second""}"");
+            Assert.That(actual, Is.Not.SameAs(expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
@@ -27,14 +27,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreSameFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = new object();
             var actual = new object();
 
             ↓ClassicAssert.AreSame(expected, actual);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -49,14 +49,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyAreSameFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = new object();
             var actual = new object();
 
             ↓ClassicAssert.AreSame(expected, actual, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -69,16 +69,16 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreSameFixWithMessageAndParams()
+        public void VerifyAreSameFixWithMessageAndOneArgumentForParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = new object();
             var actual = new object();
 
-            ↓ClassicAssert.AreSame(expected, actual, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.AreSame(expected, actual, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -91,7 +91,29 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyAreSameFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyAreSameFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            ↓ClassicAssert.AreSame(expected, actual, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            Assert.That(actual, Is.SameAs(expected), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyAreSameFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
@@ -89,5 +89,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyAreSameFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            ↓ClassicAssert.AreSame(args: new[] { ""first"", ""second"" }, actual: actual, message: ""{0}, {1}"", expected: expected);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = new object();
+            var actual = new object();
+
+            Assert.That(actual: actual, Is.SameAs(expected: expected), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
@@ -129,7 +129,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = new object();
             var actual = new object();
 
-            Assert.That(actual: actual, Is.SameAs(expected: expected), $""{""first""}, {""second""}"");
+            Assert.That(actual, Is.SameAs(expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = new object();
             var actual = new object();
 
-            Assert.That(actual: actual, Is.SameAs(expected: expected), $""{""first""}, {""second"" }"");
+            Assert.That(actual: actual, Is.SameAs(expected: expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
@@ -22,9 +22,10 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray<string>.Empty;
 
-            protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
-            {
-            }
+            protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+                Diagnostic diagnostic,
+                IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments) =>
+                (default!, default);
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ClassicModelAssertUsageCodeFixTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -25,7 +26,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
                 Diagnostic diagnostic,
                 IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments) =>
-                (default!, default);
+                throw new NotImplementedException();
         }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
@@ -27,14 +27,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyContainsFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var instance = new object();
             var collection = Array.Empty<object>();
 
             ↓ClassicAssert.Contains(instance, collection);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -49,14 +49,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyContainsFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var instance = new object();
             var collection = Array.Empty<object>();
 
             ↓ClassicAssert.Contains(instance, collection, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -69,16 +69,16 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyContainsFixWithMessageAndParams()
+        public void VerifyContainsFixWithMessageAndOneArgumentForParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var instance = new object();
             var collection = Array.Empty<object>();
 
-            ↓ClassicAssert.Contains(instance, collection, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.Contains(instance, collection, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -91,7 +91,29 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyContainsFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyContainsFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var instance = new object();
+            var collection = Array.Empty<object>();
+
+            ↓ClassicAssert.Contains(instance, collection, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var instance = new object();
+            var collection = Array.Empty<object>();
+
+            Assert.That(collection, Does.Contain(instance), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyContainsFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
@@ -129,7 +129,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var instance = new object();
             var collection = Array.Empty<object>();
 
-            Assert.That(actual: collection, Does.Contain(expected: instance), $""{""first""}, {""second""}"");
+            Assert.That(collection, Does.Contain(instance), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
@@ -89,5 +89,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
+
+        [Test]
+        public void VerifyContainsFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var instance = new object();
+            var collection = Array.Empty<object>();
+
+            ↓ClassicAssert.Contains(args: new[] { ""first"", ""second"" }, actual: collection, message: ""{0}, {1}"", expected: instance);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var instance = new object();
+            var collection = Array.Empty<object>();
+
+            Assert.That(actual: collection, Does.Contain(expected: instance), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var instance = new object();
             var collection = Array.Empty<object>();
 
-            Assert.That(actual: collection, Does.Contain(expected: instance), $""{""first""}, {""second"" }"");
+            Assert.That(actual: collection, Does.Contain(expected: instance), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, instanceDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.GreaterThan(expected: 3d), $""{""first""}, {""second"" }"");
+            Assert.That(actual: 2d, Is.GreaterThan(expected: 3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             MyFloat x = 1;
             MyFloat y = 2;
-            Assert.That((float)x, Is.GreaterThan((float)y), $""{""first""}, {""second"" }"");
+            Assert.That((float)x, Is.GreaterThan((float)y), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.GreaterThan(expected: 3d), $""{""first""}, {""second""}"");
+            Assert.That(2d, Is.GreaterThan(3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyGreaterFixWithMessageAndParams()
+        public void VerifyGreaterFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -73,7 +73,23 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyGreaterFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyGreaterFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.Greater(2d, 3d, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(2d, Is.GreaterThan(3d), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyGreaterFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -91,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             ClassicAssert.Greater(2d, 3d,
                 ""message"");");
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -27,11 +27,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyGreaterOrEqualFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.GreaterOrEqual(2d, 3d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -43,11 +43,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyGreaterOrEqualFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.GreaterOrEqual(2d, 3d, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -59,15 +59,31 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyGreaterOrEqualFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-            ↓ClassicAssert.GreaterOrEqual(2d, 3d, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+        {
+            ↓ClassicAssert.GreaterOrEqual(2d, 3d, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
             Assert.That(2d, Is.GreaterThanOrEqualTo(3d), $""message-id: {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyGreaterOrEqualFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.GreaterOrEqual(args: new[] { ""first"", ""second"" }, arg2: 3d, message: ""{0}, {1}"", arg1: 2d);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: 2d, Is.GreaterThanOrEqualTo(expected: 3d), $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -158,6 +174,44 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float x = 1;
             MyFloat y = 2;
             Assert.That(x, Is.GreaterThanOrEqualTo((float)y));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyGreaterOrEqualWithImplicitConversionFixInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            MyFloat y = 2;
+            ↓ClassicAssert.GreaterOrEqual(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", arg2: y, arg1: x);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            MyFloat y = 2;
+            Assert.That((float)x, Is.GreaterThanOrEqualTo((float)y), $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyGreaterOrEqualFixWithMessageAndParams()
+        public void VerifyGreaterOrEqualFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -73,7 +73,23 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyGreaterOrEqualFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyGreaterOrEqualFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.GreaterOrEqual(2d, 3d, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(2d, Is.GreaterThanOrEqualTo(3d), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyGreaterOrEqualFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -91,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             ClassicAssert.GreaterOrEqual(2d, 3d,
                 ""message"");");
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.GreaterThanOrEqualTo(expected: 3d), $""{""first""}, {""second"" }"");
+            Assert.That(actual: 2d, Is.GreaterThanOrEqualTo(expected: 3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             MyFloat x = 1;
             MyFloat y = 2;
-            Assert.That((float)x, Is.GreaterThanOrEqualTo((float)y), $""{""first""}, {""second"" }"");
+            Assert.That((float)x, Is.GreaterThanOrEqualTo((float)y), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.GreaterThanOrEqualTo(expected: 3d), $""{""first""}, {""second""}"");
+            Assert.That(2d, Is.GreaterThanOrEqualTo(3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var collection = Array.Empty<object>();
 
-            Assert.That(actual: collection, Is.Empty, $""{""first""}, {""second""}"");
+            Assert.That(collection, Is.Empty, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsEmptyFixWithMessageAndParams()
+        public void VerifyIsEmptyFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -85,7 +85,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsEmptyFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsEmptyFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var collection = Array.Empty<object>();
+
+            ↓ClassicAssert.IsEmpty(collection, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var collection = Array.Empty<object>();
+
+            Assert.That(collection, Is.Empty, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsEmptyFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var collection = Array.Empty<object>();
 
-            Assert.That(actual: collection, Is.Empty, $""{""first""}, {""second"" }"");
+            Assert.That(actual: collection, Is.Empty, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -27,13 +27,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsEmptyFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var collection = Array.Empty<object>();
 
             ↓ClassicAssert.IsEmpty(collection);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -47,13 +47,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsEmptyFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var collection = Array.Empty<object>();
 
             ↓ClassicAssert.IsEmpty(collection, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -67,19 +67,39 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsEmptyFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var collection = Array.Empty<object>();
 
-            ↓ClassicAssert.IsEmpty(collection, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.IsEmpty(collection, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
             var collection = Array.Empty<object>();
 
             Assert.That(collection, Is.Empty, $""message-id: {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsEmptyFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var collection = Array.Empty<object>();
+
+            ↓ClassicAssert.IsEmpty(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", collection: collection);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var collection = Array.Empty<object>();
+
+            Assert.That(actual: collection, Is.Empty, $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: false, Is.False, $""{""first""}, {""second""}"");
+            Assert.That(false, Is.False, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
         [TestCase("False", AnalyzerIdentifiers.FalseUsage)]
-        public void VerifyIsFalseAndFalseFixesWithMessageAndParams(string assertion, string diagnosticId)
+        public void VerifyIsFalseAndFalseFixesWithMessageAndOneArgumentForParams(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 
@@ -81,7 +81,26 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
         [TestCase("False", AnalyzerIdentifiers.FalseUsage)]
-        public void VerifyIsFalseAndFalseFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        public void VerifyIsFalseAndFalseFixesWithMessageAndTwoArgumentsForParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.{assertion}(false, ""{{0}}, {{1}}"", ""first"", ""second"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(false, Is.False, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
+        [TestCase("False", AnalyzerIdentifiers.FalseUsage)]
+        public void VerifyIsFalseAndFalseFixesWithMessageAndArrayParamsInNonstandardOrder(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: false, Is.False, $""{""first""}, {""second"" }"");
+            Assert.That(actual: false, Is.False, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFixTests.cs
@@ -81,6 +81,25 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
         [TestCase("False", AnalyzerIdentifiers.FalseUsage)]
+        public void VerifyIsFalseAndFalseFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.{assertion}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", condition: false);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: false, Is.False, $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsFalse", AnalyzerIdentifiers.IsFalseUsage)]
+        [TestCase("False", AnalyzerIdentifiers.FalseUsage)]
         public void VerifyIsFalseAndFalseWithImplicitTypeConversionFixes(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -298,7 +298,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
-            Assert.That(actual: actual, Is.InstanceOf<int>(), $""{""first""}, {""second""}"");");
+            Assert.That(actual, Is.InstanceOf<int>(), $""{""first""}, {""second""}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -27,14 +27,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsInstanceOfFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = typeof(int);
             var actual = 42;
 
             ↓ClassicAssert.IsInstanceOf(expected, actual);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -49,14 +49,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsInstanceOfFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = typeof(int);
             var actual = 42;
 
             ↓ClassicAssert.IsInstanceOf(expected, actual, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -71,14 +71,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsInstanceOfFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = typeof(int);
             var actual = 42;
 
-            ↓ClassicAssert.IsInstanceOf(expected, actual, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.IsInstanceOf(expected, actual, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -91,15 +91,37 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyIsInstanceOfFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            ↓ClassicAssert.IsInstanceOf(args: new[] { ""first"", ""second"" },  message: ""{0}, {1}"", actual: actual, expected: expected);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            Assert.That(actual: actual, Is.InstanceOf(expectedType: expected), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyIsInstanceOfGenericFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var actual = 42;
 
             ↓ClassicAssert.IsInstanceOf<int>(actual);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -199,13 +221,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsInstanceOfGenericFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var actual = 42;
 
             ↓ClassicAssert.IsInstanceOf<int>(actual, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -219,14 +241,28 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsInstanceOfGenericFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
-            ↓ClassicAssert.IsInstanceOf<int>(actual, ""message-id: {{0}}"", Guid.NewGuid());");
+            ↓ClassicAssert.IsInstanceOf<int>(actual, ""message-id: {0}"", Guid.NewGuid());");
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
             Assert.That(actual, Is.InstanceOf<int>(), $""message-id: {Guid.NewGuid()}"");");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsInstanceOfGenericFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            ↓ClassicAssert.IsInstanceOf<int>(args: new[] { ""first"", ""second"" },  message: ""{0}, {1}"", actual: actual);");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            Assert.That(actual: actual, Is.InstanceOf<int>(), $""{""first""}, {""second"" }"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = typeof(int);
             var actual = 42;
 
-            Assert.That(actual: actual, Is.InstanceOf(expectedType: expected), $""{""first""}, {""second""}"");
+            Assert.That(actual, Is.InstanceOf(expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsInstanceOfFixWithMessageAndParams()
+        public void VerifyIsInstanceOfFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -91,7 +91,29 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsInstanceOfFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsInstanceOfFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            ↓ClassicAssert.IsInstanceOf(expected, actual, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            Assert.That(actual, Is.InstanceOf(expected), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsInstanceOfFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -239,7 +261,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsInstanceOfGenericFixWithMessageAndParams()
+        public void VerifyIsInstanceOfGenericFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = 42;
@@ -253,7 +275,21 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsInstanceOfGenericFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsInstanceOfGenericFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            ↓ClassicAssert.IsInstanceOf<int>(actual, ""{0}, {1}"", ""first"", ""second"");");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            Assert.That(actual, Is.InstanceOf<int>(), $""{""first""}, {""second""}"");");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsInstanceOfGenericFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = 42;

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = typeof(int);
             var actual = 42;
 
-            Assert.That(actual: actual, Is.InstanceOf(expectedType: expected), $""{""first""}, {""second"" }"");
+            Assert.That(actual: actual, Is.InstanceOf(expectedType: expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -262,7 +262,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
-            Assert.That(actual: actual, Is.InstanceOf<int>(), $""{""first""}, {""second"" }"");");
+            Assert.That(actual: actual, Is.InstanceOf<int>(), $""{""first""}, {""second""}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNaNFixWithMessageAndParams()
+        public void VerifyIsNaNFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -85,7 +85,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNaNFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsNaNFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = double.NaN;
+
+            ↓ClassicAssert.IsNaN(expr, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = double.NaN;
+
+            Assert.That(expr, Is.NaN, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsNaNFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var expr = double.NaN;
 
-            Assert.That(actual: expr, Is.NaN, $""{""first""}, {""second""}"");
+            Assert.That(expr, Is.NaN, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
@@ -27,13 +27,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNaNFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = double.NaN;
 
             ↓ClassicAssert.IsNaN(expr);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -47,13 +47,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNaNFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = double.NaN;
 
             ↓ClassicAssert.IsNaN(expr, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -67,19 +67,39 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNaNFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = double.NaN;
 
-            ↓ClassicAssert.IsNaN(expr, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.IsNaN(expr, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
             var expr = double.NaN;
 
             Assert.That(expr, Is.NaN, $""message-id: {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsNaNFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = double.NaN;
+
+            ↓ClassicAssert.IsNaN(args: new[] { ""first"", ""second"" }, aDouble: expr, message: ""{0}, {1}"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = double.NaN;
+
+            Assert.That(actual: expr, Is.NaN, $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var expr = double.NaN;
 
-            Assert.That(actual: expr, Is.NaN, $""{""first""}, {""second"" }"");
+            Assert.That(actual: expr, Is.NaN, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var collection = Array.Empty<object>();
 
-            Assert.That(actual: collection, Is.Not.Empty, $""{""first""}, {""second""}"");
+            Assert.That(collection, Is.Not.Empty, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var collection = Array.Empty<object>();
 
-            Assert.That(actual: collection, Is.Not.Empty, $""{""first""}, {""second"" }"");
+            Assert.That(actual: collection, Is.Not.Empty, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -171,7 +171,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             MyString s = ""Hello NUnit"";
-            Assert.That((string)s, Is.Not.Empty, $""{""first""}, {""second"" }"");
+            Assert.That((string)s, Is.Not.Empty, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFixTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNotEmptyFixWithMessageAndParams()
+        public void VerifyIsNotEmptyFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -85,7 +85,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNotEmptyFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsNotEmptyFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var collection = Array.Empty<object>();
+
+            ↓ClassicAssert.IsNotEmpty(collection, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var collection = Array.Empty<object>();
+
+            Assert.That(collection, Is.Not.Empty, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsNotEmptyFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = typeof(int);
             var actual = 42;
 
-            Assert.That(actual: actual, Is.Not.InstanceOf(expectedType: expected), $""{""first""}, {""second""}"");
+            Assert.That(actual, Is.Not.InstanceOf(expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -69,7 +69,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNotInstanceOfFixWithMessageAndParams()
+        public void VerifyIsNotInstanceOfFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -91,7 +91,29 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNotInstanceOfFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsNotInstanceOfFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            ↓ClassicAssert.IsNotInstanceOf(expected, actual, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            Assert.That(actual, Is.Not.InstanceOf(expected), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsNotInstanceOfFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -239,7 +261,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNotInstanceOfGenericFixWithMessageAndParams()
+        public void VerifyIsNotInstanceOfGenericFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = 42;
@@ -253,7 +275,21 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyIsNotInstanceOfGenericFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyIsNotInstanceOfGenericFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            ↓ClassicAssert.IsNotInstanceOf<int>(actual, ""{0}, {1}"", ""first"", ""second"");");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            Assert.That(actual, Is.Not.InstanceOf<int>(), $""{""first""}, {""second""}"");");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsNotInstanceOfGenericFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = 42;

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var expected = typeof(int);
             var actual = 42;
 
-            Assert.That(actual: actual, Is.Not.InstanceOf(expectedType: expected), $""{""first""}, {""second"" }"");
+            Assert.That(actual: actual, Is.Not.InstanceOf(expectedType: expected), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -262,7 +262,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
-            Assert.That(actual: actual, Is.Not.InstanceOf<int>(), $""{""first""}, {""second"" }"");");
+            Assert.That(actual: actual, Is.Not.InstanceOf<int>(), $""{""first""}, {""second""}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -298,7 +298,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
-            Assert.That(actual: actual, Is.Not.InstanceOf<int>(), $""{""first""}, {""second""}"");");
+            Assert.That(actual, Is.Not.InstanceOf<int>(), $""{""first""}, {""second""}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFixTests.cs
@@ -27,14 +27,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNotInstanceOfFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = typeof(int);
             var actual = 42;
 
             ↓ClassicAssert.IsNotInstanceOf(expected, actual);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -49,14 +49,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNotInstanceOfFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = typeof(int);
             var actual = 42;
 
             ↓ClassicAssert.IsNotInstanceOf(expected, actual, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -71,14 +71,14 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNotInstanceOfFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expected = typeof(int);
             var actual = 42;
 
-            ↓ClassicAssert.IsNotInstanceOf(expected, actual, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.IsNotInstanceOf(expected, actual, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -91,15 +91,37 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyIsNotInstanceOfFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            ↓ClassicAssert.IsNotInstanceOf(args: new[] { ""first"", ""second"" },  message: ""{0}, {1}"", actual: actual, expected: expected);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expected = typeof(int);
+            var actual = 42;
+
+            Assert.That(actual: actual, Is.Not.InstanceOf(expectedType: expected), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void VerifyIsNotInstanceOfGenericFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var actual = 42;
 
             ↓ClassicAssert.IsNotInstanceOf<int>(actual);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -199,13 +221,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNotInstanceOfGenericFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var actual = 42;
 
             ↓ClassicAssert.IsNotInstanceOf<int>(actual, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -219,14 +241,28 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyIsNotInstanceOfGenericFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
-            ↓ClassicAssert.IsNotInstanceOf<int>(actual, ""message-id: {{0}}"", Guid.NewGuid());");
+            ↓ClassicAssert.IsNotInstanceOf<int>(actual, ""message-id: {0}"", Guid.NewGuid());");
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = 42;
 
             Assert.That(actual, Is.Not.InstanceOf<int>(), $""message-id: {Guid.NewGuid()}"");");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyIsNotInstanceOfGenericFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            ↓ClassicAssert.IsNotInstanceOf<int>(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", actual: actual);");
+            var fixedCode = TestUtility.WrapInTestMethod(@"
+            var actual = 42;
+
+            Assert.That(actual: actual, Is.Not.InstanceOf<int>(), $""{""first""}, {""second"" }"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
     }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -84,5 +84,26 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
+
+        [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
+        [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
+        public void VerifyIsNotNullAndNotNullFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object? obj = null;
+            ↓ClassicAssert.{assertion}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", anObject: obj);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object? obj = null;
+            Assert.That(actual: obj, Is.Not.Null, $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
         [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
-        public void VerifyIsNotNullAndNotNullFixesWithMessageAndParams(string assertion, string diagnosticId)
+        public void VerifyIsNotNullAndNotNullFixesWithMessageAndOneArgumentForParams(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 
@@ -87,7 +87,28 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
         [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
-        public void VerifyIsNotNullAndNotNullFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        public void VerifyIsNotNullAndNotNullFixesWithMessageAndTwoArgumentsForParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object? obj = null;
+            ↓ClassicAssert.{assertion}(obj, ""{{0}}, {{1}}"", ""first"", ""second"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object? obj = null;
+            Assert.That(obj, Is.Not.Null, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsNotNull", AnalyzerIdentifiers.IsNotNullUsage)]
+        [TestCase("NotNull", AnalyzerIdentifiers.NotNullUsage)]
+        public void VerifyIsNotNullAndNotNullFixesWithMessageAndArrayParamsInNonstandardOrder(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             object? obj = null;
-            Assert.That(actual: obj, Is.Not.Null, $""{""first""}, {""second"" }"");
+            Assert.That(actual: obj, Is.Not.Null, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFixTests.cs
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             object? obj = null;
-            Assert.That(actual: obj, Is.Not.Null, $""{""first""}, {""second""}"");
+            Assert.That(obj, Is.Not.Null, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             object? obj = null;
-            Assert.That(actual: obj, Is.Null, $""{""first""}, {""second""}"");
+            Assert.That(obj, Is.Null, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             object? obj = null;
-            Assert.That(actual: obj, Is.Null, $""{""first""}, {""second"" }"");
+            Assert.That(actual: obj, Is.Null, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -84,5 +84,26 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
+
+        [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
+        [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
+        public void VerifyIsNullAndNullFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object? obj = null;
+            ↓ClassicAssert.{assertion}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", anObject: obj);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object? obj = null;
+            Assert.That(actual: obj, Is.Null, $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFixTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
         [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
-        public void VerifyIsNullAndNullFixesWithMessageAndParams(string assertion, string diagnosticId)
+        public void VerifyIsNullAndNullFixesWithMessageAndOneArgumentForParams(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 
@@ -87,7 +87,28 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
         [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
-        public void VerifyIsNullAndNullFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        public void VerifyIsNullAndNullFixesWithMessageAndTwoArgumentsForParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            object? obj = null;
+            ↓ClassicAssert.{assertion}(obj, ""{{0}}, {{1}}"", ""first"", ""second"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            object? obj = null;
+            Assert.That(obj, Is.Null, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsNull", AnalyzerIdentifiers.IsNullUsage)]
+        [TestCase("Null", AnalyzerIdentifiers.NullUsage)]
+        public void VerifyIsNullAndNullFixesWithMessageAndArrayParamsInNonstandardOrder(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
         [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
-        public void VerifyIsTrueAndTrueFixesWithMessageAndParams(string assertion, string diagnosticId)
+        public void VerifyIsTrueAndTrueFixesWithMessageAndOneArgumentForParams(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 
@@ -81,7 +81,26 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
         [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
-        public void VerifyIsTrueAndTrueFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        public void VerifyIsTrueAndTrueFixesWithMessageAndTwoArgumentsForParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.{assertion}(true, ""{{0}}, {{1}}"", ""first"", ""second"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(true, Is.True, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixesWithMessageAndArrayParamsInNonstandardOrder(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
@@ -81,6 +81,25 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
         [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.{assertion}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", condition: true);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: true, Is.True, $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
         public void VerifyIsTrueAndTrueWithImplicitTypeConversionFixes(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
@@ -114,6 +133,45 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             MyBool x = true;
             Assert.That((bool)x, Is.True);
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueWithImplicitTypeConversionFixesInNonstandardOrder(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private struct MyBool
+        {{
+            private readonly bool _value;
+
+            public MyBool(bool value) => _value = value;
+
+            public static implicit operator bool(MyBool value) => value._value;
+            public static implicit operator MyBool(bool value) => new MyBool(value);
+        }}
+        public void TestMethod()
+        {{
+            MyBool x = true;
+            ↓ClassicAssert.{assertion}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", condition: x);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyBool
+        {
+            private readonly bool _value;
+
+            public MyBool(bool value) => _value = value;
+
+            public static implicit operator bool(MyBool value) => value._value;
+            public static implicit operator MyBool(bool value) => new MyBool(value);
+        }
+        public void TestMethod()
+        {
+            MyBool x = true;
+            Assert.That((bool)x, Is.True, $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: true, Is.True, $""{""first""}, {""second"" }"");
+            Assert.That(actual: true, Is.True, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -171,7 +171,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void TestMethod()
         {
             MyBool x = true;
-            Assert.That((bool)x, Is.True, $""{""first""}, {""second"" }"");
+            Assert.That((bool)x, Is.True, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFixTests.cs
@@ -93,7 +93,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: true, Is.True, $""{""first""}, {""second""}"");
+            Assert.That(true, Is.True, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -116,7 +116,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(condition: true, $""{""first""}, {""second""}"");
+            Assert.That(true, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -96,7 +96,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(condition: true, $""{""first""}, {""second"" }"");
+            Assert.That(condition: true, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -64,7 +64,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
         [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
-        public void VerifyIsTrueAndTrueFixesWithMessageAndParams(string assertion, string diagnosticId)
+        public void VerifyIsTrueAndTrueFixesWithMessageAndOneArgumentForParams(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 
@@ -84,7 +84,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
 
         [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
         [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
-        public void VerifyIsTrueAndTrueFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        public void VerifyIsTrueAndTrueFixesWithMessageAndTwoArgumentsForParams(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.{assertion}(true, ""{{0}}, {{1}}"", ""first"", ""second"");
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(true, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
+        }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixesWithMessageAndArrayParamsInNonstandardOrder(string assertion, string diagnosticId)
         {
             var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
 

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFixTests.cs
@@ -81,5 +81,25 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
                 fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
         }
+
+        [TestCase("IsTrue", AnalyzerIdentifiers.IsTrueUsage)]
+        [TestCase("True", AnalyzerIdentifiers.TrueUsage)]
+        public void VerifyIsTrueAndTrueFixesWithMessageAndParamsInNonstandardOrder(string assertion, string diagnosticId)
+        {
+            var expectedDiagnostic = ExpectedDiagnostic.Create(diagnosticId);
+
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        public void TestMethod()
+        {{
+            ↓ClassicAssert.{assertion}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", condition: true);
+        }}");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(condition: true, $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode,
+                fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription + IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.Suffix);
+        }
     }
 }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.LessThan(expected: 3d), $""{""first""}, {""second""}"");
+            Assert.That(2d, Is.LessThan(3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.LessThan(expected: 3d), $""{""first""}, {""second"" }"");
+            Assert.That(actual: 2d, Is.LessThan(expected: 3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             MyFloat x = 1;
             MyFloat y = 2;
-            Assert.That((float)x, Is.LessThan((float)y), $""{""first""}, {""second"" }"");
+            Assert.That((float)x, Is.LessThan((float)y), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyLessFixWithMessageAndParams()
+        public void VerifyLessFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -73,7 +73,23 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyLessFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyLessFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.Less(2d, 3d, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(2d, Is.LessThan(3d), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyLessFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -27,11 +27,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyLessFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.Less(2d, 3d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -43,11 +43,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyLessFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.Less(2d, 3d, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -59,11 +59,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyLessFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-            ↓ClassicAssert.Less(2d, 3d, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+        {
+            ↓ClassicAssert.Less(2d, 3d, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -73,9 +73,25 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyLessFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.Less(args: new[] { ""first"", ""second"" }, arg2: 3d, message: ""{0}, {1}"", arg1: 2d);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: 2d, Is.LessThan(expected: 3d), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             ClassicAssert.Less(2d, 3d,
                 ""message"");");
 
@@ -158,6 +174,44 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float x = 1;
             MyFloat y = 2;
             Assert.That(x, Is.LessThan((float)y));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyLessWithImplicitConversionFixInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            MyFloat y = 2;
+            ↓ClassicAssert.Less(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", arg2: y, arg1: x);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            MyFloat y = 2;
+            Assert.That((float)x, Is.LessThan((float)y), $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.LessThanOrEqualTo(expected: 3d), $""{""first""}, {""second"" }"");
+            Assert.That(actual: 2d, Is.LessThanOrEqualTo(expected: 3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }
@@ -211,7 +211,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             MyFloat x = 1;
             MyFloat y = 2;
-            Assert.That((float)x, Is.LessThanOrEqualTo((float)y), $""{""first""}, {""second"" }"");
+            Assert.That((float)x, Is.LessThanOrEqualTo((float)y), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
-            Assert.That(actual: 2d, Is.LessThanOrEqualTo(expected: 3d), $""{""first""}, {""second""}"");
+            Assert.That(2d, Is.LessThanOrEqualTo(3d), $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -27,11 +27,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyLessOrEqualFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.LessOrEqual(2d, 3d);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -43,11 +43,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyLessOrEqualFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             ↓ClassicAssert.LessOrEqual(2d, 3d, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -59,11 +59,11 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyLessOrEqualFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-            ↓ClassicAssert.LessOrEqual(2d, 3d, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+        {
+            ↓ClassicAssert.LessOrEqual(2d, 3d, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -73,9 +73,25 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
+        public void VerifyLessOrEqualFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.LessOrEqual(args: new[] { ""first"", ""second"" }, arg2: 3d, message: ""{0}, {1}"", arg1: 2d);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(actual: 2d, Is.LessThanOrEqualTo(expected: 3d), $""{""first""}, {""second"" }"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
-            var code = TestUtility.WrapInTestMethod($@"
+            var code = TestUtility.WrapInTestMethod(@"
             ClassicAssert.LessOrEqual(2d, 3d,
                 ""message"");");
 
@@ -158,6 +174,44 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
             float x = 1;
             MyFloat y = 2;
             Assert.That(x, Is.LessThanOrEqualTo((float)y));
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyLessOrEqualWithImplicitConversionFixInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            MyFloat y = 2;
+            ↓ClassicAssert.LessOrEqual(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", arg2: y, arg1: x);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        private struct MyFloat
+        {
+            private readonly float _value;
+
+            public MyFloat(float value) => _value = value;
+
+            public static implicit operator float(MyFloat value) => value._value;
+            public static implicit operator MyFloat(float value) => new MyFloat(value);
+        }
+        public void TestMethod()
+        {
+            MyFloat x = 1;
+            MyFloat y = 2;
+            Assert.That((float)x, Is.LessThanOrEqualTo((float)y), $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyLessOrEqualFixWithMessageAndParams()
+        public void VerifyLessOrEqualFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -73,7 +73,23 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyLessOrEqualFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyLessOrEqualFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            ↓ClassicAssert.LessOrEqual(2d, 3d, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            Assert.That(2d, Is.LessThanOrEqualTo(3d), $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyLessOrEqualFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var expr = default(int);
 
-            Assert.That(actual: expr, Is.Not.Zero, $""{""first""}, {""second"" }"");
+            Assert.That(actual: expr, Is.Not.Zero, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
@@ -119,7 +119,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var expr = default(int);
 
-            Assert.That(actual: expr, Is.Not.Zero, $""{""first""}, {""second""}"");
+            Assert.That(expr, Is.Not.Zero, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyNotZeroFixWithMessageAndParams()
+        public void VerifyNotZeroFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -85,7 +85,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyNotZeroFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyNotZeroFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            ↓ClassicAssert.NotZero(expr, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            Assert.That(expr, Is.Not.Zero, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyNotZeroFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFixTests.cs
@@ -27,13 +27,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyNotZeroFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = default(int);
 
             ↓ClassicAssert.NotZero(expr);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -47,13 +47,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyNotZeroFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = default(int);
 
             ↓ClassicAssert.NotZero(expr, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -67,19 +67,39 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyNotZeroFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = default(int);
 
-            ↓ClassicAssert.NotZero(expr, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.NotZero(expr, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
             var expr = default(int);
 
             Assert.That(expr, Is.Not.Zero, $""message-id: {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyNotZeroFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            ↓ClassicAssert.NotZero(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", actual: expr);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            Assert.That(actual: expr, Is.Not.Zero, $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
@@ -27,13 +27,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyZeroFix()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = default(int);
 
             ↓ClassicAssert.Zero(expr);
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -47,13 +47,13 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyZeroFixWithMessage()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = default(int);
 
             ↓ClassicAssert.Zero(expr, ""message"");
-        }}");
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -67,19 +67,39 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         [Test]
         public void VerifyZeroFixWithMessageAndParams()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             var expr = default(int);
 
-            ↓ClassicAssert.Zero(expr, ""message-id: {{0}}"", Guid.NewGuid());
-        }}");
+            ↓ClassicAssert.Zero(expr, ""message-id: {0}"", Guid.NewGuid());
+        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
             var expr = default(int);
 
             Assert.That(expr, Is.Zero, $""message-id: {Guid.NewGuid()}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyZeroFixWithMessageAndParamsInNonstandardOrder()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            ↓ClassicAssert.Zero(args: new[] { ""first"", ""second"" }, message: ""{0}, {1}"", actual: expr);
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            Assert.That(actual: expr, Is.Zero, $""{""first""}, {""second"" }"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
@@ -119,7 +119,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var expr = default(int);
 
-            Assert.That(actual: expr, Is.Zero, $""{""first""}, {""second""}"");
+            Assert.That(expr, Is.Zero, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
@@ -99,7 +99,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         {
             var expr = default(int);
 
-            Assert.That(actual: expr, Is.Zero, $""{""first""}, {""second"" }"");
+            Assert.That(actual: expr, Is.Zero, $""{""first""}, {""second""}"");
         }");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
         }

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFixTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyZeroFixWithMessageAndParams()
+        public void VerifyZeroFixWithMessageAndOneArgumentForParams()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
@@ -85,7 +85,27 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         }
 
         [Test]
-        public void VerifyZeroFixWithMessageAndParamsInNonstandardOrder()
+        public void VerifyZeroFixWithMessageAndTwoArgumentsForParams()
+        {
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            ↓ClassicAssert.Zero(expr, ""{0}, {1}"", ""first"", ""second"");
+        }");
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            var expr = default(int);
+
+            Assert.That(expr, Is.Zero, $""{""first""}, {""second""}"");
+        }");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, fixTitle: ClassicModelAssertUsageCodeFix.TransformToConstraintModelDescription);
+        }
+
+        [Test]
+        public void VerifyZeroFixWithMessageAndArrayParamsInNonstandardOrder()
         {
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageAnalyzerTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(OneCollectionParameterAsserts))]
-        public void AnalyzeOneCollectionWhenOnlyMessageArgumentsAreUsed(string method)
+        public void AnalyzeOneCollectionWhenOnlyMessageArgumentIsUsed(string method)
         {
             var testCode = TestUtility.WrapInTestMethod(@$"
                 var collection = new[] {{ 1, 2, 3 }};
@@ -40,11 +40,21 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(OneCollectionParameterAsserts))]
-        public void AnalyzeOneCollectionWhenFormatAndParamsArgumentsAreUsed(string method)
+        public void AnalyzeOneCollectionWhenFormatAndOneParamsArgumentAreUsed(string method)
         {
             var testCode = TestUtility.WrapInTestMethod(@$"
                 var collection = new[] {{ 1, 2, 3 }};
                 ↓CollectionAssert.{method}(collection, ""Because of {{0}}"", ""message"");
+            ");
+            RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(OneCollectionParameterAsserts))]
+        public void AnalyzeOneCollectionWhenFormatAndTwoParamsArgumentsAreUsed(string method)
+        {
+            var testCode = TestUtility.WrapInTestMethod(@$"
+                var collection = new[] {{ 1, 2, 3 }};
+                ↓CollectionAssert.{method}(collection, ""{{0}}, {{1}}"", ""first"", ""second"");
             ");
             RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
         }
@@ -61,7 +71,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(TwoCollectionParameterAsserts))]
-        public void AnalyzeTwoCollectionWhenOnlyMessageArgumentsAreUsed(string method)
+        public void AnalyzeTwoCollectionWhenOnlyMessageArgumentIsUsed(string method)
         {
             var testCode = TestUtility.WrapInTestMethod(@$"
                 var collection1 = new[] {{ 1, 2, 3 }};
@@ -72,12 +82,23 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(TwoCollectionParameterAsserts))]
-        public void AnalyzeTwoCollectionWhenFormatAndParamsArgumentsAreUsed(string method)
+        public void AnalyzeTwoCollectionWhenFormatAndOneParamsArgumentAreUsed(string method)
         {
             var testCode = TestUtility.WrapInTestMethod(@$"
                 var collection1 = new[] {{ 1, 2, 3 }};
                 var collection2 = new[] {{ 2, 4, 6 }};
                 ↓CollectionAssert.{method}(collection1, collection2, ""Because of {{0}}"", ""message"");
+            ");
+            RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(TwoCollectionParameterAsserts))]
+        public void AnalyzeTwoCollectionWhenFormatAndTwoParamsArgumentsAreUsed(string method)
+        {
+            var testCode = TestUtility.WrapInTestMethod(@$"
+                var collection1 = new[] {{ 1, 2, 3 }};
+                var collection2 = new[] {{ 2, 4, 6 }};
+                ↓CollectionAssert.{method}(collection1, collection2, ""{{0}}, {{1}}"", ""first"", ""second"");
             ");
             RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
         }
@@ -115,7 +136,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(CollectionAndItemParameterAsserts))]
-        public void AnalyzeCollectionAndItemWhenOnlyMessageArgumentsAreUsed(string method)
+        public void AnalyzeCollectionAndItemWhenOnlyMessageArgumentIsUsed(string method)
         {
             var testCode = TestUtility.WrapInTestMethod(@$"
                 var collection = new[] {{ typeof(byte), typeof(char) }};
@@ -125,11 +146,21 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(CollectionAndItemParameterAsserts))]
-        public void AnalyzeCollectionAndItemWhenFormatAndParamsArgumentsAreUsed(string method)
+        public void AnalyzeCollectionAndItemWhenFormatAndOneParamsArgumentAreUsed(string method)
         {
             var testCode = TestUtility.WrapInTestMethod(@$"
                 var collection = new[] {{ typeof(byte), typeof(char) }};
                 ↓CollectionAssert.{method}(collection, typeof(byte), ""Because of {{0}}"", ""message"");
+            ");
+            RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
+        }
+
+        [TestCaseSource(nameof(CollectionAndItemParameterAsserts))]
+        public void AnalyzeCollectionAndItemWhenFormatAndTwoParamsArgumentsAreUsed(string method)
+        {
+            var testCode = TestUtility.WrapInTestMethod(@$"
+                var collection = new[] {{ typeof(byte), typeof(char) }};
+                ↓CollectionAssert.{method}(collection, typeof(byte), ""{{0}}, {{1}}"", ""first"", ""second"");
             ");
             RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
         }

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(OneCollectionParameterAsserts))]
-        public void AnalyzeOneCollectionWhenOnlyMessageArgumentsAreUsed(string method)
+        public void AnalyzeOneCollectionWhenOnlyMessageArgumentIsUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ 1, 2, 3 }};
@@ -50,7 +50,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(OneCollectionParameterAsserts))]
-        public void AnalyzeOneCollectionWhenFormatAndParamsArgumentsAreUsed(string method)
+        public void AnalyzeOneCollectionWhenFormatAndOneParamsArgumentAreUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ 1, 2, 3 }};
@@ -59,6 +59,20 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ 1, 2, 3 }};
             Assert.That(collection, {CollectionAssertUsageAnalyzer.OneCollectionParameterAsserts[method]}, $""Because of {{""message""}}"");
+            ");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(OneCollectionParameterAsserts))]
+        public void AnalyzeOneCollectionWhenFormatAndTwoParamsArgumentsAreUsed(string method)
+        {
+            var code = TestUtility.WrapInTestMethod(@$"
+            var collection = new[] {{ 1, 2, 3 }};
+            ↓CollectionAssert.{method}(collection, ""{{0}}, {{1}}"", ""first"", ""second"");
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@$"
+            var collection = new[] {{ 1, 2, 3 }};
+            Assert.That(collection, {CollectionAssertUsageAnalyzer.OneCollectionParameterAsserts[method]}, $""{{""first""}}, {{""second""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -110,7 +124,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(TwoCollectionParameterAsserts))]
-        public void AnalyzeTwoCollectionWhenOnlyMessageArgumentsAreUsed(string method)
+        public void AnalyzeTwoCollectionWhenOnlyMessageArgumentIsUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
             var collection1 = new[] {{ 1, 2, 3 }};
@@ -126,7 +140,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(TwoCollectionParameterAsserts))]
-        public void AnalyzeTwoCollectionWhenFormatAndParamsArgumentsAreUsed(string method)
+        public void AnalyzeTwoCollectionWhenFormatAndOneParamsArgumentAreUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
             var collection1 = new[] {{ 1, 2, 3 }};
@@ -137,6 +151,22 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             var collection1 = new[] {{ 1, 2, 3 }};
             var collection2 = new[] {{ 2, 4, 6 }};
             Assert.That({GetAdjustedTwoCollectionConstraint(method)}, $""Because of {{""message""}}"");
+            ");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(TwoCollectionParameterAsserts))]
+        public void AnalyzeTwoCollectionWhenFormatAndTwoParamsArgumentsAreUsed(string method)
+        {
+            var code = TestUtility.WrapInTestMethod(@$"
+            var collection1 = new[] {{ 1, 2, 3 }};
+            var collection2 = new[] {{ 2, 4, 6 }};
+            ↓CollectionAssert.{method}(collection1, collection2, ""{{0}}, {{1}}"", ""first"", ""second"");
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@$"
+            var collection1 = new[] {{ 1, 2, 3 }};
+            var collection2 = new[] {{ 2, 4, 6 }};
+            Assert.That({GetAdjustedTwoCollectionConstraint(method)}, $""{{""first""}}, {{""second""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -195,7 +225,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(CollectionAndItemParameterAsserts))]
-        public void AnalyzeCollectionAndItemWhenOnlyMessageArgumentsAreUsed(string method)
+        public void AnalyzeCollectionAndItemWhenOnlyMessageArgumentIsUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ typeof(byte), typeof(char) }};
@@ -211,7 +241,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
         }
 
         [TestCaseSource(nameof(CollectionAndItemParameterAsserts))]
-        public void AnalyzeCollectionAndItemWhenFormatAndParamsArgumentsAreUsed(string method)
+        public void AnalyzeCollectionAndItemWhenFormatAndOneParamsArgumentAreUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ typeof(byte), typeof(char) }};
@@ -222,6 +252,22 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             var collection = new[] {{ typeof(byte), typeof(char) }};
             var expected = typeof(byte);
             Assert.That(collection, {CollectionAssertUsageAnalyzer.CollectionAndItemParameterAsserts[method]}, $""Because of {{""message""}}"");
+            ");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+        }
+
+        [TestCaseSource(nameof(CollectionAndItemParameterAsserts))]
+        public void AnalyzeCollectionAndItemWhenFormatAndTwoParamsArgumentsAreUsed(string method)
+        {
+            var code = TestUtility.WrapInTestMethod(@$"
+            var collection = new[] {{ typeof(byte), typeof(char) }};
+            var expected = typeof(byte);
+            ↓CollectionAssert.{method}(collection, expected, ""{{0}}, {{1}}"", ""first"", ""second"");
+            ");
+            var fixedCode = TestUtility.WrapInTestMethod(@$"
+            var collection = new[] {{ typeof(byte), typeof(char) }};
+            var expected = typeof(byte);
+            Assert.That(collection, {CollectionAssertUsageAnalyzer.CollectionAndItemParameterAsserts[method]}, $""{{""first""}}, {{""second""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
@@ -196,19 +196,10 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
 
         private static string GetAdjustedTwoCollectionConstraint(string method)
         {
-            string actualArgument;
-            string constraintArgument;
-
-            if (CollectionAssertUsageCodeFix.CollectionAssertToOneUnswappedParameterConstraints.ContainsKey(method))
-            {
-                actualArgument = "collection1";
-                constraintArgument = "collection2";
-            }
-            else
-            {
-                actualArgument = "collection2";
-                constraintArgument = "collection1";
-            }
+            (string actualArgument, string constraintArgument) =
+                CollectionAssertUsageCodeFix.CollectionAssertToOneUnswappedParameterConstraints.ContainsKey(method)
+                    ? ("collection1", "collection2")
+                    : ("collection2", "collection1");
 
             string constraint = CollectionAssertUsageAnalyzer.TwoCollectionParameterAsserts[method]
                                                              .Replace("expected", constraintArgument);

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
@@ -72,7 +72,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ 1, 2, 3 }};
-            Assert.That(collection, {CollectionAssertUsageAnalyzer.OneCollectionParameterAsserts[method]}, $""{{""first""}}, {{""second"" }}"");
+            Assert.That(collection, {CollectionAssertUsageAnalyzer.OneCollectionParameterAsserts[method]}, $""{{""first""}}, {{""second""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -154,7 +154,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@$"
             var collection1 = new[] {{ 1, 2, 3 }};
             var collection2 = new[] {{ 2, 4, 6 }};
-            Assert.That({GetAdjustedTwoCollectionConstraint(method)}, $""{{""first""}}, {{""second"" }}"");
+            Assert.That({GetAdjustedTwoCollectionConstraint(method)}, $""{{""first""}}, {{""second""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -238,7 +238,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             var fixedCode = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ typeof(byte), typeof(char) }};
             var expected = typeof(byte);
-            Assert.That(collection, {CollectionAssertUsageAnalyzer.CollectionAndItemParameterAsserts[method]}, $""{{""first""}}, {{""second"" }}"");
+            Assert.That(collection, {CollectionAssertUsageAnalyzer.CollectionAndItemParameterAsserts[method]}, $""{{""first""}}, {{""second""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
@@ -233,7 +233,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             var code = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ typeof(byte), typeof(char) }};
             var expected = typeof(byte);
-            ↓CollectionAssert.{method}({secondParameterName}: expected, args: new[] {{ ""first"", ""second"" }}, collection: collection, message: ""{{0}}, {{1}}"");
+            ↓CollectionAssert.{method}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", {secondParameterName}: expected, collection: collection);
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
             var collection = new[] {{ typeof(byte), typeof(char) }};

--- a/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             ↓StringAssert.{method}(""expected"", ""actual"");
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(""actual"", {GetAdjustedConstraint(method, useNamedParameter: false)});
+            Assert.That(""actual"", {GetAdjustedConstraint(method)});
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             ↓StringAssert.{method}(""expected"", ""actual"", ""message"");
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(""actual"", {GetAdjustedConstraint(method, useNamedParameter: false)}, ""message"");
+            Assert.That(""actual"", {GetAdjustedConstraint(method)}, ""message"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             ↓StringAssert.{method}(""expected"", ""actual"", ""Because of {{0}}"", ""message"");
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(""actual"", {GetAdjustedConstraint(method, useNamedParameter: false)}, $""Because of {{""message""}}"");
+            Assert.That(""actual"", {GetAdjustedConstraint(method)}, $""Because of {{""message""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -60,19 +60,12 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             var code = TestUtility.WrapInTestMethod(@$"
 		    ↓StringAssert.{method}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", actual: ""actual"", {firstParameterName}: ""expected"");");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(actual: ""actual"", {GetAdjustedConstraint(method, useNamedParameter: true)}, $""{{""first""}}, {{""second""}}"");");
+            Assert.That(""actual"", {GetAdjustedConstraint(method)}, $""{{""first""}}, {{""second""}}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
 
-        private static string GetAdjustedConstraint(string method, bool useNamedParameter)
-        {
-            const string Expected = "expected";
-
-            var expectedParameterName = StringAssertUsageCodeFix.StringAssertToExpectedParameterName[method];
-            return StringAssertUsageAnalyzer.StringAssertToConstraint[method]
-                .Replace(
-                    Expected,
-                    useNamedParameter ? $"{expectedParameterName}: \"{Expected}\"" : $"\"{Expected}\"");
-        }
+        private static string GetAdjustedConstraint(string method) =>
+            StringAssertUsageAnalyzer.StringAssertToConstraint[method]
+                .Replace("expected", "\"expected\"");
     }
 }

--- a/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             ↓StringAssert.{method}(""expected"", ""actual"");
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(""actual"", {GetAdjustedConstraint(method)});
+            Assert.That(""actual"", {GetAdjustedConstraint(method, useNamedParameter: false)});
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             ↓StringAssert.{method}(""expected"", ""actual"", ""message"");
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(""actual"", {GetAdjustedConstraint(method)}, ""message"");
+            Assert.That(""actual"", {GetAdjustedConstraint(method, useNamedParameter: false)}, ""message"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
@@ -48,15 +48,29 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             ↓StringAssert.{method}(""expected"", ""actual"", ""Because of {{0}}"", ""message"");
             ");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(""actual"", {GetAdjustedConstraint(method)}, $""Because of {{""message""}}"");
+            Assert.That(""actual"", {GetAdjustedConstraint(method, useNamedParameter: false)}, $""Because of {{""message""}}"");
             ");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
 
-        private static string GetAdjustedConstraint(string method)
+        [TestCaseSource(nameof(StringAsserts))]
+        public void AnalyzeWhenFormatAndArgumentsAreUsedOutOfOrder(string method)
         {
+            var firstParameterName = StringAssertUsageCodeFix.StringAssertToExpectedParameterName[method];
+            var code = TestUtility.WrapInTestMethod(@$"
+		    ↓StringAssert.{method}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", actual: ""actual"", {firstParameterName}: ""expected"");");
+            var fixedCode = TestUtility.WrapInTestMethod(@$"
+            Assert.That(actual: ""actual"", {GetAdjustedConstraint(method, useNamedParameter: true)}, $""{{""first""}}, {{""second"" }}"");");
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+        }
+
+        private static string GetAdjustedConstraint(string method, bool useNamedParameter)
+        {
+            var expectedParameterName = StringAssertUsageCodeFix.StringAssertToExpectedParameterName[method];
             return StringAssertUsageAnalyzer.StringAssertToConstraint[method]
-                                            .Replace("expected", "\"expected\"");
+                .Replace(
+                    "expected",
+                    useNamedParameter ? $"{expectedParameterName}: \"expected\"" : "\"expected\"");
         }
     }
 }

--- a/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
@@ -60,7 +60,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
             var code = TestUtility.WrapInTestMethod(@$"
 		    ↓StringAssert.{method}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", actual: ""actual"", {firstParameterName}: ""expected"");");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
-            Assert.That(actual: ""actual"", {GetAdjustedConstraint(method, useNamedParameter: true)}, $""{{""first""}}, {{""second"" }}"");");
+            Assert.That(actual: ""actual"", {GetAdjustedConstraint(method, useNamedParameter: true)}, $""{{""first""}}, {{""second""}}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
 

--- a/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
         {
             var firstParameterName = StringAssertUsageCodeFix.StringAssertToExpectedParameterName[method];
             var code = TestUtility.WrapInTestMethod(@$"
-		    ↓StringAssert.{method}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", actual: ""actual"", {firstParameterName}: ""expected"");");
+            ↓StringAssert.{method}(args: new[] {{ ""first"", ""second"" }}, message: ""{{0}}, {{1}}"", actual: ""actual"", {firstParameterName}: ""expected"");");
             var fixedCode = TestUtility.WrapInTestMethod(@$"
             Assert.That(""actual"", {GetAdjustedConstraint(method)}, $""{{""first""}}, {{""second""}}"");");
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);

--- a/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/StringAssertUsage/StringAssertUsageCodeFixTests.cs
@@ -66,11 +66,13 @@ namespace NUnit.Analyzers.Tests.StringAssertUsage
 
         private static string GetAdjustedConstraint(string method, bool useNamedParameter)
         {
+            const string Expected = "expected";
+
             var expectedParameterName = StringAssertUsageCodeFix.StringAssertToExpectedParameterName[method];
             return StringAssertUsageAnalyzer.StringAssertToConstraint[method]
                 .Replace(
-                    "expected",
-                    useNamedParameter ? $"{expectedParameterName}: \"expected\"" : "\"expected\"");
+                    Expected,
+                    useNamedParameter ? $"{expectedParameterName}: \"{Expected}\"" : $"\"{Expected}\"");
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var equalToInvocationNode = SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
@@ -45,7 +45,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.SingletonSeparatedList(toleranceArgumentNoColon)));
             }
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, SyntaxFactory.Argument(equalToInvocationNode));
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -17,7 +16,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.AreEqualUsage);
 
-        protected override List<ArgumentSyntax> UpdateArguments(Diagnostic diagnostic, IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax ConstraintArgument) UpdateArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
@@ -50,18 +51,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.SingletonSeparatedList(toleranceArgumentNoColon)));
             }
 
-            var arguments = new List<ArgumentSyntax>() { actualArgument, SyntaxFactory.Argument(equalToInvocationNode) };
-            var handledParameterNames = new[]
-            {
-                NUnitFrameworkConstants.NameOfExpectedParameter,
-                NUnitFrameworkConstants.NameOfActualParameter,
-                NameOfDeltaParameter,
-            };
-            return arguments
-                .Concat(argumentNamesToArguments
-                    .Where(kvp => !handledParameterNames.Contains(kvp.Key))
-                    .Select(kvp => kvp.Value))
-                .ToList();
+            return (actualArgument, SyntaxFactory.Argument(equalToInvocationNode));
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -16,16 +17,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.AreEqualUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override List<ArgumentSyntax> UpdateArguments(Diagnostic diagnostic, IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            // If named parameters are used, we can't assume that the first argument is the expected one and the second is the actual.
-            // Therefore, start by finding the expected argument and the actual argument.
-            var expectedPosition = arguments.FindIndex(arg => arg.NameColon?.Name.Identifier.Text == NUnitFrameworkConstants.NameOfExpectedParameter);
-            var actualPosition = arguments.FindIndex(arg => arg.NameColon?.Name.Identifier.Text == NUnitFrameworkConstants.NameOfActualParameter);
-
-            // If named arguments are not used, the first argument is expected, and the second is actual.
-            var expectedArgument = expectedPosition != -1 ? arguments[expectedPosition] : arguments[0];
-            var actualArgument = actualPosition != -1 ? arguments[actualPosition] : arguments[1];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
 
             // Note that if there's a 3rd argument and it's a double,
             // it has to be added to the "Is.EqualTo(1st argument)" with ".Within(3rd argument)"
@@ -37,13 +32,14 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(expectedArgument)));
 
+            const string NameOfDeltaParameter = "delta";
             var hasToleranceValue = diagnostic.Properties[AnalyzerPropertyKeys.HasToleranceValue] == true.ToString();
-
             if (hasToleranceValue)
             {
                 // The tolerance argument should be renamed from 'delta' to 'amount' but with the model constraint the
                 // argument is moved to Within which makes it way more explicit so we can just drop the name colon.
-                var toleranceArgumentNoColon = arguments[2].WithNameColon(null);
+                var toleranceArgument = argumentNamesToArguments[NameOfDeltaParameter];
+                var toleranceArgumentNoColon = toleranceArgument.WithNameColon(null);
 
                 equalToInvocationNode = SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -54,26 +50,18 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.SingletonSeparatedList(toleranceArgumentNoColon)));
             }
 
-            arguments.Insert(2, SyntaxFactory.Argument(equalToInvocationNode));
-
-            // Then we have to remove the 1st argument because that's now in the "Is.EqualTo()"
-            arguments.RemoveAt(0);
-
-            // If the now-first argument had a named parameter, we need to make sure it's actual.
-            if (arguments[0].NameColon?.Name.Identifier.Text is { } parameterName
-                && parameterName != NUnitFrameworkConstants.NameOfActualParameter)
+            var arguments = new List<ArgumentSyntax>() { actualArgument, SyntaxFactory.Argument(equalToInvocationNode) };
+            var handledParameterNames = new[]
             {
-                arguments[0] = SyntaxFactory.Argument(
-                    SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter),
-                    actualArgument.RefKindKeyword,
-                    actualArgument.Expression);
-            }
-
-            // ... and if the 3rd argument was a double, that has to go too.
-            if (hasToleranceValue)
-            {
-                arguments.RemoveAt(2);
-            }
+                NUnitFrameworkConstants.NameOfExpectedParameter,
+                NUnitFrameworkConstants.NameOfActualParameter,
+                NameOfDeltaParameter,
+            };
+            return arguments
+                .Concat(argumentNamesToArguments
+                    .Where(kvp => !handledParameterNames.Contains(kvp.Key))
+                    .Select(kvp => kvp.Value))
+                .ToList();
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreEqualClassicModelAssertUsageCodeFix.cs
@@ -34,12 +34,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                     SyntaxFactory.SingletonSeparatedList(expectedArgument)));
 
             const string NameOfDeltaParameter = "delta";
-            var hasToleranceValue = diagnostic.Properties[AnalyzerPropertyKeys.HasToleranceValue] == true.ToString();
-            if (hasToleranceValue)
+            if (argumentNamesToArguments.TryGetValue(NameOfDeltaParameter, out var toleranceArgument))
             {
                 // The tolerance argument should be renamed from 'delta' to 'amount' but with the model constraint the
                 // argument is moved to Within which makes it way more explicit so we can just drop the name colon.
-                var toleranceArgument = argumentNamesToArguments[NameOfDeltaParameter];
                 var toleranceArgumentNoColon = toleranceArgument.WithNameColon(null);
 
                 equalToInvocationNode = SyntaxFactory.InvocationExpression(

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFix.cs
@@ -16,9 +16,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.AreNotEqualUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -28,10 +31,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEqualTo)))
                     .WithArgumentList(SyntaxFactory.ArgumentList(
-                        SyntaxFactory.SingletonSeparatedList(arguments[0])))));
+                        SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            // Then we have to remove the 1st argument because that's now in the "Is.EqualTo()"
-            arguments.RemoveAt(0);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreNotEqualClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -33,7 +33,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                     .WithArgumentList(SyntaxFactory.ArgumentList(
                         SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFix.cs
@@ -16,9 +16,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.AreNotSameUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -28,10 +31,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsSameAs)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[0])))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            // Then we have to remove the 1st argument because that's now in the "Is.Not.SameAs()"
-            arguments.RemoveAt(0);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreNotSameClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -33,7 +33,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFix.cs
@@ -16,19 +16,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.AreSameUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsSameAs)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[0])))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            // Then we have to remove the 1st argument because that's now in the "Is.SameAs()"
-            arguments.RemoveAt(0);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/AreSameClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -252,10 +252,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             return new Dictionary<string, string?>
             {
                 [AnalyzerPropertyKeys.ModelName] = invocationSymbol.Name,
-                [AnalyzerPropertyKeys.HasToleranceValue] =
-                    (invocationSymbol.Name == NameOfAssertAreEqual &&
-                        invocationSymbol.Parameters.Length >= 3 &&
-                        invocationSymbol.Parameters[2].Type.SpecialType == SpecialType.System_Double).ToString(),
             }.ToImmutableDictionary();
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFix.cs
@@ -16,19 +16,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.ContainsUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfDoes),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfDoesContain)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[0])))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            // Then we have to remove the 1st argument because that's now in the "Does.Contain()"
-            arguments.RemoveAt(0);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ContainsClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -30,7 +30,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,12 +28,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        arg2Argument.WithNameColon(null)))));
+                    SyntaxFactory.SingletonSeparatedList(arg2Argument))));
 
-            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgument = arg1Argument.WithNameColon(null);
-            return (actualArgument, constraintArgument);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter].WithNameColon(null);
+            return (arg1Argument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
@@ -20,10 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
-            var expectedArgumentNameColon = arg2.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -32,13 +29,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        arg2.WithNameColon(expectedArgumentNameColon)))));
+                        arg2Argument.WithNameColon(null)))));
 
-            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgumentNameColon = arg1.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-            var actualArgument = arg1.WithNameColon(actualArgumentNameColon);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            var actualArgument = arg1Argument.WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
@@ -21,6 +21,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var expectedArgumentNameColon = arg2.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,10 +31,15 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arg2))));
+                    SyntaxFactory.SingletonSeparatedList(
+                        arg2.WithNameColon(expectedArgumentNameColon)))));
 
             var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            return (arg1, constraintArgument);
+            var actualArgumentNameColon = arg1.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+            var actualArgument = arg1.WithNameColon(actualArgumentNameColon);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFix.cs
@@ -16,19 +16,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.GreaterUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[1])))));
+                    SyntaxFactory.SingletonSeparatedList(arg2))));
 
-            // Then we have to remove the 2nd argument because that's now in the "Is.GreaterThan()"
-            arguments.RemoveAt(1);
+            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            return (arg1, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
@@ -21,6 +21,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var expectedArgumentNameColon = arg2.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,10 +31,15 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arg2))));
+                    SyntaxFactory.SingletonSeparatedList(
+                        arg2.WithNameColon(expectedArgumentNameColon)))));
 
             var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            return (arg1, constraintArgument);
+            var actualArgumentNameColon = arg1.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+            var actualArgument = arg1.WithNameColon(actualArgumentNameColon);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
@@ -20,10 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
-            var expectedArgumentNameColon = arg2.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -32,13 +29,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        arg2.WithNameColon(expectedArgumentNameColon)))));
+                        arg2Argument.WithNameColon(null)))));
 
-            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgumentNameColon = arg1.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-            var actualArgument = arg1.WithNameColon(actualArgumentNameColon);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            var actualArgument = arg1Argument.WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,12 +28,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        arg2Argument.WithNameColon(null)))));
+                    SyntaxFactory.SingletonSeparatedList(arg2Argument))));
 
-            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgument = arg1Argument.WithNameColon(null);
-            return (actualArgument, constraintArgument);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter].WithNameColon(null);
+            return (arg1Argument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFix.cs
@@ -16,19 +16,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.GreaterOrEqualUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsGreaterThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[1])))));
+                    SyntaxFactory.SingletonSeparatedList(arg2))));
 
-            // Then we have to remove the 2nd argument because that's now in the "Is.GreaterThanOrEqualTo()"
-            arguments.RemoveAt(1);
+            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            return (arg1, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
@@ -25,12 +25,16 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
                 ? collectionArgument
                 : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
@@ -17,13 +17,20 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             AnalyzerIdentifiers.IsEmptyUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            // different overloads have different "actual" arguments
+            var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
+                ? collectionArgument
+                : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
@@ -25,13 +25,14 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
                 ? collectionArgument
                 : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
+            actualArgument = actualArgument.WithNameColon(null);
 
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsEmptyClassicModelAssertUsageCodeFix.cs
@@ -25,16 +25,13 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
                 ? collectionArgument
                 : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
 
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
@@ -23,16 +23,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsFalse)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
@@ -22,13 +22,13 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsFalse)));
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
@@ -23,12 +23,16 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsFalse)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsFalseAndFalseClassicModelAssertUsageCodeFix.cs
@@ -18,13 +18,17 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             AnalyzerIdentifiers.IsFalseUsage,
             AnalyzerIdentifiers.FalseUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsFalse))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsFalse)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -37,10 +37,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
-            var expectedArgumentNameColon = expectedArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedTypeParameter);
-
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -49,13 +45,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        expectedArgument.WithNameColon(expectedArgumentNameColon)))));
+                        expectedArgument.WithNameColon(null)))));
 
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -16,30 +16,38 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.IsInstanceOfUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments, TypeArgumentListSyntax typeArguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments,
+            TypeArgumentListSyntax typeArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.GenericName(NUnitFrameworkConstants.NameOfIsInstanceOf)
-                            .WithTypeArgumentList(typeArguments)))));
+                            .WithTypeArgumentList(typeArguments))));
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[0])))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            // Then we have to remove the 1st argument because that's now in the "Is.InstanceOf()"
-            arguments.RemoveAt(0);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -28,7 +28,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.GenericName(NUnitFrameworkConstants.NameOfIsInstanceOf)
                             .WithTypeArgumentList(typeArguments))));
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
 
@@ -36,7 +36,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -44,11 +44,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        expectedArgument.WithNameColon(null)))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -37,6 +37,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgumentNameColon = expectedArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedTypeParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -44,10 +48,14 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
+                    SyntaxFactory.SingletonSeparatedList(
+                        expectedArgument.WithNameColon(expectedArgumentNameColon)))));
 
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
-            return (actualArgument, constraintArgument);
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
@@ -17,13 +17,17 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             AnalyzerIdentifiers.IsNaNUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfADoubleParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNaN))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNaN)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
@@ -22,12 +22,16 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfADoubleParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNaN)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
@@ -22,16 +22,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfADoubleParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNaN)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNaNClassicModelAssertUsageCodeFix.cs
@@ -21,13 +21,13 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfADoubleParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfADoubleParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNaN)));
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
@@ -24,6 +24,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
                 ? collectionArgument
                 : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
@@ -32,7 +36,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
@@ -24,6 +24,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
                 ? collectionArgument
                 : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
+            actualArgument = actualArgument.WithNameColon(null);
 
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
@@ -33,7 +34,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
@@ -17,16 +17,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             AnalyzerIdentifiers.IsNotEmptyUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
+                ? collectionArgument
+                : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotEmptyClassicModelAssertUsageCodeFix.cs
@@ -24,9 +24,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             var actualArgument = argumentNamesToArguments.TryGetValue(NUnitFrameworkConstants.NameOfCollectionParameter, out var collectionArgument)
                 ? collectionArgument
                 : argumentNamesToArguments[NUnitFrameworkConstants.NameOfAStringParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
 
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
@@ -36,7 +33,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEmpty)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -16,9 +16,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.IsNotInstanceOfUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments, TypeArgumentListSyntax typeArguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments,
+            TypeArgumentListSyntax typeArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -27,12 +30,17 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.GenericName(NUnitFrameworkConstants.NameOfIsInstanceOf)
-                            .WithTypeArgumentList(typeArguments)))));
+                            .WithTypeArgumentList(typeArguments))));
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -42,10 +50,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[0])))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            // Then we have to remove the 1st argument because that's now in the "Is.Not.InstanceOf()"
-            arguments.RemoveAt(0);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -40,6 +40,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgumentNameColon = expectedArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedTypeParameter);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -50,10 +53,14 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
+                    SyntaxFactory.SingletonSeparatedList(
+                        expectedArgument.WithNameColon(expectedArgumentNameColon)))));
 
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
-            return (actualArgument, constraintArgument);
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -31,7 +31,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.GenericName(NUnitFrameworkConstants.NameOfIsInstanceOf)
                             .WithTypeArgumentList(typeArguments))));
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
 
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
+            var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -50,11 +50,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                             SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        expectedArgument.WithNameColon(null)))));
+                    SyntaxFactory.SingletonSeparatedList(expectedArgument))));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotInstanceOfClassicModelAssertUsageCodeFix.cs
@@ -40,9 +40,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var expectedArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfExpectedParameter];
-            var expectedArgumentNameColon = expectedArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedTypeParameter);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -54,13 +51,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsInstanceOf)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        expectedArgument.WithNameColon(expectedArgumentNameColon)))));
+                        expectedArgument.WithNameColon(null)))));
 
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
@@ -23,6 +23,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
@@ -31,7 +35,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
@@ -22,11 +22,6 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
@@ -35,7 +30,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
@@ -31,8 +31,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter].WithNameColon(null);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNotNullAndNotNullClassicModelAssertUsageCodeFix.cs
@@ -18,16 +18,20 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             AnalyzerIdentifiers.IsNotNullUsage,
             AnalyzerIdentifiers.NotNullUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
@@ -22,17 +22,14 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
@@ -23,12 +23,16 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
@@ -18,13 +18,17 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             AnalyzerIdentifiers.IsNullUsage,
             AnalyzerIdentifiers.NullUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsNullAndNullClassicModelAssertUsageCodeFix.cs
@@ -28,8 +28,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNull)));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter];
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfAnObjectParameter].WithNameColon(null);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
@@ -22,17 +22,14 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
-            var actualArgumentNameColon = actualArgument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsTrue)));
-            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
+
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
@@ -28,8 +28,8 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsTrue)));
 
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter].WithNameColon(null);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
@@ -18,13 +18,17 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             AnalyzerIdentifiers.IsTrueUsage,
             AnalyzerIdentifiers.TrueUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsTrue))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsTrue)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCodeFix.cs
@@ -23,12 +23,16 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            var actualArgumentNameColon = actualArgument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsTrue)));
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(actualArgumentNameColon), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
@@ -27,7 +27,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter].WithNameColon(null);
             return (actualArgument, null); // The condensed form doesn't have the constraint argument.
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/IsTrueAndTrueClassicModelAssertUsageCondensedCodeFix.cs
@@ -23,9 +23,12 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
 
         protected override string Title => base.Title + Suffix;
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            // Nothing to do
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfConditionParameter];
+            return (actualArgument, null); // The condensed form doesn't have the constraint argument.
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
@@ -21,6 +21,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var expectedArgumentNameColon = arg2.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,10 +31,15 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arg2))));
+                    SyntaxFactory.SingletonSeparatedList(
+                        arg2.WithNameColon(expectedArgumentNameColon)))));
 
-            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            return (arg1, constraintArgument);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            var actualArgumentNameColon = arg1Argument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+            var actualArgument = arg1Argument.WithNameColon(actualArgumentNameColon);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
@@ -16,19 +16,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.LessUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[1])))));
+                    SyntaxFactory.SingletonSeparatedList(arg2))));
 
-            // Then we have to remove the 2nd argument because that's now in the "Is.LessThan()"
-            arguments.RemoveAt(1);
+            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            return (arg1, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
@@ -20,10 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
-            var expectedArgumentNameColon = arg2.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -32,14 +29,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        arg2.WithNameColon(expectedArgumentNameColon)))));
+                        arg2Argument.WithNameColon(null)))));
 
             var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgumentNameColon = arg1Argument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-            var actualArgument = arg1Argument.WithNameColon(actualArgumentNameColon);
-            return (actualArgument, constraintArgument);
+            return (arg1Argument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,11 +28,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThan)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        arg2Argument.WithNameColon(null)))));
+                    SyntaxFactory.SingletonSeparatedList(arg2Argument))));
 
-            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            return (arg1Argument.WithNameColon(null), constraintArgument);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter].WithNameColon(null);
+            return (arg1Argument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
@@ -21,6 +21,9 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
             var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var expectedArgumentNameColon = arg2.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -28,10 +31,15 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arg2))));
+                    SyntaxFactory.SingletonSeparatedList(
+                        arg2.WithNameColon(expectedArgumentNameColon)))));
 
-            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            return (arg1, constraintArgument);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            var actualArgumentNameColon = arg1Argument.NameColon is null
+                ? null
+                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
+            var actualArgument = arg1Argument.WithNameColon(actualArgumentNameColon);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
@@ -20,7 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -29,11 +29,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        arg2Argument.WithNameColon(null)))));
+                        arg2Argument))));
 
-            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgument = arg1Argument.WithNameColon(null);
-            return (actualArgument, constraintArgument);
+            var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter].WithNameColon(null);
+            return (arg1Argument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
@@ -28,8 +28,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        arg2Argument))));
+                    SyntaxFactory.SingletonSeparatedList(arg2Argument))));
 
             var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter].WithNameColon(null);
             return (arg1Argument, constraintArgument);

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
@@ -16,19 +16,22 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(AnalyzerIdentifiers.LessOrEqualUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(2, SyntaxFactory.Argument(
+            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(arguments[1])))));
+                    SyntaxFactory.SingletonSeparatedList(arg2))));
 
-            // Then we have to remove the 2nd argument because that's now in the "Is.LessThanOrEqualTo()"
-            arguments.RemoveAt(1);
+            var arg1 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
+            return (arg1, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFix.cs
@@ -20,10 +20,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var arg2 = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
-            var expectedArgumentNameColon = arg2.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfExpectedParameter);
+            var arg2Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg2Parameter];
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -32,13 +29,10 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsLessThanOrEqualTo)))
                 .WithArgumentList(SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
-                        arg2.WithNameColon(expectedArgumentNameColon)))));
+                        arg2Argument.WithNameColon(null)))));
 
             var arg1Argument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfArg1Parameter];
-            var actualArgumentNameColon = arg1Argument.NameColon is null
-                ? null
-                : SyntaxFactory.NameColon(NUnitFrameworkConstants.NameOfActualParameter);
-            var actualArgument = arg1Argument.WithNameColon(actualArgumentNameColon);
+            var actualArgument = arg1Argument.WithNameColon(null);
             return (actualArgument, constraintArgument);
         }
     }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFix.cs
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,

--- a/src/nunit.analyzers/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/NotZeroClassicModelAssertUsageCodeFix.cs
@@ -17,16 +17,20 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             AnalyzerIdentifiers.NotZeroUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
                         SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsNot)),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsZero))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsZero)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFix.cs
@@ -21,7 +21,7 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
             Diagnostic diagnostic,
             IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter].WithNameColon(null);
             var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ZeroClassicModelAssertUsageCodeFix.cs
@@ -17,13 +17,17 @@ namespace NUnit.Analyzers.ClassicModelAssertUsage
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             AnalyzerIdentifiers.ZeroUsage);
 
-        protected override void UpdateArguments(Diagnostic diagnostic, List<ArgumentSyntax> arguments)
+        protected override (ArgumentSyntax ActualArgument, ArgumentSyntax? ConstraintArgument) ConstructActualAndConstraintArguments(
+            Diagnostic diagnostic,
+            IReadOnlyDictionary<string, ArgumentSyntax> argumentNamesToArguments)
         {
-            arguments.Insert(1, SyntaxFactory.Argument(
+            var actualArgument = argumentNamesToArguments[NUnitFrameworkConstants.NameOfActualParameter];
+            var constraintArgument = SyntaxFactory.Argument(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIs),
-                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsZero))));
+                    SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsZero)));
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageAnalyzer.cs
@@ -67,26 +67,16 @@ namespace NUnit.Analyzers.CollectionAssertUsage
                 TwoCollectionParameterAsserts.TryGetValue(methodSymbol.Name, out constraint) ||
                 CollectionAndItemParameterAsserts.TryGetValue(methodSymbol.Name, out constraint))
             {
-                var parameters = methodSymbol.Parameters;
-                string comparerParameterIndex = parameters.Length > 1 && IsIComparer(parameters[1]) ? "1" :
-                                               (parameters.Length > 2 && IsIComparer(parameters[2]) ? "2" : "0");
-
                 context.ReportDiagnostic(Diagnostic.Create(
                     collectionAssertDescriptor,
                     assertOperation.Syntax.GetLocation(),
                     new Dictionary<string, string?>
                     {
                         [AnalyzerPropertyKeys.ModelName] = methodSymbol.Name,
-                        [AnalyzerPropertyKeys.ComparerParameterIndex] = comparerParameterIndex,
                     }.ToImmutableDictionary(),
                     constraint,
                     methodSymbol.Name));
             }
-        }
-
-        private static bool IsIComparer(IParameterSymbol parameterSymbol)
-        {
-            return parameterSymbol.Type.Name == "IComparer";
         }
     }
 }

--- a/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageCodeFix.cs
@@ -49,7 +49,7 @@ namespace NUnit.Analyzers.CollectionAssertUsage
                 { NameOfCollectionAssertIsSupersetOf, new Constraints(NameOfIs, default(string), NameOfIsSupersetOf) },
             }.ToImmutableDictionary();
 
-        private static readonly ImmutableDictionary<string, string> CollectionAssertToFirstParameterName =
+        internal static readonly ImmutableDictionary<string, string> CollectionAssertToFirstParameterName =
             new Dictionary<string, string>()
             {
                 { NameOfCollectionAssertAllItemsAreNotNull, NameOfCollectionParameter },
@@ -70,7 +70,7 @@ namespace NUnit.Analyzers.CollectionAssertUsage
                 { NameOfCollectionAssertIsSupersetOf, NameOfSupersetParameter },
             }.ToImmutableDictionary();
 
-        private static readonly ImmutableDictionary<string, string> CollectionAssertToSecondParameterName =
+        internal static readonly ImmutableDictionary<string, string> CollectionAssertToSecondParameterName =
             new Dictionary<string, string>()
             {
                 { NameOfCollectionAssertAreEqual, NameOfActualParameter },
@@ -128,24 +128,27 @@ namespace NUnit.Analyzers.CollectionAssertUsage
 
             if (CollectionAssertToParameterlessConstraints.TryGetValue(methodName, out Constraints? constraints))
             {
+                var actualArgument = firstArgument.WithNameColon(null);
                 var constraintArgument = Argument(constraints.CreateConstraint());
-                return (firstArgument, constraintArgument);
+                return (actualArgument, constraintArgument);
             }
             else if (CollectionAssertToOneSwappedParameterConstraints.TryGetValue(methodName, out constraints))
             {
                 var secondParameterName = CollectionAssertToSecondParameterName[methodName];
                 var secondArgument = argumentNamesToArguments[secondParameterName];
+                var actualArgument = secondArgument.WithNameColon(null);
 
-                var constraintArgument = Argument(constraints.CreateConstraint(firstArgument));
-                return (secondArgument, constraintArgument);
+                var constraintArgument = Argument(constraints.CreateConstraint(firstArgument.WithNameColon(null)));
+                return (actualArgument, constraintArgument);
             }
             else if (CollectionAssertToOneUnswappedParameterConstraints.TryGetValue(methodName, out constraints))
             {
                 var secondParameterName = CollectionAssertToSecondParameterName[methodName];
                 var secondArgument = argumentNamesToArguments[secondParameterName];
-                var constraintArgument = Argument(constraints.CreateConstraint(secondArgument));
+                var constraintArgument = Argument(constraints.CreateConstraint(secondArgument.WithNameColon(null)));
 
-                return (firstArgument, constraintArgument);
+                var actualArgument = firstArgument.WithNameColon(null);
+                return (actualArgument, constraintArgument);
             }
             else
             {

--- a/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageCodeFix.cs
@@ -124,31 +124,27 @@ namespace NUnit.Analyzers.CollectionAssertUsage
         {
             var methodName = diagnostic.Properties[AnalyzerPropertyKeys.ModelName]!;
             var firstParameterName = CollectionAssertToFirstParameterName[methodName];
-            var firstArgument = argumentNamesToArguments[firstParameterName];
+            var firstArgument = argumentNamesToArguments[firstParameterName].WithNameColon(null);
 
             if (CollectionAssertToParameterlessConstraints.TryGetValue(methodName, out Constraints? constraints))
             {
-                var actualArgument = firstArgument.WithNameColon(null);
                 var constraintArgument = Argument(constraints.CreateConstraint());
-                return (actualArgument, constraintArgument);
+                return (firstArgument, constraintArgument);
             }
             else if (CollectionAssertToOneSwappedParameterConstraints.TryGetValue(methodName, out constraints))
             {
                 var secondParameterName = CollectionAssertToSecondParameterName[methodName];
-                var secondArgument = argumentNamesToArguments[secondParameterName];
-                var actualArgument = secondArgument.WithNameColon(null);
-
-                var constraintArgument = Argument(constraints.CreateConstraint(firstArgument.WithNameColon(null)));
-                return (actualArgument, constraintArgument);
+                var secondArgument = argumentNamesToArguments[secondParameterName].WithNameColon(null);
+                var constraintArgument = Argument(constraints.CreateConstraint(firstArgument));
+                return (secondArgument, constraintArgument);
             }
             else if (CollectionAssertToOneUnswappedParameterConstraints.TryGetValue(methodName, out constraints))
             {
                 var secondParameterName = CollectionAssertToSecondParameterName[methodName];
-                var secondArgument = argumentNamesToArguments[secondParameterName];
-                var constraintArgument = Argument(constraints.CreateConstraint(secondArgument.WithNameColon(null)));
+                var secondArgument = argumentNamesToArguments[secondParameterName].WithNameColon(null);
+                var constraintArgument = Argument(constraints.CreateConstraint(secondArgument));
 
-                var actualArgument = firstArgument.WithNameColon(null);
-                return (actualArgument, constraintArgument);
+                return (firstArgument, constraintArgument);
             }
             else
             {

--- a/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
@@ -4,6 +4,5 @@ namespace NUnit.Analyzers.Constants
     {
         internal const string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
         internal const string MinimumNumberOfArguments = nameof(AnalyzerPropertyKeys.MinimumNumberOfArguments);
-        internal const string ComparerParameterIndex = nameof(AnalyzerPropertyKeys.ComparerParameterIndex);
     }
 }

--- a/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
@@ -2,7 +2,6 @@ namespace NUnit.Analyzers.Constants
 {
     internal static class AnalyzerPropertyKeys
     {
-        internal const string HasToleranceValue = nameof(AnalyzerPropertyKeys.HasToleranceValue);
         internal const string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
         internal const string MinimumNumberOfArguments = nameof(AnalyzerPropertyKeys.MinimumNumberOfArguments);
         internal const string ComparerParameterIndex = nameof(AnalyzerPropertyKeys.ComparerParameterIndex);

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -189,11 +189,23 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfExpectedResult = "ExpectedResult";
 
         public const string NameOfActualParameter = "actual";
+        public const string NameOfADoubleParameter = "aDouble";
+        public const string NameOfAnObjectParameter = "anObject";
+        public const string NameOfArg1Parameter = "arg1";
+        public const string NameOfArg2Parameter = "arg2";
+        public const string NameOfArgsParameter = "args";
+        public const string NameOfAStringParameter = "aString";
+        public const string NameOfCollectionParameter = "collection";
+        public const string NameOfComparerParameter = "comparer";
         public const string NameOfConditionParameter = "condition";
+        public const string NameOfDeltaParameter = "delta";
         public const string NameOfExpectedParameter = "expected";
+        public const string NameOfExpectedTypeParameter = "expectedType";
         public const string NameOfExpressionParameter = "expression";
         public const string NameOfMessageParameter = "message";
-        public const string NameOfArgsParameter = "args";
+        public const string NameOfPatternParameter = "pattern";
+        public const string NameOfSubsetParameter = "subset";
+        public const string NameOfSupersetParameter = "superset";
 
         public const string NameOfConstraintExpressionAnd = "And";
         public const string NameOfConstraintExpressionOr = "Or";

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -192,6 +192,7 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfConditionParameter = "condition";
         public const string NameOfExpectedParameter = "expected";
         public const string NameOfExpressionParameter = "expression";
+        public const string NameOfMessageParameter = "message";
 
         public const string NameOfConstraintExpressionAnd = "And";
         public const string NameOfConstraintExpressionOr = "Or";

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -193,6 +193,7 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfExpectedParameter = "expected";
         public const string NameOfExpressionParameter = "expression";
         public const string NameOfMessageParameter = "message";
+        public const string NameOfArgsParameter = "args";
 
         public const string NameOfConstraintExpressionAnd = "And";
         public const string NameOfConstraintExpressionOr = "Or";

--- a/src/nunit.analyzers/Helpers/CodeFixHelper.cs
+++ b/src/nunit.analyzers/Helpers/CodeFixHelper.cs
@@ -55,11 +55,10 @@ namespace NUnit.Analyzers.Helpers
                 return messageArgument;
 
             var formatSpecification = literalExpression.Token.ValueText;
-
-            var argsExpression = args.Single(a => a != messageArgument).Expression;
-            var formatArgumentExpressions = argsExpression is ImplicitArrayCreationExpressionSyntax argsArrayExpression
-                ? argsArrayExpression.Initializer.Expressions.ToArray()
-                : new[] { argsExpression };
+            var formatArgumentExpressions =
+                (args.Count == 1 && args[0].Expression is ImplicitArrayCreationExpressionSyntax argsArrayExpression)
+                    ? argsArrayExpression.Initializer.Expressions
+                    : args.Select(x => x.Expression);
 
             var interpolatedStringContent = UpdateStringFormatToFormattableString(
                 formatSpecification,

--- a/src/nunit.analyzers/Helpers/CodeFixHelper.cs
+++ b/src/nunit.analyzers/Helpers/CodeFixHelper.cs
@@ -61,7 +61,9 @@ namespace NUnit.Analyzers.Helpers
                 ? argsArrayExpression.Initializer.Expressions.ToArray()
                 : new[] { argsExpression };
 
-            var interpolatedStringContent = UpdateStringFormatToFormattableString(formatSpecification, formatArgumentExpressions);
+            var interpolatedStringContent = UpdateStringFormatToFormattableString(
+                formatSpecification,
+                formatArgumentExpressions.Select(e => e.WithoutTrivia()).ToArray());
             var interpolatedString = SyntaxFactory.InterpolatedStringExpression(
                 SyntaxFactory.Token(SyntaxKind.InterpolatedStringStartToken),
                 SyntaxFactory.List(interpolatedStringContent));

--- a/src/nunit.analyzers/Helpers/CodeFixHelper.cs
+++ b/src/nunit.analyzers/Helpers/CodeFixHelper.cs
@@ -39,8 +39,8 @@ namespace NUnit.Analyzers.Helpers
         /// This is assumed to be arguments for an 'Assert.That(actual, constraint, "...: {0} - {1}", param0, param1)`
         /// which needs converting into 'Assert.That(actual, constraint, $"...: {param0} - {param1}").
         /// </summary>
-        /// <param name="arguments">The arguments passed to the 'Assert' method. </param>
-        /// <param name="minimumNumberOfArguments">The argument needed for the actual method, any more are assumed messages.</param>
+        /// <param name="messageArgument">The argument that corresponds to the composite format string.</param>
+        /// <param name="args">The list of arguments that correspond to format items.</param>
         public static ArgumentSyntax? GetInterpolatedMessageArgumentOrDefault(ArgumentSyntax? messageArgument, List<ArgumentSyntax> args)
         {
             if (messageArgument is null)

--- a/src/nunit.analyzers/Helpers/CodeFixHelper.cs
+++ b/src/nunit.analyzers/Helpers/CodeFixHelper.cs
@@ -41,6 +41,42 @@ namespace NUnit.Analyzers.Helpers
         /// </summary>
         /// <param name="arguments">The arguments passed to the 'Assert' method. </param>
         /// <param name="minimumNumberOfArguments">The argument needed for the actual method, any more are assumed messages.</param>
+        public static ArgumentSyntax? GetInterpolatedMessageArgumentOrDefault(List<ArgumentSyntax> messageAndParams)
+        {
+            if (messageAndParams.Count == 0)
+                return null;
+
+            var messageArgument = messageAndParams.SingleOrDefault(a => a.NameColon?.Name.Identifier.Text == NUnitFrameworkConstants.NameOfMessageParameter)
+                ?? messageAndParams.First();
+            var formatSpecificationArgument = messageArgument.Expression;
+            if (formatSpecificationArgument.IsKind(SyntaxKind.NullLiteralExpression))
+                return null;
+
+            // We only support converting if the format specification is a constant string.
+            if (messageAndParams.Count == 1 || formatSpecificationArgument is not LiteralExpressionSyntax literalExpression)
+                return messageAndParams[0];
+
+            var formatSpecification = literalExpression.Token.ValueText;
+
+            // var formatArgumentExpressions = new List<ExpressionSyntax>(capacity: messageAndParams.Count - 1);
+            var argsExpression = messageAndParams.Single(a => a != messageArgument).Expression;
+            var formatArgumentExpressions = argsExpression is ImplicitArrayCreationExpressionSyntax args
+                ? args.Initializer.Expressions.ToArray()
+                : new[] { argsExpression };
+
+            var interpolatedStringContent = UpdateStringFormatToFormattableString(formatSpecification, formatArgumentExpressions);
+            var interpolatedString = SyntaxFactory.InterpolatedStringExpression(
+                SyntaxFactory.Token(SyntaxKind.InterpolatedStringStartToken),
+                SyntaxFactory.List(interpolatedStringContent));
+            return SyntaxFactory.Argument(interpolatedString);
+        }
+
+        /// <summary>
+        /// This is assumed to be arguments for an 'Assert.That(actual, constraint, "...: {0} - {1}", param0, param1)`
+        /// which needs converting into 'Assert.That(actual, constraint, $"...: {param0} - {param1}").
+        /// </summary>
+        /// <param name="arguments">The arguments passed to the 'Assert' method. </param>
+        /// <param name="minimumNumberOfArguments">The argument needed for the actual method, any more are assumed messages.</param>
         public static void UpdateStringFormatToFormattableString(List<ArgumentSyntax> arguments, int minimumNumberOfArguments = 2)
         {
             int firstParamsArgument = minimumNumberOfArguments + 1;

--- a/src/nunit.analyzers/StringAssertUsage/StringAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/StringAssertUsage/StringAssertUsageCodeFix.cs
@@ -55,12 +55,12 @@ namespace NUnit.Analyzers.StringAssertUsage
         {
             var methodName = diagnostic.Properties[AnalyzerPropertyKeys.ModelName]!;
             var expectedParameterName = StringAssertToExpectedParameterName[methodName];
-            var expectedArgument = argumentNamesToArguments[expectedParameterName];
+            var expectedArgument = argumentNamesToArguments[expectedParameterName].WithNameColon(null);
             var constraints = StringAssertToConstraints[methodName];
-            var constraintArgument = Argument(constraints.CreateConstraint(expectedArgument.WithNameColon(null)));
+            var constraintArgument = Argument(constraints.CreateConstraint(expectedArgument));
 
-            var actualArgument = argumentNamesToArguments[NameOfActualParameter];
-            return (actualArgument.WithNameColon(null), constraintArgument);
+            var actualArgument = argumentNamesToArguments[NameOfActualParameter].WithNameColon(null);
+            return (actualArgument, constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/StringAssertUsage/StringAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/StringAssertUsage/StringAssertUsageCodeFix.cs
@@ -16,6 +16,21 @@ namespace NUnit.Analyzers.StringAssertUsage
     [Shared]
     internal class StringAssertUsageCodeFix : ClassicModelAssertUsageCodeFix
     {
+        internal static readonly ImmutableDictionary<string, string> StringAssertToExpectedParameterName =
+            new Dictionary<string, string>()
+            {
+                { NameOfStringAssertContains, NameOfExpectedParameter },
+                { NameOfStringAssertDoesNotContain, NameOfExpectedParameter },
+                { NameOfStringAssertStartsWith, NameOfExpectedParameter },
+                { NameOfStringAssertDoesNotStartWith, NameOfExpectedParameter },
+                { NameOfStringAssertEndsWith, NameOfExpectedParameter },
+                { NameOfStringAssertDoesNotEndWith, NameOfExpectedParameter },
+                { NameOfStringAssertAreEqualIgnoringCase, NameOfExpectedParameter },
+                { NameOfStringAssertAreNotEqualIgnoringCase, NameOfExpectedParameter },
+                { NameOfStringAssertIsMatch, NameOfPatternParameter },
+                { NameOfStringAssertDoesNotMatch, NameOfPatternParameter },
+            }.ToImmutableDictionary();
+
         private static readonly ImmutableDictionary<string, Constraints> StringAssertToConstraints =
             new Dictionary<string, Constraints>
             {
@@ -29,21 +44,6 @@ namespace NUnit.Analyzers.StringAssertUsage
                 { NameOfStringAssertAreNotEqualIgnoringCase, new Constraints(NameOfIs, NameOfIsNot, NameOfIsEqualTo, NameOfEqualConstraintIgnoreCase) },
                 { NameOfStringAssertIsMatch, new Constraints(NameOfDoes, default(string), NameOfDoesMatch) },
                 { NameOfStringAssertDoesNotMatch, new Constraints(NameOfDoes, NameOfDoesNot, NameOfDoesMatch) },
-            }.ToImmutableDictionary();
-
-        private static readonly ImmutableDictionary<string, string> StringAssertToExpectedParameterName =
-            new Dictionary<string, string>()
-            {
-                { NameOfStringAssertContains, NameOfExpectedParameter },
-                { NameOfStringAssertDoesNotContain, NameOfExpectedParameter },
-                { NameOfStringAssertStartsWith, NameOfExpectedParameter },
-                { NameOfStringAssertDoesNotStartWith, NameOfExpectedParameter },
-                { NameOfStringAssertEndsWith, NameOfExpectedParameter },
-                { NameOfStringAssertDoesNotEndWith, NameOfExpectedParameter },
-                { NameOfStringAssertAreEqualIgnoringCase, NameOfExpectedParameter },
-                { NameOfStringAssertAreNotEqualIgnoringCase, NameOfExpectedParameter },
-                { NameOfStringAssertIsMatch, NameOfPatternParameter },
-                { NameOfStringAssertDoesNotMatch, NameOfPatternParameter },
             }.ToImmutableDictionary();
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(

--- a/src/nunit.analyzers/StringAssertUsage/StringAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers/StringAssertUsage/StringAssertUsageCodeFix.cs
@@ -57,10 +57,10 @@ namespace NUnit.Analyzers.StringAssertUsage
             var expectedParameterName = StringAssertToExpectedParameterName[methodName];
             var expectedArgument = argumentNamesToArguments[expectedParameterName];
             var constraints = StringAssertToConstraints[methodName];
-            var constraintArgument = Argument(constraints.CreateConstraint(expectedArgument));
+            var constraintArgument = Argument(constraints.CreateConstraint(expectedArgument.WithNameColon(null)));
 
             var actualArgument = argumentNamesToArguments[NameOfActualParameter];
-            return (actualArgument, constraintArgument);
+            return (actualArgument.WithNameColon(null), constraintArgument);
         }
     }
 }

--- a/src/nunit.analyzers/UpdateStringFormatToInterpolatableString/UpdateStringFormatToInterpolatableStringAnalyzer.cs
+++ b/src/nunit.analyzers/UpdateStringFormatToInterpolatableString/UpdateStringFormatToInterpolatableStringAnalyzer.cs
@@ -107,7 +107,7 @@ namespace NUnit.Analyzers.UpdateStringFormatToInterpolatableString
                 IParameterSymbol parameter = parameters[formatParameterIndex];
                 if (parameter.IsOptional)
                 {
-                    if (parameter.Name == "message")
+                    if (parameter.Name == NUnitFrameworkConstants.NameOfMessageParameter)
                         break;
 
                     // Overload with FormattableString or Func<string> overload


### PR DESCRIPTION
I found another bug while fixing the code, but in the interest of making the PR more targeted and reviewable, I'll file another issue and another PR to fix that.

Closes #712.