### PR TITLE
Add support for Assert.EnterMultipleScope

### DIFF
--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -74,8 +74,10 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfMultiple), nameof(Assert.Multiple)),
 #if NUNIT4
             (nameof(NUnitFrameworkConstants.NameOfMultipleAsync), nameof(Assert.MultipleAsync)),
+            (nameof(NUnitFrameworkConstants.NameOfEnterMultipleScope), nameof(Assert.EnterMultipleScope)),
 #else
             (nameof(NUnitFrameworkConstants.NameOfMultipleAsync), "MultipleAsync"),
+            (nameof(NUnitFrameworkConstants.NameOfEnterMultipleScope), "EnterMultipleScope"),
 #endif
 
             (nameof(NUnitFrameworkConstants.NameOfOut), nameof(TestContext.Out)),

--- a/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleAnalyzerTests.cs
@@ -45,6 +45,38 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
         }");
             RoslynAssert.Valid(this.analyzer, testCode);
         }
+
+#if WOULD_SOMEONE_ACTUALLY_USE_THIS
+        [Test]
+        public void AnalyzeWhenMultipleScopeDeclarationIsUsed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            using IDisposable disposable = Assert.EnterMultipleScope();
+
+            Assert.That(true, Is.True);
+            disposable.Dispose();
+            Assert.That(false, Is.False);
+        }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
+#endif
+
+        [Test]
+        public void AnalyzeWhenMultipleScopeStatementIsUsed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(true, Is.True);
+                Assert.That(false, Is.False);
+            }
+        }");
+            RoslynAssert.Valid(this.analyzer, testCode);
+        }
 #endif
 
         [Test]

--- a/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertMultiple/UseAssertMultipleCodeFixTests.cs
@@ -34,6 +34,7 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             Assert.That(false, Is.False);
             Console.WriteLine(""Next Statement"");
         }");
+
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
         {
@@ -44,12 +45,36 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             });
             Console.WriteLine(""Next Statement"");
         }");
-            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertMultiple);
+
+#if NUNIT4
+            fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(true, Is.True);
+                Assert.That(false, Is.False);
+            }
+            Console.WriteLine(""Next Statement"");
+        }");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertEnterMultipleScope);
+#endif
         }
 
         [Test]
         public void VerifyPartlyIndependent()
         {
+            const string ConfigurationClass = @"
+        private sealed class Configuration
+        {
+            public int Value1 { get; set; }
+            public double Value2 { get; set; }
+            public string Value11 { get; set; } = string.Empty;
+        }";
+
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void Test()
         {
@@ -59,14 +84,8 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             Assert.That(configuration.Value2, Is.EqualTo(0.0));
             Assert.That(configuration.Value11, Is.EqualTo(string.Empty));
             configuration = null;
-        }
+        }" + ConfigurationClass);
 
-        private sealed class Configuration
-        {
-            public int Value1 { get; set; }
-            public double Value2 { get; set; }
-            public string Value11 { get; set; } = string.Empty;
-        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void Test()
         {
@@ -79,22 +98,43 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
                 Assert.That(configuration.Value11, Is.EqualTo(string.Empty));
             });
             configuration = null;
-        }
+        }" + ConfigurationClass);
 
-        private sealed class Configuration
+            RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertMultiple);
+
+#if NUNIT4
+            fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void Test()
         {
-            public int Value1 { get; set; }
-            public double Value2 { get; set; }
-            public string Value11 { get; set; } = string.Empty;
-        }");
-            RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode);
+            var configuration = new Configuration();
+            Assert.That(configuration, Is.Not.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(configuration.Value1, Is.EqualTo(0));
+                Assert.That(configuration.Value2, Is.EqualTo(0.0));
+                Assert.That(configuration.Value11, Is.EqualTo(string.Empty));
+            }
+            configuration = null;
+        }" + ConfigurationClass);
+
+            RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertEnterMultipleScope);
+#endif
         }
 
         [Test]
         public void AddsAsyncWhenAwaitIsUsed()
         {
+            const string ConfigurationClass = @"
+        private sealed class Configuration
+        {
+            public int Value1 { get; set; }
+            public double Value2 { get; set; }
+            public string Value11 { get; set; } = string.Empty;
+            public Task<string> AsStringAsync() => Task.FromResult(Value11);
+        }";
+
             var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
-        public void Test()
+        public async Task Test()
         {
             var configuration = new Configuration();
             Assert.That(configuration, Is.Not.Null);
@@ -102,17 +142,10 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             Assert.That(configuration.Value2, Is.EqualTo(0.0));
             Assert.That(await configuration.AsStringAsync(), Is.EqualTo(string.Empty));
             configuration = null;
-        }
+        }" + ConfigurationClass);
 
-        private sealed class Configuration
-        {
-            public int Value1 { get; set; }
-            public double Value2 { get; set; }
-            public string Value11 { get; set; } = string.Empty;
-            public Task<string> AsStringAsync() => Task.FromResult(Value11);
-        }");
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
-        public void Test()
+        public async Task Test()
         {
             var configuration = new Configuration();
             Assert.That(configuration, Is.Not.Null);
@@ -123,16 +156,30 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
                 Assert.That(await configuration.AsStringAsync(), Is.EqualTo(string.Empty));
             });
             configuration = null;
-        }
+        }" + ConfigurationClass);
 
-        private sealed class Configuration
+            // The test method itself no longer awaits, so CS1998 is generated.
+            // Fixing this is outside the scope of this analyzer and there could be other non-touched statements that are waited.
+            RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertMultiple,
+                Settings.Default.WithAllowedCompilerDiagnostics(AllowedCompilerDiagnostics.WarningsAndErrors));
+
+#if NUNIT4
+            fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public async Task Test()
         {
-            public int Value1 { get; set; }
-            public double Value2 { get; set; }
-            public string Value11 { get; set; } = string.Empty;
-            public Task<string> AsStringAsync() => Task.FromResult(Value11);
-        }");
-            RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode);
+            var configuration = new Configuration();
+            Assert.That(configuration, Is.Not.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(configuration.Value1, Is.EqualTo(0));
+                Assert.That(configuration.Value2, Is.EqualTo(0.0));
+                Assert.That(await configuration.AsStringAsync(), Is.EqualTo(string.Empty));
+            }
+            configuration = null;
+        }" + ConfigurationClass);
+
+            RoslynAssert.FixAll(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertEnterMultipleScope);
+#endif
         }
 
         [Test]
@@ -152,6 +199,7 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             Assert.That(False, Is.False);{newline}
             {preComment}Console.WriteLine(""Next Statement"");{postComment}
         }}");
+
             var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
         public void TestMethod()
         {{
@@ -166,30 +214,67 @@ namespace NUnit.Analyzers.Tests.UseAssertMultiple
             }});{newline}
             {preComment}Console.WriteLine(""Next Statement"");{postComment}
         }}");
-            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertMultiple);
+
+#if NUNIT4
+            fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+        public void TestMethod()
+        {{
+            const bool True = true;
+            const bool False = false;
+
+            using (Assert.EnterMultipleScope())
+            {{
+                // Verify that our bool constants are correct
+                Assert.That(True, Is.True);
+                Assert.That(False, Is.False);
+            }}{newline}
+            {preComment}Console.WriteLine(""Next Statement"");{postComment}
+        }}");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertEnterMultipleScope);
+#endif
         }
 
         [Test]
         public void VerifyKeepsTrivia()
         {
-            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+            var code = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
-                // Verify that boolean work as expected
+        {
+            // Verify that boolean work as expected
             ↓Assert.That(true, Is.True);
             Assert.That(false, Is.False);
-        }}");
-            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"
+        }");
+
+            var fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
         public void TestMethod()
-        {{
+        {
             Assert.Multiple(() =>
-            {{
+            {
                 // Verify that boolean work as expected
                 Assert.That(true, Is.True);
                 Assert.That(false, Is.False);
-            }});
-        }}");
-            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
+            });
+        }");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertMultiple);
+
+#if NUNIT4
+            fixedCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public void TestMethod()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                // Verify that boolean work as expected
+                Assert.That(true, Is.True);
+                Assert.That(false, Is.False);
+            }
+        }");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode, UseAssertMultipleCodeFix.WrapWithAssertEnterMultipleScope);
+#endif
         }
     }
 }

--- a/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
@@ -5,5 +5,7 @@ namespace NUnit.Analyzers.Constants
         internal const string ModelName = nameof(AnalyzerPropertyKeys.ModelName);
         internal const string ArgsIsArray = nameof(AnalyzerPropertyKeys.ArgsIsArray);
         internal const string MinimumNumberOfArguments = nameof(AnalyzerPropertyKeys.MinimumNumberOfArguments);
+
+        internal const string SupportsEnterMultipleScope = nameof(AnalyzerPropertyKeys.SupportsEnterMultipleScope);
     }
 }

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -53,6 +53,7 @@ namespace NUnit.Analyzers.Constants
 
         public const string NameOfMultiple = "Multiple";
         public const string NameOfMultipleAsync = "MultipleAsync";
+        public const string NameOfEnterMultipleScope = "EnterMultipleScope";
 
         public const string NameOfOut = "Out";
         public const string NameOfWrite = "Write";


### PR DESCRIPTION
Fixes #769 

Detects that code inside a `using (Assert.EnterMultipleScope())` is inside a multiple context.
Adds a codefix for to use `Assert.EnterMultipleScope`.
