### PR TITLE
chore: Replace "buildstats.info" with "img.shields.io"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions build status](https://github.com/nunit/nunit.analyzers/actions/workflows/ci.yml/badge.svg)](https://github.com/nunit/nunit.analyzers/actions/workflows/ci.yml)
 [![NuGet Version](https://img.shields.io/nuget/v/nunit.analyzers?label=nuget%20version)](https://www.nuget.org/packages/NUnit.Analyzers)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/nunit.analyzers?label=nuget%20downloads)](https://www.nuget.org/packages/NUnit.Analyzers)
-[![MyGet Feed](https://img.shields.io/myget/nunit-analyzers/v/nunit.analyzers?label=myget%20version)](https://www.myget.org/feed/nunit-analyzers/package/nuget/NUnit.Analyzers)
+[![MyGet Feed](https://img.shields.io/myget/nunit-analyzers/vpre/nunit.analyzers?label=myget%20version)](https://www.myget.org/feed/nunit-analyzers/package/nuget/NUnit.Analyzers)
 
 This is a suite of analyzers that target the NUnit testing framework. Right now, the code is separate from the NUnit framework, so if you want to try out the analyzers you'll need to download the analyzers separately as a nuget package. In the future the analyzers may be added as part of the NUnit framework package but that hasn't been done yet.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Build status](https://ci.appveyor.com/api/projects/status/rlx18p32vkh80p2f/branch/master?svg=true)](https://ci.appveyor.com/project/mikkelbu/nunit-analyzers/branch/master)
 [![GitHub Actions build status](https://github.com/nunit/nunit.analyzers/actions/workflows/ci.yml/badge.svg)](https://github.com/nunit/nunit.analyzers/actions/workflows/ci.yml)
-[![NuGet Version and Downloads count](https://buildstats.info/nuget/NUnit.Analyzers)](https://www.nuget.org/packages/NUnit.Analyzers)
-[![MyGet Feed](https://img.shields.io/myget/nunit-analyzers/v/NUnit.Analyzers.svg)](https://www.myget.org/feed/nunit-analyzers/package/nuget/NUnit.Analyzers)
+[![NuGet Version](https://img.shields.io/nuget/v/nunit.analyzers?label=nuget%20version)](https://www.nuget.org/packages/NUnit.Analyzers)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/nunit.analyzers?label=nuget%20downloads)](https://www.nuget.org/packages/NUnit.Analyzers)
+[![MyGet Feed](https://img.shields.io/myget/nunit-analyzers/v/nunit.analyzers?label=myget%20version)](https://www.myget.org/feed/nunit-analyzers/package/nuget/NUnit.Analyzers)
 
 This is a suite of analyzers that target the NUnit testing framework. Right now, the code is separate from the NUnit framework, so if you want to try out the analyzers you'll need to download the analyzers separately as a nuget package. In the future the analyzers may be added as part of the NUnit framework package but that hasn't been done yet.
 


### PR DESCRIPTION
It seems like buildstats.info is no longer working.