### PR TITLE
Prevent exception when fields are declared in a different source file.

### DIFF
--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -1034,6 +1034,8 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
         {{
             private const double Tolerance = 1E-10;
 
+            private IDisposable? field;
+
             private static IDisposable? Property {{ get; set; }}
 
             [SetUp]
@@ -1059,6 +1061,8 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
             [Test]
             public void SomeTest()
             {
+                // field needs Disposal, but as TearDown is in a different source 'file' we cannot check if it is.
+                field = new DummyDisposable();
                 SomeAsserts();
             }
         }");

--- a/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
+++ b/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
@@ -366,6 +366,12 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
         {
             if (IsPossibleDisposableCreation(expression))
             {
+                if (model.SyntaxTree != expression.SyntaxTree)
+                {
+                    // It might need it, but we cannot check it.
+                    return false;
+                }
+
                 ITypeSymbol? instanceType = model.GetTypeInfo(expression).Type;
                 return instanceType is not null &&
                        instanceType.IsDisposable() &&


### PR DESCRIPTION
Fixes #766 