### PR TITLE
Update the solution file

### DIFF
--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -96,6 +96,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		..\documentation\NUnit3002.md = ..\documentation\NUnit3002.md
 		..\documentation\NUnit3003.md = ..\documentation\NUnit3003.md
 		..\documentation\NUnit3004.md = ..\documentation\NUnit3004.md
+		..\documentation\NUnit4001.md = ..\documentation\NUnit4001.md
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
@@ -116,10 +117,6 @@ Global
 		{74151914-3C12-4EAC-8FD5-5766EBEA35A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74151914-3C12-4EAC-8FD5-5766EBEA35A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74151914-3C12-4EAC-8FD5-5766EBEA35A3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5D87311B-74DE-4DF9-BCC3-E14D8EE4E7B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5D87311B-74DE-4DF9-BCC3-E14D8EE4E7B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5D87311B-74DE-4DF9-BCC3-E14D8EE4E7B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5D87311B-74DE-4DF9-BCC3-E14D8EE4E7B0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{070974CB-B483-4347-BA5A-53ED977E639C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{070974CB-B483-4347-BA5A-53ED977E639C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{070974CB-B483-4347-BA5A-53ED977E639C}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
I forgot to add `NUnit4001.md` as a solution item in #758, so I did that in VS 2022.

However, that also caused another diff in `nunit.analyzers.sln`. It appears that:
- `74151914-3C12-4EAC-8FD5-5766EBEA35A3` corresponds to `nunit.analyzers.csproj`.
- `070974CB-B483-4347-BA5A-53ED977E639C` corresponds to `nunit.analyzers.tests.csproj`.
- `5D87311B-74DE-4DF9-BCC3-E14D8EE4E7B0` [used to correspond to](https://github.com/nunit/nunit.analyzers/commit/f16dea518dcb70acff3d00c680989fbe7aa40c6f#diff-364917a53411b086282ed7b8454b102dda5f3e2e768e563b16e5d2316003819dR8) `nunit.analyzers.vsix.csproj` but it wasn't properly cleaned up in https://github.com/nunit/nunit.analyzers/commit/5f0b678f708961dee13011196c5f9add2e669a24 likely because the cleanup was done manually.