### PR TITLE
Use specific constraint

### DIFF
--- a/documentation/NUnit4002.md
+++ b/documentation/NUnit4002.md
@@ -1,0 +1,93 @@
+# NUnit4002
+
+## Use Specific constraint
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit4002
+| Severity | Info
+| Enabled  | True
+| Category | Style
+| Code     | [UseSpecificConstraintAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintAnalyzer.cs)
+
+## Description
+
+Replace 'EqualTo' with a keyword in the corresponding specific constraint.
+
+## Motivation
+
+Sometimes constraints can be written more concisely using the inbuilt constraints provided by NUnit -
+e.g. `Is.True` instead of `Is.EqualTo(true)`.
+
+Also, from NUnit version 4.3.0 where new overloads of `Is.EqualTo` were introduced, it is sometimes
+not possible to uniquely determine `default` when provided as the expected value - e.g. in
+`Is.EqualTo(default)`. Again, in such cases, it is better to use the inbuilt constraint provided by NUnit.
+
+Some examples of constraints that can be be simplified by using a more specific constraint can be seen below.
+
+```csharp
+[Test]
+public void Test()
+{
+    Assert.That(actualFalse, Is.EqualTo(false));
+    Assert.That(actualTrue, Is.EqualTo(true));
+    Assert.That(actualObject, Is.EqualTo(null));
+    Assert.That(actualObject, Is.EqualTo(default));
+    Assert.That(actualInt, Is.EqualTo(default));
+}
+
+## How to fix violations
+
+The analyzer comes with a code fix that will replace the constraint `Is.EqualTo(x)` with
+the matching `Is.X` constraint (for some `x`). So the code block above will be changed into
+
+```csharp
+[Test]
+public void Test()
+{
+    Assert.That(actualFalse, Is.False);
+    Assert.That(actualTrue, Is.True);
+    Assert.That(actualObject, Is.Null);
+    Assert.That(actualObject, Is.Null);
+    Assert.That(actualInt, Is.Default);
+}
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file
+
+Configure the severity per project, for more info see
+[MSDN](https://learn.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2022).
+
+### Via .editorconfig file
+
+```ini
+# NUnit4002: Use Specific constraint
+dotnet_diagnostic.NUnit4002.severity = chosenSeverity
+```
+
+where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, or `error`.
+
+### Via #pragma directive
+
+```csharp
+#pragma warning disable NUnit4002 // Use Specific constraint
+Code violating the rule here
+#pragma warning restore NUnit4002 // Use Specific constraint
+```
+
+Or put this at the top of the file to disable all instances.
+
+```csharp
+#pragma warning disable NUnit4002 // Use Specific constraint
+```
+
+### Via attribute `[SuppressMessage]`
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Style",
+    "NUnit4002:Use Specific constraint",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -132,4 +132,5 @@ Rules which help you write concise and readable NUnit test code.
 
 | Id       | Title       | :mag: | :memo: | :bulb: |
 | :--      | :--         | :--:  | :--:   | :--:   |
-| [NUnit4001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit4001.md) | Simplify the Values attribute | :white_check_mark: | :information_source: | :x: |
+| [NUnit4001](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit4001.md) | Simplify the Values attribute | :white_check_mark: | :information_source: | :white_check_mark: |
+| [NUnit4002](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit4002.md) | Use Specific constraint | :white_check_mark: | :information_source: | :white_check_mark: |

--- a/src/nunit.analyzers.codefixes/CollectionAssertUsage/CollectionAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/CollectionAssertUsage/CollectionAssertUsageCodeFix.cs
@@ -9,8 +9,11 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.ClassicModelAssertUsage;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Helpers;
+
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
 using static NUnit.Analyzers.Constants.NUnitFrameworkConstants;
+using static NUnit.Analyzers.Constants.NUnitLegacyFrameworkConstants;
 
 namespace NUnit.Analyzers.CollectionAssertUsage
 {

--- a/src/nunit.analyzers.codefixes/ConstActualValueUsage/ConstActualValueUsageCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/ConstActualValueUsage/ConstActualValueUsageCodeFix.cs
@@ -18,34 +18,34 @@ namespace NUnit.Analyzers.ConstActualValueUsage
     {
         internal const string SwapArgumentsDescription = "Swap actual and expected arguments";
 
-        private static readonly string[] SupportedClassicAsserts = new[]
-        {
-            NUnitFrameworkConstants.NameOfAssertAreEqual,
-            NUnitFrameworkConstants.NameOfAssertAreNotEqual,
-            NUnitFrameworkConstants.NameOfAssertAreSame,
-            NUnitFrameworkConstants.NameOfAssertAreNotSame,
-        };
+        private static readonly string[] SupportedClassicAsserts =
+        [
+            NUnitLegacyFrameworkConstants.NameOfAssertAreEqual,
+            NUnitLegacyFrameworkConstants.NameOfAssertAreNotEqual,
+            NUnitLegacyFrameworkConstants.NameOfAssertAreSame,
+            NUnitLegacyFrameworkConstants.NameOfAssertAreNotSame,
+        ];
 
-        private static readonly string[] SupportedStringAsserts = new[]
-        {
-            NUnitFrameworkConstants.NameOfStringAssertAreEqualIgnoringCase,
-            NUnitFrameworkConstants.NameOfStringAssertAreNotEqualIgnoringCase,
-            NUnitFrameworkConstants.NameOfStringAssertContains,
-            NUnitFrameworkConstants.NameOfStringAssertDoesNotContain,
-            NUnitFrameworkConstants.NameOfStringAssertDoesNotEndWith,
-            NUnitFrameworkConstants.NameOfStringAssertDoesNotMatch,
-            NUnitFrameworkConstants.NameOfStringAssertDoesNotStartWith,
-            NUnitFrameworkConstants.NameOfStringAssertEndsWith,
-            NUnitFrameworkConstants.NameOfStringAssertIsMatch,
-            NUnitFrameworkConstants.NameOfStringAssertStartsWith,
-        };
+        private static readonly string[] SupportedStringAsserts =
+        [
+            NUnitLegacyFrameworkConstants.NameOfStringAssertAreEqualIgnoringCase,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertAreNotEqualIgnoringCase,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertContains,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotContain,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotEndWith,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotMatch,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotStartWith,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertEndsWith,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertIsMatch,
+            NUnitLegacyFrameworkConstants.NameOfStringAssertStartsWith,
+        ];
 
-        private static readonly string[] SupportedIsConstraints = new[]
-        {
+        private static readonly string[] SupportedIsConstraints =
+        [
             NUnitFrameworkConstants.NameOfIsEqualTo,
             NUnitFrameworkConstants.NameOfIsSameAs,
             NUnitFrameworkConstants.NameOfIsSamePath
-        };
+        ];
 
         public override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(AnalyzerIdentifiers.ConstActualValueUsage);

--- a/src/nunit.analyzers.codefixes/SameAsOnValueTypes/SameAsOnValueTypesCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/SameAsOnValueTypes/SameAsOnValueTypesCodeFix.cs
@@ -57,11 +57,11 @@ namespace NUnit.Analyzers.SameAsOnValueTypes
 
             switch (assertExpression.Name.ToString())
             {
-                case NUnitFrameworkConstants.NameOfAssertAreSame:
-                    replacement = assertExpression.WithName(SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfAssertAreEqual));
+                case NUnitLegacyFrameworkConstants.NameOfAssertAreSame:
+                    replacement = assertExpression.WithName(SyntaxFactory.IdentifierName(NUnitLegacyFrameworkConstants.NameOfAssertAreEqual));
                     break;
-                case NUnitFrameworkConstants.NameOfAssertAreNotSame:
-                    replacement = assertExpression.WithName(SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfAssertAreNotEqual));
+                case NUnitLegacyFrameworkConstants.NameOfAssertAreNotSame:
+                    replacement = assertExpression.WithName(SyntaxFactory.IdentifierName(NUnitLegacyFrameworkConstants.NameOfAssertAreNotEqual));
                     break;
                 case NUnitFrameworkConstants.NameOfIsSameAs:
                     replacement = assertExpression.WithName(SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfIsEqualTo));

--- a/src/nunit.analyzers.codefixes/StringAssertUsage/StringAssertUsageCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/StringAssertUsage/StringAssertUsageCodeFix.cs
@@ -7,8 +7,11 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Analyzers.ClassicModelAssertUsage;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Helpers;
+
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
 using static NUnit.Analyzers.Constants.NUnitFrameworkConstants;
+using static NUnit.Analyzers.Constants.NUnitLegacyFrameworkConstants;
 
 namespace NUnit.Analyzers.StringAssertUsage
 {

--- a/src/nunit.analyzers.codefixes/UseAssertMultiple/UseAssertMultipleCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/UseAssertMultiple/UseAssertMultipleCodeFix.cs
@@ -103,7 +103,7 @@ namespace NUnit.Analyzers.UseAssertMultiple
                 {
                     // Remember the trivia and delete it from the first statement inside the Assert.Multiple
                     endOfLineTrivia = firstTrivia;
-                    statementsInsideAssertMultiple[0] = firstStatement.ReplaceTrivia(firstTrivia, Enumerable.Empty<SyntaxTrivia>());
+                    statementsInsideAssertMultiple[0] = firstStatement.ReplaceTrivia(firstTrivia, []);
                 }
             }
 
@@ -117,7 +117,7 @@ namespace NUnit.Analyzers.UseAssertMultiple
                             SyntaxFactory.MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfAssert),
-                                SyntaxFactory.IdentifierName(NUnitFrameworkConstants.NameOfEnterMultipleScope))),
+                                SyntaxFactory.IdentifierName(NUnitV4FrameworkConstants.NameOfEnterMultipleScope))),
                         SyntaxFactory.Block(statementsInsideAssertMultiple))
                     .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed)
                     .WithAdditionalAnnotations(Formatter.Annotation);

--- a/src/nunit.analyzers.codefixes/UseSpecificConstraint/UseSpecificConstraintCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/UseSpecificConstraint/UseSpecificConstraintCodeFix.cs
@@ -1,0 +1,72 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace NUnit.Analyzers.UseSpecificConstraint
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    internal class UseSpecificConstraintCodeFix : CodeFixProvider
+    {
+        internal const string UseSpecificConstraint = "Use specific constraint";
+
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+            AnalyzerIdentifiers.UseSpecificConstraint);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            if (root is null)
+            {
+                return;
+            }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            SyntaxNode node = root.FindNode(context.Span);
+
+            if (node is ArgumentSyntax argument)
+            {
+                node = argument.Expression;
+            }
+
+            if (node is not InvocationExpressionSyntax originalExpression ||
+                originalExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+            {
+                return;
+            }
+
+            var diagnostic = context.Diagnostics.First();
+            var constraint = diagnostic.Properties[AnalyzerPropertyKeys.SpecificConstraint]!;
+
+            var newExpression = MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                memberAccessExpression.Expression,
+                IdentifierName(constraint));
+
+            SyntaxNode newRoot = root.ReplaceNode(originalExpression, newExpression);
+
+            var codeAction = CodeAction.Create(
+                UseSpecificConstraint,
+                _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
+                UseSpecificConstraint);
+
+            context.RegisterCodeFix(codeAction, context.Diagnostics);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageAnalyzerTests.cs
@@ -103,8 +103,8 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
         }
 
-        [TestCase(NUnitFrameworkConstants.NameOfCollectionAssertAreEqual)]
-        [TestCase(NUnitFrameworkConstants.NameOfCollectionAssertAreNotEqual)]
+        [TestCase(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreEqual)]
+        [TestCase(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreNotEqual)]
         public void AnalyzeTwoCollectionWithComparerWhenFormatAndParamsArgumentsAreUsed(string method)
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@$"

--- a/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/CollectionAssertUsage/CollectionAssertUsageCodeFixTests.cs
@@ -92,7 +92,7 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
 
-        [TestCase(NUnitFrameworkConstants.NameOfCollectionAssertIsOrdered)]
+        [TestCase(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsOrdered)]
         public void AnalyzeOneCollectionWithComparerWhenFormatAndParamsArgumentsAreUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"
@@ -350,8 +350,8 @@ namespace NUnit.Analyzers.Tests.CollectionAssertUsage
             RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, code, fixedCode);
         }
 
-        [TestCase(NUnitFrameworkConstants.NameOfCollectionAssertAreEqual)]
-        [TestCase(NUnitFrameworkConstants.NameOfCollectionAssertAreNotEqual)]
+        [TestCase(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreEqual)]
+        [TestCase(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreNotEqual)]
         public void AnalyzeTwoCollectionWithComparerWhenFormatAndParamsArgumentsAreUsed(string method)
         {
             var code = TestUtility.WrapInTestMethod(@$"

--- a/src/nunit.analyzers.tests/Constants/BaseNUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/BaseNUnitFrameworkConstantsTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Analyzers.Tests.Constants
+{
+    /// <summary>
+    /// Tests to ensure that the string constants in the analyzer project correspond
+    /// to the NUnit concepts that they represent.
+    /// </summary>
+    /// <typeparam name="T">The type of the constants class to test.</typeparam>
+    [TestFixture]
+    internal abstract class BaseNUnitFrameworkConstantsTests<T>
+        where T : class
+    {
+        private static readonly (string Constant, string TypeName)[] NameOfSource = [];
+
+        private static readonly (string Constant, Type Type)[] FullNameOfTypeSource = [];
+
+        protected abstract IEnumerable<string> Names { get; }
+
+        protected abstract IEnumerable<string> FullNames { get; }
+
+        [TestCaseSource(nameof(NameOfSource))]
+        public void TestNameOfConstants((string Constant, string TypeName) pair)
+        {
+            Assert.That(GetValue(pair.Constant), Is.EqualTo(pair.TypeName), pair.Constant);
+        }
+
+        [TestCaseSource(nameof(FullNameOfTypeSource))]
+        public void TestFullNameOfConstants((string Constant, Type Type) pair)
+        {
+            Assert.That(GetValue(pair.Constant), Is.EqualTo(pair.Type.FullName), pair.Constant);
+        }
+
+        [Test]
+        public void EnsureAllNameOfDefinitionsAreTested()
+        {
+            EnsureAllNameDefinitionsAreTested("NameOf", this.Names);
+        }
+
+        [Test]
+        public void EnsureAllFullNameOfTypeDefinitionsAreTested()
+        {
+            EnsureAllNameDefinitionsAreTested("FullNameOf", this.FullNames);
+        }
+
+        protected static IEnumerable<string> Constant<TType>(IEnumerable<(string Constant, TType Type)> source) =>
+            source.Select(pair => pair.Constant);
+
+        private static void EnsureAllNameDefinitionsAreTested(string prefix, IEnumerable<string> testedNames)
+        {
+            IEnumerable<string> allNames =
+                typeof(T).GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(f => f.IsLiteral)
+                .Select(f => f.Name)
+                .Where(name => !name.EndsWith("Parameter", StringComparison.Ordinal))
+                .Where(name => name.StartsWith(prefix, StringComparison.Ordinal));
+
+            Assert.That(testedNames, Is.EquivalentTo(allNames));
+        }
+
+        private static string? GetValue(string fieldName) =>
+            typeof(T).GetField(fieldName)?.GetRawConstantValue() as string;
+    }
+}

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -1,19 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Threading;
 using NUnit.Analyzers.Constants;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-
-#if NUNIT4
-using NUnit.Framework.Legacy;
-#else
-using ClassicAssert = NUnit.Framework.Assert;
-#endif
 
 namespace NUnit.Analyzers.Tests.Constants
 {
@@ -22,10 +14,10 @@ namespace NUnit.Analyzers.Tests.Constants
     /// to the NUnit concepts that they represent.
     /// </summary>
     [TestFixture]
-    public sealed class NUnitFrameworkConstantsTests
+    internal sealed class NUnitFrameworkConstantsTests : BaseNUnitFrameworkConstantsTests<NUnitFrameworkConstants>
     {
-        private static readonly (string Constant, string TypeName)[] NameOfSource = new (string Constant, string TypeName)[]
-        {
+        public static readonly (string Constant, string TypeName)[] NameOfSource =
+        [
             (nameof(NUnitFrameworkConstants.NameOfIs), nameof(Is)),
             (nameof(NUnitFrameworkConstants.NameOfIsFalse), nameof(Is.False)),
             (nameof(NUnitFrameworkConstants.NameOfIsTrue), nameof(Is.True)),
@@ -72,13 +64,6 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfHasMember), nameof(Has.Member)),
 
             (nameof(NUnitFrameworkConstants.NameOfMultiple), nameof(Assert.Multiple)),
-#if NUNIT4
-            (nameof(NUnitFrameworkConstants.NameOfMultipleAsync), nameof(Assert.MultipleAsync)),
-            (nameof(NUnitFrameworkConstants.NameOfEnterMultipleScope), nameof(Assert.EnterMultipleScope)),
-#else
-            (nameof(NUnitFrameworkConstants.NameOfMultipleAsync), "MultipleAsync"),
-            (nameof(NUnitFrameworkConstants.NameOfEnterMultipleScope), "EnterMultipleScope"),
-#endif
 
             (nameof(NUnitFrameworkConstants.NameOfOut), nameof(TestContext.Out)),
             (nameof(NUnitFrameworkConstants.NameOfWrite), nameof(TestContext.Out.Write)),
@@ -99,70 +84,12 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfAssertIgnore), nameof(Assert.Ignore)),
             (nameof(NUnitFrameworkConstants.NameOfAssertInconclusive), nameof(Assert.Inconclusive)),
 
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsTrue), nameof(ClassicAssert.IsTrue)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertTrue), nameof(ClassicAssert.True)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsFalse), nameof(ClassicAssert.IsFalse)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertFalse), nameof(ClassicAssert.False)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertAreEqual), nameof(ClassicAssert.AreEqual)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertAreNotEqual), nameof(ClassicAssert.AreNotEqual)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertAreSame), nameof(ClassicAssert.AreSame)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertAreNotSame), nameof(ClassicAssert.AreNotSame)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertNull), nameof(ClassicAssert.Null)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsNull), nameof(ClassicAssert.IsNull)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsNotNull), nameof(ClassicAssert.IsNotNull)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertNotNull), nameof(ClassicAssert.NotNull)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertThat), nameof(ClassicAssert.That)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertGreater), nameof(ClassicAssert.Greater)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertGreaterOrEqual), nameof(ClassicAssert.GreaterOrEqual)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertLess), nameof(ClassicAssert.Less)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertLessOrEqual), nameof(ClassicAssert.LessOrEqual)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertZero), nameof(ClassicAssert.Zero)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertNotZero), nameof(ClassicAssert.NotZero)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsNaN), nameof(ClassicAssert.IsNaN)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsEmpty), nameof(ClassicAssert.IsEmpty)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsNotEmpty), nameof(ClassicAssert.IsNotEmpty)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertContains), nameof(ClassicAssert.Contains)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsInstanceOf), nameof(ClassicAssert.IsInstanceOf)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsNotInstanceOf), nameof(ClassicAssert.IsNotInstanceOf)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertPositive), nameof(ClassicAssert.Positive)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertNegative), nameof(ClassicAssert.Negative)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsAssignableFrom), nameof(ClassicAssert.IsAssignableFrom)),
-            (nameof(NUnitFrameworkConstants.NameOfAssertIsNotAssignableFrom), nameof(ClassicAssert.IsNotAssignableFrom)),
+            (nameof(NUnitFrameworkConstants.NameOfAssertThat), nameof(Assert.That)),
 
             (nameof(NUnitFrameworkConstants.NameOfAssertCatch), nameof(Assert.Catch)),
             (nameof(NUnitFrameworkConstants.NameOfAssertCatchAsync), nameof(Assert.CatchAsync)),
             (nameof(NUnitFrameworkConstants.NameOfAssertThrows), nameof(Assert.Throws)),
             (nameof(NUnitFrameworkConstants.NameOfAssertThrowsAsync), nameof(Assert.ThrowsAsync)),
-
-            (nameof(NUnitFrameworkConstants.NameOfStringAssert), nameof(StringAssert)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertContains), nameof(StringAssert.Contains)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotContain), nameof(StringAssert.DoesNotContain)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertStartsWith), nameof(StringAssert.StartsWith)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotStartWith), nameof(StringAssert.DoesNotStartWith)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertEndsWith), nameof(StringAssert.EndsWith)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotEndWith), nameof(StringAssert.DoesNotEndWith)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertAreEqualIgnoringCase), nameof(StringAssert.AreEqualIgnoringCase)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertAreNotEqualIgnoringCase), nameof(StringAssert.AreNotEqualIgnoringCase)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertIsMatch), nameof(StringAssert.IsMatch)),
-            (nameof(NUnitFrameworkConstants.NameOfStringAssertDoesNotMatch), nameof(StringAssert.DoesNotMatch)),
-
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssert), nameof(CollectionAssert)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAllItemsAreInstancesOfType), nameof(CollectionAssert.AllItemsAreInstancesOfType)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAllItemsAreNotNull), nameof(CollectionAssert.AllItemsAreNotNull)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAllItemsAreUnique), nameof(CollectionAssert.AllItemsAreUnique)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAreEqual), nameof(CollectionAssert.AreEqual)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAreEquivalent), nameof(CollectionAssert.AreEquivalent)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAreNotEqual), nameof(CollectionAssert.AreNotEqual)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertAreNotEquivalent), nameof(CollectionAssert.AreNotEquivalent)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertContains), nameof(CollectionAssert.Contains)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertDoesNotContain), nameof(CollectionAssert.DoesNotContain)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsNotSubsetOf), nameof(CollectionAssert.IsNotSubsetOf)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsSubsetOf), nameof(CollectionAssert.IsSubsetOf)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsNotSupersetOf), nameof(CollectionAssert.IsNotSupersetOf)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsSupersetOf), nameof(CollectionAssert.IsSupersetOf)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsEmpty), nameof(CollectionAssert.IsEmpty)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsNotEmpty), nameof(CollectionAssert.IsNotEmpty)),
-            (nameof(NUnitFrameworkConstants.NameOfCollectionAssertIsOrdered), nameof(CollectionAssert.IsOrdered)),
 
             (nameof(NUnitFrameworkConstants.NameOfConstraint), nameof(Constraint)),
 
@@ -178,8 +105,6 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfSetUpAttribute), nameof(SetUpAttribute)),
             (nameof(NUnitFrameworkConstants.NameOfTearDownAttribute), nameof(TearDownAttribute)),
 
-            (nameof(NUnitFrameworkConstants.NameOfCancelAfterAttribute), nameof(CancelAfterAttribute)),
-
             (nameof(NUnitFrameworkConstants.NameOfExpectedResult), nameof(TestAttribute.ExpectedResult)),
 
             (nameof(NUnitFrameworkConstants.NameOfConstraintExpressionAnd), nameof(EqualConstraint.And)),
@@ -190,12 +115,10 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.NameOfEqualConstraintUsing), nameof(EqualConstraint.Using)),
             (nameof(NUnitFrameworkConstants.NameOfEqualConstraintWithin), nameof(EqualConstraint.Within)),
             (nameof(NUnitFrameworkConstants.NameOfEqualConstraintAsCollection), nameof(EqualConstraint.AsCollection)),
+        ];
 
-            (nameof(NUnitFrameworkConstants.NameOfClassicAssert), "ClassicAssert"),
-        };
-
-        private static readonly (string Constant, Type Type)[] FullNameOfTypeSource = new (string Constant, Type Type)[]
-        {
+        public static readonly (string Constant, Type Type)[] FullNameOfTypeSource =
+        [
             (nameof(NUnitFrameworkConstants.FullNameOfTypeIs), typeof(Is)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeTestCaseAttribute), typeof(TestCaseAttribute)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeTestCaseSourceAttribute), typeof(TestCaseSourceAttribute)),
@@ -217,9 +140,6 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.FullNameOfFixtureLifeCycleAttribute), typeof(FixtureLifeCycleAttribute)),
             (nameof(NUnitFrameworkConstants.FullNameOfLifeCycle), typeof(LifeCycle)),
 
-            (nameof(NUnitFrameworkConstants.FullNameOfCancelAfterAttribute), typeof(CancelAfterAttribute)),
-            (nameof(NUnitFrameworkConstants.FullNameOfCancellationToken), typeof(CancellationToken)),
-
             (nameof(NUnitFrameworkConstants.FullNameOfTypeTestContext), typeof(TestContext)),
 
             (nameof(NUnitFrameworkConstants.FullNameOfSameAsConstraint), typeof(SameAsConstraint)),
@@ -238,36 +158,16 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.FullNameOfDelayedConstraint), typeof(DelayedConstraint)),
             (nameof(NUnitFrameworkConstants.FullNameOfTestDelegate), typeof(TestDelegate)),
             (nameof(NUnitFrameworkConstants.FullNameOfThrows), typeof(Throws)),
-        };
+        ];
 
-        [TestCaseSource(nameof(NameOfSource))]
-        public void TestNameOfConstants((string Constant, string TypeName) pair)
-        {
-            Assert.That(GetValue(pair.Constant), Is.EqualTo(pair.TypeName), pair.Constant);
-        }
+        protected override IEnumerable<string> Names => Constant(NameOfSource);
 
-        [TestCaseSource(nameof(FullNameOfTypeSource))]
-        public void TestFullNameOfConstants((string Constant, Type Type) pair)
-        {
-            Assert.That(GetValue(pair.Constant), Is.EqualTo(pair.Type.FullName), pair.Constant);
-        }
+        protected override IEnumerable<string> FullNames => Constant(FullNameOfTypeSource);
 
         [Test]
         public void TestPrefixOfAllEqualConstraints()
         {
             Assert.That(NUnitFrameworkConstants.PrefixOfAllEqualToConstraints, Is.EqualTo("NUnit.Framework.Constraints.Equal"));
-        }
-
-        [Test]
-        public void NameOfAssertAreEqualParameters()
-        {
-            var parameters = typeof(ClassicAssert).GetMethods()
-                .First(m => m.Name == nameof(ClassicAssert.AreEqual))
-                .GetParameters();
-            var parameterNames = parameters.Select(p => p.Name);
-
-            Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfActualParameter));
-            Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfExpectedParameter));
         }
 
         [Test]
@@ -285,21 +185,6 @@ namespace NUnit.Analyzers.Tests.Constants
             Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfConditionParameter));
         }
 
-        [TestCase(nameof(ClassicAssert.True))]
-        [TestCase(nameof(ClassicAssert.IsTrue))]
-        [TestCase(nameof(ClassicAssert.False))]
-        [TestCase(nameof(ClassicAssert.IsFalse))]
-        [TestCase(nameof(ClassicAssert.IsTrue))]
-        public void NameOfAssertConditionParameters(string method)
-        {
-            var parameters = typeof(ClassicAssert).GetMethods()
-                .First(m => m.Name == method)
-                .GetParameters();
-            var parameterNames = parameters.Select(p => p.Name);
-
-            Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfConditionParameter));
-        }
-
         [Test]
         public void NUnitAssemblyNameTest()
         {
@@ -310,46 +195,5 @@ namespace NUnit.Analyzers.Tests.Constants
                 Is.EqualTo(typeof(Assert).Assembly.GetName().Name));
 #pragma warning restore NUnit2007 // The actual value should not be a constant
         }
-
-        [Test]
-        public void NUnitLegacyAssemblyNameTest()
-        {
-            // We are testing that the value of the constant is correct
-#pragma warning disable NUnit2007 // The actual value should not be a constant
-#if NUNIT4
-            Assert.That(NUnitFrameworkConstants.NUnitFrameworkLegacyAssemblyName,
-#else
-            Assert.That(NUnitFrameworkConstants.NUnitFrameworkAssemblyName,
-#endif
-                Is.EqualTo(typeof(ClassicAssert).Assembly.GetName().Name));
-#pragma warning restore NUnit2007 // The actual value should not be a constant
-        }
-
-        [Test]
-        public void EnsureAllNameOfDefinitionsAreTested()
-        {
-            EnsureAllNameDefinitionsAreTested("NameOf", NameOfSource.Select(pair => pair.Constant));
-        }
-
-        [Test]
-        public void EnsureAllFullNameOfTypeDefinitionsAreTested()
-        {
-            EnsureAllNameDefinitionsAreTested("FullNameOf", FullNameOfTypeSource.Select(pair => pair.Constant));
-        }
-
-        private static void EnsureAllNameDefinitionsAreTested(string prefix, IEnumerable<string> testedNames)
-        {
-            IEnumerable<string> allNames =
-                typeof(NUnitFrameworkConstants).GetFields(BindingFlags.Public | BindingFlags.Static)
-                .Where(f => f.IsLiteral)
-                .Select(f => f.Name)
-                .Where(name => !name.EndsWith("Parameter", System.StringComparison.Ordinal))
-                .Where(name => name.StartsWith(prefix, System.StringComparison.Ordinal));
-
-            Assert.That(testedNames, Is.EquivalentTo(allNames));
-        }
-
-        private static string? GetValue(string fieldName) =>
-            typeof(NUnitFrameworkConstants).GetField(fieldName)?.GetRawConstantValue() as string;
     }
 }

--- a/src/nunit.analyzers.tests/Constants/NUnitLegacyFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitLegacyFrameworkConstantsTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Analyzers.Constants;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+#if NUNIT4
+using NUnit.Framework.Legacy;
+#else
+using ClassicAssert = NUnit.Framework.Assert;
+#endif
+
+namespace NUnit.Analyzers.Tests.Constants
+{
+    /// <summary>
+    /// Tests to ensure that the string constants in the analyzer project correspond
+    /// to the NUnit concepts that they represent.
+    /// </summary>
+    [TestFixture]
+    internal sealed class NUnitLegacyFrameworkConstantsTests : BaseNUnitFrameworkConstantsTests<NUnitLegacyFrameworkConstants>
+    {
+        public static readonly (string Constant, string TypeName)[] NameOfSource =
+        [
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsTrue), nameof(ClassicAssert.IsTrue)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertTrue), nameof(ClassicAssert.True)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsFalse), nameof(ClassicAssert.IsFalse)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertFalse), nameof(ClassicAssert.False)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertAreEqual), nameof(ClassicAssert.AreEqual)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertAreNotEqual), nameof(ClassicAssert.AreNotEqual)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertAreSame), nameof(ClassicAssert.AreSame)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertAreNotSame), nameof(ClassicAssert.AreNotSame)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertNull), nameof(ClassicAssert.Null)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsNull), nameof(ClassicAssert.IsNull)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsNotNull), nameof(ClassicAssert.IsNotNull)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertNotNull), nameof(ClassicAssert.NotNull)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertGreater), nameof(ClassicAssert.Greater)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertGreaterOrEqual), nameof(ClassicAssert.GreaterOrEqual)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertLess), nameof(ClassicAssert.Less)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertLessOrEqual), nameof(ClassicAssert.LessOrEqual)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertZero), nameof(ClassicAssert.Zero)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertNotZero), nameof(ClassicAssert.NotZero)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsNaN), nameof(ClassicAssert.IsNaN)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsEmpty), nameof(ClassicAssert.IsEmpty)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsNotEmpty), nameof(ClassicAssert.IsNotEmpty)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertContains), nameof(ClassicAssert.Contains)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsInstanceOf), nameof(ClassicAssert.IsInstanceOf)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsNotInstanceOf), nameof(ClassicAssert.IsNotInstanceOf)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertPositive), nameof(ClassicAssert.Positive)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertNegative), nameof(ClassicAssert.Negative)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsAssignableFrom), nameof(ClassicAssert.IsAssignableFrom)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfAssertIsNotAssignableFrom), nameof(ClassicAssert.IsNotAssignableFrom)),
+
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssert), nameof(StringAssert)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertContains), nameof(StringAssert.Contains)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotContain), nameof(StringAssert.DoesNotContain)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertStartsWith), nameof(StringAssert.StartsWith)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotStartWith), nameof(StringAssert.DoesNotStartWith)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertEndsWith), nameof(StringAssert.EndsWith)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotEndWith), nameof(StringAssert.DoesNotEndWith)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertAreEqualIgnoringCase), nameof(StringAssert.AreEqualIgnoringCase)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertAreNotEqualIgnoringCase), nameof(StringAssert.AreNotEqualIgnoringCase)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertIsMatch), nameof(StringAssert.IsMatch)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfStringAssertDoesNotMatch), nameof(StringAssert.DoesNotMatch)),
+
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssert), nameof(CollectionAssert)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAllItemsAreInstancesOfType), nameof(CollectionAssert.AllItemsAreInstancesOfType)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAllItemsAreNotNull), nameof(CollectionAssert.AllItemsAreNotNull)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAllItemsAreUnique), nameof(CollectionAssert.AllItemsAreUnique)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreEqual), nameof(CollectionAssert.AreEqual)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreEquivalent), nameof(CollectionAssert.AreEquivalent)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreNotEqual), nameof(CollectionAssert.AreNotEqual)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertAreNotEquivalent), nameof(CollectionAssert.AreNotEquivalent)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertContains), nameof(CollectionAssert.Contains)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertDoesNotContain), nameof(CollectionAssert.DoesNotContain)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsNotSubsetOf), nameof(CollectionAssert.IsNotSubsetOf)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsSubsetOf), nameof(CollectionAssert.IsSubsetOf)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsNotSupersetOf), nameof(CollectionAssert.IsNotSupersetOf)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsSupersetOf), nameof(CollectionAssert.IsSupersetOf)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsEmpty), nameof(CollectionAssert.IsEmpty)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsNotEmpty), nameof(CollectionAssert.IsNotEmpty)),
+            (nameof(NUnitLegacyFrameworkConstants.NameOfCollectionAssertIsOrdered), nameof(CollectionAssert.IsOrdered)),
+
+            (nameof(NUnitLegacyFrameworkConstants.NameOfClassicAssert), "ClassicAssert"),
+        ];
+
+        protected override IEnumerable<string> Names => Constant(NameOfSource);
+
+        protected override IEnumerable<string> FullNames => [];
+
+        [Test]
+        public void NameOfAssertAreEqualParameters()
+        {
+            var parameters = typeof(ClassicAssert).GetMethods()
+                .First(m => m.Name == nameof(ClassicAssert.AreEqual))
+                .GetParameters();
+            var parameterNames = parameters.Select(p => p.Name);
+
+            Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfActualParameter));
+            Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfExpectedParameter));
+        }
+
+        [TestCase(nameof(ClassicAssert.True))]
+        [TestCase(nameof(ClassicAssert.IsTrue))]
+        [TestCase(nameof(ClassicAssert.False))]
+        [TestCase(nameof(ClassicAssert.IsFalse))]
+        [TestCase(nameof(ClassicAssert.IsTrue))]
+        public void NameOfAssertConditionParameters(string method)
+        {
+            var parameters = typeof(ClassicAssert).GetMethods()
+                .First(m => m.Name == method)
+                .GetParameters();
+            var parameterNames = parameters.Select(p => p.Name);
+
+            Assert.That(parameterNames, Does.Contain(NUnitFrameworkConstants.NameOfConditionParameter));
+        }
+
+        [Test]
+        public void NUnitLegacyAssemblyNameTest()
+        {
+            // We are testing that the value of the constant is correct
+#pragma warning disable NUnit2007 // The actual value should not be a constant
+#if NUNIT4
+            Assert.That(NUnitLegacyFrameworkConstants.NUnitFrameworkLegacyAssemblyName,
+#else
+            Assert.That(NUnitFrameworkConstants.NUnitFrameworkAssemblyName,
+#endif
+                Is.EqualTo(typeof(ClassicAssert).Assembly.GetName().Name));
+#pragma warning restore NUnit2007 // The actual value should not be a constant
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/Constants/NUnitV4FrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitV4FrameworkConstantsTests.cs
@@ -1,0 +1,39 @@
+#if NUNIT4
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Analyzers.Constants;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Analyzers.Tests.Constants
+{
+    /// <summary>
+    /// Tests to ensure that the string constants in the analyzer project correspond
+    /// to the NUnit concepts that they represent.
+    /// </summary>
+    [TestFixture]
+    internal sealed class NUnitV4FrameworkConstantsTests : BaseNUnitFrameworkConstantsTests<NUnitV4FrameworkConstants>
+    {
+        public static readonly (string Constant, string TypeName)[] NameOfSource =
+        [
+            (nameof(NUnitV4FrameworkConstants.NameOfIsDefault), nameof(Is.Default)),
+            (nameof(NUnitV4FrameworkConstants.NameOfMultipleAsync), nameof(Assert.MultipleAsync)),
+            (nameof(NUnitV4FrameworkConstants.NameOfEnterMultipleScope), nameof(Assert.EnterMultipleScope)),
+
+            (nameof(NUnitV4FrameworkConstants.NameOfCancelAfterAttribute), nameof(CancelAfterAttribute)),
+        ];
+
+        public static readonly (string Constant, Type Type)[] FullNameOfTypeSource =
+        [
+            (nameof(NUnitV4FrameworkConstants.FullNameOfCancelAfterAttribute), typeof(CancelAfterAttribute)),
+            (nameof(NUnitV4FrameworkConstants.FullNameOfCancellationToken), typeof(CancellationToken)),
+        ];
+
+        protected override IEnumerable<string> Names => Constant(NameOfSource);
+
+        protected override IEnumerable<string> FullNames => Constant(FullNameOfTypeSource);
+    }
+}
+
+#endif

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -215,7 +215,7 @@ namespace NUnit.Analyzers.Tests
 
         [TestCase(Categories.Structure, 0)]
         [TestCase(Categories.Assertion, 1)]
-        [TestCase(Categories.Style, 2)]
+        [TestCase(Categories.Style, 3)]
         public void EnsureThatAnalyzerIndexIsAsExpected(string category, int tableNumber)
         {
             var builder = new StringBuilder();

--- a/src/nunit.analyzers.tests/DocumentationTests.cs
+++ b/src/nunit.analyzers.tests/DocumentationTests.cs
@@ -215,6 +215,7 @@ namespace NUnit.Analyzers.Tests
 
         [TestCase(Categories.Structure, 0)]
         [TestCase(Categories.Assertion, 1)]
+        [TestCase(Categories.Style, 2)]
         public void EnsureThatAnalyzerIndexIsAsExpected(string category, int tableNumber)
         {
             var builder = new StringBuilder();

--- a/src/nunit.analyzers.tests/Extensions/IMethodSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/IMethodSymbolExtensionsTests.cs
@@ -48,7 +48,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
     }
 }";
             var (method, compilation) = await GetMethodSymbolAsync(testCode).ConfigureAwait(false);
-            INamedTypeSymbol? cancellationTokenType = compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancellationToken);
+            INamedTypeSymbol? cancellationTokenType = compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancellationToken);
 
             var (requiredParameters, optionalParameters, paramsCount) = method.GetParameterCounts(hasCancelAfter, cancellationTokenType);
             int adjustment = hasCancelAfter ? 0 : 1;

--- a/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
+++ b/src/nunit.analyzers.tests/Extensions/ITypeSymbolExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenThisIsNull" }).ConfigureAwait(false);
+                ["IsAssignableFromWhenThisIsNull"]).ConfigureAwait(false);
             var other = types[0];
 
             Assert.That(default(ITypeSymbol).IsAssignableFrom(other), Is.False);
@@ -39,7 +39,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsNull" }).ConfigureAwait(false);
+                ["IsAssignableFromWhenOtherIsNull"]).ConfigureAwait(false);
             var instance = types[0];
 
             Assert.That(instance.IsAssignableFrom(default(ITypeSymbol)), Is.False);
@@ -55,7 +55,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsSameTypeAsThis" }).ConfigureAwait(false);
+                ["IsAssignableFromWhenOtherIsSameTypeAsThis"]).ConfigureAwait(false);
             var instance = types[0];
             var other = instance;
 
@@ -72,11 +72,11 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types1 = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" }).ConfigureAwait(false);
+                ["IsAssignableFromWhenOtherIsInDifferentAssembly"]).ConfigureAwait(false);
             var instance = types1[0];
             var types2 = await GetTypeSymbolAsync(
                 testCode,
-                new[] { "IsAssignableFromWhenOtherIsInDifferentAssembly" }).ConfigureAwait(false);
+                ["IsAssignableFromWhenOtherIsInDifferentAssembly"]).ConfigureAwait(false);
             var other = types2[0];
 
             Assert.That(instance.IsAssignableFrom(other), Is.False);
@@ -96,11 +96,10 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[]
-                {
+                [
                     "IsAssignableFromWhenOtherIsASubclassBase",
                     "IsAssignableFromWhenOtherIsASubclassSub"
-                }).ConfigureAwait(false);
+                ]).ConfigureAwait(false);
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.True);
         }
@@ -117,11 +116,10 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[]
-                {
+                [
                     "IsAssignableFromWhenOtherIsNotASubclassA",
                     "IsAssignableFromWhenOtherIsNotASubclassB"
-                }).ConfigureAwait(false);
+                ]).ConfigureAwait(false);
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.False);
         }
@@ -140,11 +138,10 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
 }";
             var types = await GetTypeSymbolAsync(
                 testCode,
-                new[]
-                {
+                [
                     "IsAssignableFromWhenOtherImplementsInterface",
                     "IsAssignableFromWhenOtherImplementsInterfaceType"
-                }).ConfigureAwait(false);
+                ]).ConfigureAwait(false);
 
             Assert.That(types[0].IsAssignableFrom(types[1]), Is.True);
         }
@@ -234,7 +231,7 @@ namespace NUnit.Analyzers.Tests.Targets.Extensions
             VariableDeclaratorSyntax variableDeclaration = fieldNode.Declaration.Variables[0];
             IFieldSymbol? symbol = rootAndModel.Model.GetDeclaredSymbol(variableDeclaration) as IFieldSymbol;
             Assert.That(symbol, Is.Not.Null, $"Cannot find symbol for {variableDeclaration.Identifier}");
-            Assert.That(symbol.Type.Kind, Is.Not.EqualTo(SymbolKind.ErrorType), $"Cannot find type for {fieldNode.ToString()}");
+            Assert.That(symbol.Type.Kind, Is.Not.EqualTo(SymbolKind.ErrorType), $"Cannot find type for {fieldNode}");
 
             return symbol.Type;
         }

--- a/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintAnalyzerTests.cs
@@ -1,0 +1,60 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.UseSpecificConstraint;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.UseSpecificConstraint
+{
+    public class UseSpecificConstraintAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new UseSpecificConstraintAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.UseSpecificConstraint);
+
+        private static readonly string[][] EqualToSpecificConstraint =
+        [
+            ["false", "False"],
+#if NUNIT4
+            ["default(bool)", "Default"],
+#else
+            ["default(bool)", "False"],
+#endif
+            ["true", "True"],
+
+            ["null", "Null"],
+            ["default(object)", "Null"],
+            ["default(string)", "Null"],
+#if NUNIT4
+            ["default(int)", "Default"],
+#endif
+        ];
+
+        [TestCaseSource(nameof(EqualToSpecificConstraint))]
+        public void AnalyzeForSpecificConstraint(string literal, string constraint) => AnalyzeForEqualTo(literal, constraint);
+
+#if NUNIT4
+        [Test]
+        public void AnalyzeForIsDefault() => AnalyzeForEqualTo("default", "Default",
+            Settings.Default.WithAllowedCompilerDiagnostics(AllowedCompilerDiagnostics.WarningsAndErrors));
+#endif
+
+        private static void AnalyzeForEqualTo(string literal, string constraint, Settings? settings = null)
+        {
+            AnalyzeForEqualTo("Is", string.Empty, literal, constraint, settings);
+            AnalyzeForEqualTo("Is", ".And.Not.Empty", literal, constraint, settings);
+            AnalyzeForEqualTo("Is.Not", string.Empty, literal, constraint, settings);
+            AnalyzeForEqualTo("Is.EqualTo(0).Or", string.Empty, literal, constraint, settings);
+        }
+
+        private static void AnalyzeForEqualTo(string prefix, string suffix, string literal, string constraint, Settings? settings = null)
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(false, ↓{prefix}.EqualTo({literal}){suffix});");
+
+            RoslynAssert.Diagnostics(analyzer,
+                expectedDiagnostic.WithMessage($"Replace 'Is.EqualTo({literal})' with 'Is.{constraint}' constraint"),
+                testCode, settings);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintCodeFixTests.cs
@@ -1,0 +1,66 @@
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.UseSpecificConstraint;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.UseSpecificConstraint
+{
+    public class UseSpecificConstraintCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new UseSpecificConstraintAnalyzer();
+        private static readonly CodeFixProvider fix = new UseSpecificConstraintCodeFix();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.UseSpecificConstraint);
+
+        private static readonly string[][] EqualToSpecificConstraint =
+        [
+            ["false", "False"],
+#if NUNIT4
+            ["default(bool)", "Default"],
+#else
+            ["default(bool)", "False"],
+#endif
+            ["true", "True"],
+
+            ["null", "Null"],
+            ["default(object)", "Null"],
+            ["default(string)", "Null"],
+#if NUNIT4
+            ["default(int)", "Default"],
+#endif
+        ];
+
+        [TestCaseSource(nameof(EqualToSpecificConstraint))]
+        public void AnalyzeForSpecificConstraint(string literal, string constraint) => AnalyzeForEqualTo(literal, constraint);
+
+#if NUNIT4
+        [Test]
+        public void AnalyzeForIsDefault() => AnalyzeForEqualTo("default", "Default",
+            Settings.Default.WithAllowedCompilerDiagnostics(AllowedCompilerDiagnostics.WarningsAndErrors));
+#endif
+
+        private static void AnalyzeForEqualTo(string literal, string constraint, Settings? settings = null)
+        {
+            AnalyzeForEqualTo("Is", string.Empty, literal, constraint, settings);
+            AnalyzeForEqualTo("Is", ".And.Not.Empty", literal, constraint, settings);
+            AnalyzeForEqualTo("Is.Not", string.Empty, literal, constraint, settings);
+            AnalyzeForEqualTo("Is.EqualTo(0).Or", string.Empty, literal, constraint, settings);
+        }
+
+        private static void AnalyzeForEqualTo(string prefix, string suffix, string literal, string constraint, Settings? settings = null)
+        {
+            var testCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(false, ↓{prefix}.EqualTo({literal}){suffix});");
+
+            var fixedCode = TestUtility.WrapInTestMethod(
+                $"Assert.That(false, {prefix}.{constraint}{suffix});");
+
+            RoslynAssert.CodeFix(analyzer, fix,
+                expectedDiagnostic.WithMessage($"Replace 'Is.EqualTo({literal})' with 'Is.{constraint}' constraint"),
+                testCode, fixedCode,
+                settings: settings);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\nunit.analyzers\nunit.analyzers.csproj" OutputItemType="Analyzer" />
-    <ProjectReference Include="..\nunit.analyzers.codefixes\nunit.analyzers.codefixes.csproj"  OutputItemType="Analyzer" />
+    <ProjectReference Include="..\nunit.analyzers.codefixes\nunit.analyzers.codefixes.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>

--- a/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/ClassicModelAssertUsage/ClassicModelAssertUsageAnalyzer.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Helpers;
-using static NUnit.Analyzers.Constants.NUnitFrameworkConstants;
+using static NUnit.Analyzers.Constants.NUnitLegacyFrameworkConstants;
 
 namespace NUnit.Analyzers.ClassicModelAssertUsage
 {

--- a/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/CollectionAssertUsage/CollectionAssertUsageAnalyzer.cs
@@ -6,7 +6,9 @@ using Microsoft.CodeAnalysis.Operations;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
 using NUnit.Analyzers.Helpers;
+
 using static NUnit.Analyzers.Constants.NUnitFrameworkConstants;
+using static NUnit.Analyzers.Constants.NUnitLegacyFrameworkConstants;
 
 namespace NUnit.Analyzers.CollectionAssertUsage
 {

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -111,6 +111,7 @@ namespace NUnit.Analyzers.Constants
         #region Style
 
         internal const string SimplifyValues = "NUnit4001";
+        internal const string UseSpecificConstraint = "NUnit4002";
 
         #endregion
     }

--- a/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerPropertyKeys.cs
@@ -7,5 +7,7 @@ namespace NUnit.Analyzers.Constants
         internal const string MinimumNumberOfArguments = nameof(AnalyzerPropertyKeys.MinimumNumberOfArguments);
 
         internal const string SupportsEnterMultipleScope = nameof(AnalyzerPropertyKeys.SupportsEnterMultipleScope);
+
+        internal const string SpecificConstraint = nameof(AnalyzerPropertyKeys.SpecificConstraint);
     }
 }

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -3,8 +3,9 @@ namespace NUnit.Analyzers.Constants
     /// <summary>
     /// String constants for relevant NUnit concepts (classes, fields, properties etc.)
     /// so that we do not need have a dependency on NUnit from the analyzer project.
+    /// These are constants for NUnit v3 and later.
     /// </summary>
-    public static class NUnitFrameworkConstants
+    internal abstract class NUnitFrameworkConstants
     {
         public const string NameOfIs = "Is";
         public const string NameOfIsFalse = "False";
@@ -52,8 +53,6 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfHasMember = "Member";
 
         public const string NameOfMultiple = "Multiple";
-        public const string NameOfMultipleAsync = "MultipleAsync";
-        public const string NameOfEnterMultipleScope = "EnterMultipleScope";
 
         public const string NameOfOut = "Out";
         public const string NameOfWrite = "Write";
@@ -74,70 +73,12 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfAssertIgnore = "Ignore";
         public const string NameOfAssertInconclusive = "Inconclusive";
 
-        public const string NameOfAssertIsTrue = "IsTrue";
-        public const string NameOfAssertTrue = "True";
-        public const string NameOfAssertIsFalse = "IsFalse";
-        public const string NameOfAssertFalse = "False";
-        public const string NameOfAssertAreEqual = "AreEqual";
-        public const string NameOfAssertAreNotEqual = "AreNotEqual";
-        public const string NameOfAssertAreSame = "AreSame";
-        public const string NameOfAssertAreNotSame = "AreNotSame";
-        public const string NameOfAssertNull = "Null";
-        public const string NameOfAssertIsNull = "IsNull";
-        public const string NameOfAssertNotNull = "NotNull";
-        public const string NameOfAssertIsNotNull = "IsNotNull";
         public const string NameOfAssertThat = "That";
-        public const string NameOfAssertGreater = "Greater";
-        public const string NameOfAssertGreaterOrEqual = "GreaterOrEqual";
-        public const string NameOfAssertLess = "Less";
-        public const string NameOfAssertLessOrEqual = "LessOrEqual";
-        public const string NameOfAssertZero = "Zero";
-        public const string NameOfAssertNotZero = "NotZero";
-        public const string NameOfAssertIsNaN = "IsNaN";
-        public const string NameOfAssertIsEmpty = "IsEmpty";
-        public const string NameOfAssertIsNotEmpty = "IsNotEmpty";
-        public const string NameOfAssertContains = "Contains";
-        public const string NameOfAssertIsInstanceOf = "IsInstanceOf";
-        public const string NameOfAssertIsNotInstanceOf = "IsNotInstanceOf";
-        public const string NameOfAssertIsAssignableFrom = "IsAssignableFrom";
-        public const string NameOfAssertIsNotAssignableFrom = "IsNotAssignableFrom";
-        public const string NameOfAssertPositive = "Positive";
-        public const string NameOfAssertNegative = "Negative";
 
         public const string NameOfAssertCatch = "Catch";
         public const string NameOfAssertCatchAsync = "CatchAsync";
         public const string NameOfAssertThrows = "Throws";
         public const string NameOfAssertThrowsAsync = "ThrowsAsync";
-
-        public const string NameOfStringAssert = "StringAssert";
-        public const string NameOfStringAssertContains = "Contains";
-        public const string NameOfStringAssertDoesNotContain = "DoesNotContain";
-        public const string NameOfStringAssertStartsWith = "StartsWith";
-        public const string NameOfStringAssertDoesNotStartWith = "DoesNotStartWith";
-        public const string NameOfStringAssertEndsWith = "EndsWith";
-        public const string NameOfStringAssertDoesNotEndWith = "DoesNotEndWith";
-        public const string NameOfStringAssertAreEqualIgnoringCase = "AreEqualIgnoringCase";
-        public const string NameOfStringAssertAreNotEqualIgnoringCase = "AreNotEqualIgnoringCase";
-        public const string NameOfStringAssertIsMatch = "IsMatch";
-        public const string NameOfStringAssertDoesNotMatch = "DoesNotMatch";
-
-        public const string NameOfCollectionAssert = "CollectionAssert";
-        public const string NameOfCollectionAssertAllItemsAreInstancesOfType = "AllItemsAreInstancesOfType";
-        public const string NameOfCollectionAssertAllItemsAreNotNull = "AllItemsAreNotNull";
-        public const string NameOfCollectionAssertAllItemsAreUnique = "AllItemsAreUnique";
-        public const string NameOfCollectionAssertAreEqual = "AreEqual";
-        public const string NameOfCollectionAssertAreEquivalent = "AreEquivalent";
-        public const string NameOfCollectionAssertAreNotEqual = "AreNotEqual";
-        public const string NameOfCollectionAssertAreNotEquivalent = "AreNotEquivalent";
-        public const string NameOfCollectionAssertContains = "Contains";
-        public const string NameOfCollectionAssertDoesNotContain = "DoesNotContain";
-        public const string NameOfCollectionAssertIsNotSubsetOf = "IsNotSubsetOf";
-        public const string NameOfCollectionAssertIsSubsetOf = "IsSubsetOf";
-        public const string NameOfCollectionAssertIsNotSupersetOf = "IsNotSupersetOf";
-        public const string NameOfCollectionAssertIsSupersetOf = "IsSupersetOf";
-        public const string NameOfCollectionAssertIsEmpty = "IsEmpty";
-        public const string NameOfCollectionAssertIsNotEmpty = "IsNotEmpty";
-        public const string NameOfCollectionAssertIsOrdered = "IsOrdered";
 
         public const string FullNameOfTypeIs = "NUnit.Framework.Is";
         public const string FullNameOfTypeTestCaseAttribute = "NUnit.Framework.TestCaseAttribute";
@@ -160,9 +101,6 @@ namespace NUnit.Analyzers.Constants
 
         public const string FullNameOfFixtureLifeCycleAttribute = "NUnit.Framework.FixtureLifeCycleAttribute";
         public const string FullNameOfLifeCycle = "NUnit.Framework.LifeCycle";
-
-        public const string FullNameOfCancelAfterAttribute = "NUnit.Framework.CancelAfterAttribute";
-        public const string FullNameOfCancellationToken = "System.Threading.CancellationToken";
 
         public const string FullNameOfTypeTestContext = "NUnit.Framework.TestContext";
 
@@ -199,8 +137,6 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfSetUpAttribute = "SetUpAttribute";
         public const string NameOfTearDownAttribute = "TearDownAttribute";
 
-        public const string NameOfCancelAfterAttribute = "CancelAfterAttribute";
-
         public const string NameOfExpectedResult = "ExpectedResult";
 
         public const string NameOfActualParameter = "actual";
@@ -232,8 +168,5 @@ namespace NUnit.Analyzers.Constants
         public const string NameOfEqualConstraintAsCollection = "AsCollection";
 
         public const string NUnitFrameworkAssemblyName = "nunit.framework";
-
-        public const string NUnitFrameworkLegacyAssemblyName = "nunit.framework.legacy";
-        public const string NameOfClassicAssert = "ClassicAssert";
     }
 }

--- a/src/nunit.analyzers/Constants/NUnitLegacyFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitLegacyFrameworkConstants.cs
@@ -1,0 +1,72 @@
+namespace NUnit.Analyzers.Constants
+{
+    /// <summary>
+    /// String constants for relevant NUnit concepts (classes, fields, properties etc.)
+    /// so that we do not need have a dependency on NUnit from the analyzer project.
+    /// These are constants for NUnit Legacy Framework.
+    /// </summary>
+    internal abstract class NUnitLegacyFrameworkConstants
+    {
+        public const string NameOfAssertIsTrue = "IsTrue";
+        public const string NameOfAssertTrue = "True";
+        public const string NameOfAssertIsFalse = "IsFalse";
+        public const string NameOfAssertFalse = "False";
+        public const string NameOfAssertAreEqual = "AreEqual";
+        public const string NameOfAssertAreNotEqual = "AreNotEqual";
+        public const string NameOfAssertAreSame = "AreSame";
+        public const string NameOfAssertAreNotSame = "AreNotSame";
+        public const string NameOfAssertNull = "Null";
+        public const string NameOfAssertIsNull = "IsNull";
+        public const string NameOfAssertNotNull = "NotNull";
+        public const string NameOfAssertIsNotNull = "IsNotNull";
+        public const string NameOfAssertGreater = "Greater";
+        public const string NameOfAssertGreaterOrEqual = "GreaterOrEqual";
+        public const string NameOfAssertLess = "Less";
+        public const string NameOfAssertLessOrEqual = "LessOrEqual";
+        public const string NameOfAssertZero = "Zero";
+        public const string NameOfAssertNotZero = "NotZero";
+        public const string NameOfAssertIsNaN = "IsNaN";
+        public const string NameOfAssertIsEmpty = "IsEmpty";
+        public const string NameOfAssertIsNotEmpty = "IsNotEmpty";
+        public const string NameOfAssertContains = "Contains";
+        public const string NameOfAssertIsInstanceOf = "IsInstanceOf";
+        public const string NameOfAssertIsNotInstanceOf = "IsNotInstanceOf";
+        public const string NameOfAssertIsAssignableFrom = "IsAssignableFrom";
+        public const string NameOfAssertIsNotAssignableFrom = "IsNotAssignableFrom";
+        public const string NameOfAssertPositive = "Positive";
+        public const string NameOfAssertNegative = "Negative";
+
+        public const string NameOfStringAssert = "StringAssert";
+        public const string NameOfStringAssertContains = "Contains";
+        public const string NameOfStringAssertDoesNotContain = "DoesNotContain";
+        public const string NameOfStringAssertStartsWith = "StartsWith";
+        public const string NameOfStringAssertDoesNotStartWith = "DoesNotStartWith";
+        public const string NameOfStringAssertEndsWith = "EndsWith";
+        public const string NameOfStringAssertDoesNotEndWith = "DoesNotEndWith";
+        public const string NameOfStringAssertAreEqualIgnoringCase = "AreEqualIgnoringCase";
+        public const string NameOfStringAssertAreNotEqualIgnoringCase = "AreNotEqualIgnoringCase";
+        public const string NameOfStringAssertIsMatch = "IsMatch";
+        public const string NameOfStringAssertDoesNotMatch = "DoesNotMatch";
+
+        public const string NameOfCollectionAssert = "CollectionAssert";
+        public const string NameOfCollectionAssertAllItemsAreInstancesOfType = "AllItemsAreInstancesOfType";
+        public const string NameOfCollectionAssertAllItemsAreNotNull = "AllItemsAreNotNull";
+        public const string NameOfCollectionAssertAllItemsAreUnique = "AllItemsAreUnique";
+        public const string NameOfCollectionAssertAreEqual = "AreEqual";
+        public const string NameOfCollectionAssertAreEquivalent = "AreEquivalent";
+        public const string NameOfCollectionAssertAreNotEqual = "AreNotEqual";
+        public const string NameOfCollectionAssertAreNotEquivalent = "AreNotEquivalent";
+        public const string NameOfCollectionAssertContains = "Contains";
+        public const string NameOfCollectionAssertDoesNotContain = "DoesNotContain";
+        public const string NameOfCollectionAssertIsNotSubsetOf = "IsNotSubsetOf";
+        public const string NameOfCollectionAssertIsSubsetOf = "IsSubsetOf";
+        public const string NameOfCollectionAssertIsNotSupersetOf = "IsNotSupersetOf";
+        public const string NameOfCollectionAssertIsSupersetOf = "IsSupersetOf";
+        public const string NameOfCollectionAssertIsEmpty = "IsEmpty";
+        public const string NameOfCollectionAssertIsNotEmpty = "IsNotEmpty";
+        public const string NameOfCollectionAssertIsOrdered = "IsOrdered";
+
+        public const string NUnitFrameworkLegacyAssemblyName = "nunit.framework.legacy";
+        public const string NameOfClassicAssert = "ClassicAssert";
+    }
+}

--- a/src/nunit.analyzers/Constants/NUnitV4FrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitV4FrameworkConstants.cs
@@ -1,0 +1,20 @@
+namespace NUnit.Analyzers.Constants
+{
+    /// <summary>
+    /// String constants for relevant NUnit concepts (classes, fields, properties etc.)
+    /// so that we do not need have a dependency on NUnit from the analyzer project.
+    /// These are constants for NUnit v4.
+    /// </summary>
+    internal abstract class NUnitV4FrameworkConstants
+    {
+        public const string NameOfIsDefault = "Default";
+
+        public const string NameOfMultipleAsync = "MultipleAsync";
+        public const string NameOfEnterMultipleScope = "EnterMultipleScope";
+
+        public const string NameOfCancelAfterAttribute = "CancelAfterAttribute";
+
+        public const string FullNameOfCancelAfterAttribute = "NUnit.Framework.CancelAfterAttribute";
+        public const string FullNameOfCancellationToken = "System.Threading.CancellationToken";
+    }
+}

--- a/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
+++ b/src/nunit.analyzers/ConstraintUsage/BaseConditionConstraintAnalyzer.cs
@@ -6,7 +6,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using NUnit.Analyzers.Extensions;
+
 using static NUnit.Analyzers.Constants.NUnitFrameworkConstants;
+using static NUnit.Analyzers.Constants.NUnitLegacyFrameworkConstants;
 
 namespace NUnit.Analyzers.ConstraintUsage
 {
@@ -15,18 +17,18 @@ namespace NUnit.Analyzers.ConstraintUsage
         internal const string SuggestedConstraintString = nameof(SuggestedConstraintString);
         internal const string SwapOperands = nameof(SwapOperands);
 
-        protected static readonly string[] SupportedPositiveAssertMethods = new[]
-        {
+        protected static readonly string[] SupportedPositiveAssertMethods =
+        [
             NameOfAssertThat,
             NameOfAssertTrue,
             NameOfAssertIsTrue
-        };
+        ];
 
-        protected static readonly string[] SupportedNegativeAssertMethods = new[]
-        {
+        protected static readonly string[] SupportedNegativeAssertMethods =
+        [
             NameOfAssertFalse,
             NameOfAssertIsFalse
-        };
+        ];
 
         protected static bool IsRefStruct(IOperation operation)
         {

--- a/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
+++ b/src/nunit.analyzers/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressor.cs
@@ -338,23 +338,23 @@ namespace NUnit.Analyzers.DiagnosticSuppressors
                         }
                     }
                 }
-                else if (member == NUnitFrameworkConstants.NameOfAssertNotNull ||
-                    member == NUnitFrameworkConstants.NameOfAssertIsNotNull)
+                else if (member == NUnitLegacyFrameworkConstants.NameOfAssertNotNull ||
+                    member == NUnitLegacyFrameworkConstants.NameOfAssertIsNotNull)
                 {
                     if (CoveredBy(firstArgument, possibleNullReference))
                     {
                         return true;
                     }
                 }
-                else if (member == NUnitFrameworkConstants.NameOfAssertIsTrue ||
-                         member == NUnitFrameworkConstants.NameOfAssertTrue)
+                else if (member == NUnitLegacyFrameworkConstants.NameOfAssertIsTrue ||
+                         member == NUnitLegacyFrameworkConstants.NameOfAssertTrue)
                 {
                     if (IsHasValue(firstArgument, possibleNullReference))
                     {
                         return true;
                     }
                 }
-                else if (member is NUnitFrameworkConstants.NameOfMultiple or NUnitFrameworkConstants.NameOfMultipleAsync)
+                else if (member is NUnitFrameworkConstants.NameOfMultiple or NUnitV4FrameworkConstants.NameOfMultipleAsync)
                 {
                     // Look up into the actual asserted parameter
                     if (argumentList.Arguments.FirstOrDefault()?.Expression is AnonymousFunctionExpressionSyntax anonymousFunction)

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -29,8 +29,8 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
             IOperation? actualOperation;
             IOperation? expectedOperation;
 
-            if (assertOperation.TargetMethod.Name.Equals(NUnitFrameworkConstants.NameOfAssertAreEqual, StringComparison.Ordinal) ||
-                assertOperation.TargetMethod.Name.Equals(NUnitFrameworkConstants.NameOfAssertAreNotEqual, StringComparison.Ordinal))
+            if (assertOperation.TargetMethod.Name.Equals(NUnitLegacyFrameworkConstants.NameOfAssertAreEqual, StringComparison.Ordinal) ||
+                assertOperation.TargetMethod.Name.Equals(NUnitLegacyFrameworkConstants.NameOfAssertAreNotEqual, StringComparison.Ordinal))
             {
                 actualOperation = assertOperation.GetArgumentOperation(NUnitFrameworkConstants.NameOfActualParameter);
                 expectedOperation = assertOperation.GetArgumentOperation(NUnitFrameworkConstants.NameOfExpectedParameter);

--- a/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/ITypeSymbolExtensions.cs
@@ -36,22 +36,22 @@ namespace NUnit.Analyzers.Extensions
         internal static bool IsClassicAssert(this ITypeSymbol? @this)
         {
             return @this is not null &&
-                   @this.ContainingAssembly.Name is NUnitFrameworkConstants.NUnitFrameworkLegacyAssemblyName &&
-                   @this.Name is NUnitFrameworkConstants.NameOfClassicAssert;
+                   @this.ContainingAssembly.Name is NUnitLegacyFrameworkConstants.NUnitFrameworkLegacyAssemblyName &&
+                   @this.Name is NUnitLegacyFrameworkConstants.NameOfClassicAssert;
         }
 
         internal static bool IsStringAssert(this ITypeSymbol? @this)
         {
             return @this is not null &&
-                   @this.ContainingAssembly.Name is NUnitFrameworkConstants.NUnitFrameworkLegacyAssemblyName or NUnitFrameworkConstants.NUnitFrameworkAssemblyName &&
-                   @this.Name is NUnitFrameworkConstants.NameOfStringAssert;
+                   @this.ContainingAssembly.Name is NUnitLegacyFrameworkConstants.NUnitFrameworkLegacyAssemblyName or NUnitFrameworkConstants.NUnitFrameworkAssemblyName &&
+                   @this.Name is NUnitLegacyFrameworkConstants.NameOfStringAssert;
         }
 
         internal static bool IsCollectionAssert(this ITypeSymbol? @this)
         {
             return @this is not null &&
-                   @this.ContainingAssembly.Name is NUnitFrameworkConstants.NUnitFrameworkLegacyAssemblyName or NUnitFrameworkConstants.NUnitFrameworkAssemblyName &&
-                   @this.Name is NUnitFrameworkConstants.NameOfCollectionAssert;
+                   @this.ContainingAssembly.Name is NUnitLegacyFrameworkConstants.NUnitFrameworkLegacyAssemblyName or NUnitFrameworkConstants.NUnitFrameworkAssemblyName &&
+                   @this.Name is NUnitLegacyFrameworkConstants.NameOfCollectionAssert;
         }
 
         internal static bool IsConstraint(this ITypeSymbol? @this)

--- a/src/nunit.analyzers/Helpers/AssertHelper.cs
+++ b/src/nunit.analyzers/Helpers/AssertHelper.cs
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.Helpers
             while ((possibleAssertMultipleInvocation = currentNode.Ancestors().OfType<InvocationExpressionSyntax>().FirstOrDefault()) is not null)
             {
                 // Is the statement inside a Block which is part of an Assert.Multiple.
-                if (IsAssert(possibleAssertMultipleInvocation, NUnitFrameworkConstants.NameOfMultiple, NUnitFrameworkConstants.NameOfMultipleAsync))
+                if (IsAssert(possibleAssertMultipleInvocation, NUnitFrameworkConstants.NameOfMultiple, NUnitV4FrameworkConstants.NameOfMultipleAsync))
                 {
                     return true;
                 }
@@ -117,7 +117,7 @@ namespace NUnit.Analyzers.Helpers
             {
                 // Is the using expression an Assert.EnterMultipleScope.
                 if (usingStatement.Expression is InvocationExpressionSyntax usingInvocation &&
-                    IsAssert(usingInvocation, NUnitFrameworkConstants.NameOfEnterMultipleScope))
+                    IsAssert(usingInvocation, NUnitV4FrameworkConstants.NameOfEnterMultipleScope))
                 {
                     return true;
                 }
@@ -150,7 +150,7 @@ namespace NUnit.Analyzers.Helpers
         {
             return IsAssert(expression,
                             x => x is NUnitFrameworkConstants.NameOfAssert
-                                   or NUnitFrameworkConstants.NameOfClassicAssert
+                                   or NUnitLegacyFrameworkConstants.NameOfClassicAssert
                                    or NUnitFrameworkConstants.NameOfAssume,
                             out member, out argumentList);
         }

--- a/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/IgnoreCaseUsage/IgnoreCaseUsageAnalyzer.cs
@@ -15,13 +15,13 @@ namespace NUnit.Analyzers.IgnoreCaseUsage
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class IgnoreCaseUsageAnalyzer : BaseAssertionAnalyzer
     {
-        private static readonly string[] SupportedIsMethods = new[]
-        {
+        private static readonly string[] SupportedIsMethods =
+        [
             NUnitFrameworkConstants.NameOfIsEqualTo,
             NUnitFrameworkConstants.NameOfIsEquivalentTo,
             NUnitFrameworkConstants.NameOfIsSupersetOf,
             NUnitFrameworkConstants.NameOfIsSubsetOf
-        };
+        ];
 
         private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.IgnoreCaseUsage,

--- a/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsIncompatibleTypes/SameAsIncompatibleTypesAnalyzer.cs
@@ -28,8 +28,8 @@ namespace NUnit.Analyzers.SameAsIncompatibleTypes
             IOperation? actualOperation;
             IOperation? expectedOperation;
 
-            if (assertOperation.TargetMethod.Name.Equals(NUnitFrameworkConstants.NameOfAssertAreSame, StringComparison.Ordinal) ||
-                assertOperation.TargetMethod.Name.Equals(NUnitFrameworkConstants.NameOfAssertAreNotSame, StringComparison.Ordinal))
+            if (assertOperation.TargetMethod.Name.Equals(NUnitLegacyFrameworkConstants.NameOfAssertAreSame, StringComparison.Ordinal) ||
+                assertOperation.TargetMethod.Name.Equals(NUnitLegacyFrameworkConstants.NameOfAssertAreNotSame, StringComparison.Ordinal))
             {
                 actualOperation = assertOperation.GetArgumentOperation(NUnitFrameworkConstants.NameOfActualParameter);
                 expectedOperation = assertOperation.GetArgumentOperation(NUnitFrameworkConstants.NameOfExpectedParameter);

--- a/src/nunit.analyzers/SameAsOnValueTypes/SameAsOnValueTypesAnalyzer.cs
+++ b/src/nunit.analyzers/SameAsOnValueTypes/SameAsOnValueTypesAnalyzer.cs
@@ -27,8 +27,8 @@ namespace NUnit.Analyzers.SameAsOnValueTypes
             IOperation? actualOperation;
             IOperation? expectedOperation;
 
-            if (assertOperation.TargetMethod.Name.Equals(NUnitFrameworkConstants.NameOfAssertAreSame, StringComparison.Ordinal) ||
-                assertOperation.TargetMethod.Name.Equals(NUnitFrameworkConstants.NameOfAssertAreNotSame, StringComparison.Ordinal))
+            if (assertOperation.TargetMethod.Name.Equals(NUnitLegacyFrameworkConstants.NameOfAssertAreSame, StringComparison.Ordinal) ||
+                assertOperation.TargetMethod.Name.Equals(NUnitLegacyFrameworkConstants.NameOfAssertAreNotSame, StringComparison.Ordinal))
             {
                 actualOperation = assertOperation.GetArgumentOperation(NUnitFrameworkConstants.NameOfActualParameter);
                 expectedOperation = assertOperation.GetArgumentOperation(NUnitFrameworkConstants.NameOfExpectedParameter);

--- a/src/nunit.analyzers/StringAssertUsage/StringAssertUsageAnalyzer.cs
+++ b/src/nunit.analyzers/StringAssertUsage/StringAssertUsageAnalyzer.cs
@@ -6,7 +6,9 @@ using Microsoft.CodeAnalysis.Operations;
 using NUnit.Analyzers.Constants;
 using NUnit.Analyzers.Extensions;
 using NUnit.Analyzers.Helpers;
+
 using static NUnit.Analyzers.Constants.NUnitFrameworkConstants;
+using static NUnit.Analyzers.Constants.NUnitLegacyFrameworkConstants;
 
 namespace NUnit.Analyzers.StringAssertUsage
 {

--- a/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzer.cs
@@ -121,8 +121,8 @@ namespace NUnit.Analyzers.TestCaseSourceUsage
                 return;
             }
 
-            INamedTypeSymbol? cancelAfterType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancelAfterAttribute);
-            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancellationToken);
+            INamedTypeSymbol? cancelAfterType = context.Compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancelAfterAttribute);
+            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancellationToken);
 
             context.RegisterSyntaxNodeAction(syntaxContext => AnalyzeAttribute(syntaxContext, testCaseSourceAttribute, cancelAfterType, cancellationTokenType), SyntaxKind.Attribute);
         }

--- a/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestCaseUsage/TestCaseUsageAnalyzer.cs
@@ -52,8 +52,8 @@ namespace NUnit.Analyzers.TestCaseUsage
             if (testCaseType is null)
                 return;
 
-            INamedTypeSymbol? cancelAfterType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancelAfterAttribute);
-            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancellationToken);
+            INamedTypeSymbol? cancelAfterType = context.Compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancelAfterAttribute);
+            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancellationToken);
 
             context.RegisterSymbolAction(symbolContext => AnalyzeMethod(symbolContext, testCaseType, cancelAfterType, cancellationTokenType), SymbolKind.Method);
         }

--- a/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
+++ b/src/nunit.analyzers/TestMethodUsage/TestMethodUsageAnalyzer.cs
@@ -89,8 +89,8 @@ namespace NUnit.Analyzers.TestMethodUsage
             if (testCaseType is null || testType is null)
                 return;
 
-            INamedTypeSymbol? cancelAfterType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancelAfterAttribute);
-            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(NUnitFrameworkConstants.FullNameOfCancellationToken);
+            INamedTypeSymbol? cancelAfterType = context.Compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancelAfterAttribute);
+            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(NUnitV4FrameworkConstants.FullNameOfCancellationToken);
 
             context.RegisterSymbolAction(symbolContext => AnalyzeMethod(symbolContext, testCaseType, testType, cancelAfterType, cancellationTokenType), SymbolKind.Method);
         }

--- a/src/nunit.analyzers/UpdateStringFormatToInterpolatableString/UpdateStringFormatToInterpolatableStringAnalyzer.cs
+++ b/src/nunit.analyzers/UpdateStringFormatToInterpolatableString/UpdateStringFormatToInterpolatableStringAnalyzer.cs
@@ -16,14 +16,14 @@ namespace NUnit.Analyzers.UpdateStringFormatToInterpolatableString
     public sealed class UpdateStringFormatToInterpolatableStringAnalyzer : BaseAssertionAnalyzer
     {
         private static readonly string[] ObsoleteParamsMethods =
-        {
+        [
             NUnitFrameworkConstants.NameOfAssertPass,
             NUnitFrameworkConstants.NameOfAssertFail,
             NUnitFrameworkConstants.NameOfAssertWarn,
             NUnitFrameworkConstants.NameOfAssertIgnore,
             NUnitFrameworkConstants.NameOfAssertInconclusive,
             NUnitFrameworkConstants.NameOfAssertThat,
-        };
+        ];
 
         private static readonly DiagnosticDescriptor updateStringFormatToInterpolatableString = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.UpdateStringFormatToInterpolatableString,

--- a/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleAnalyzer.cs
+++ b/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleAnalyzer.cs
@@ -13,7 +13,7 @@ namespace NUnit.Analyzers.UseAssertMultiple
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class UseAssertMultipleAnalyzer : BaseAssertionAnalyzer
     {
-        private static readonly Version firstNUnitVersionWithEnterMultipleScope = new Version(4, 2);
+        private static readonly Version firstNUnitVersionWithEnterMultipleScope = new(4, 2);
 
         private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.UseAssertMultiple,
@@ -139,7 +139,7 @@ namespace NUnit.Analyzers.UseAssertMultiple
                     var properties = ImmutableDictionary.CreateBuilder<string, string?>();
                     properties.Add(AnalyzerPropertyKeys.SupportsEnterMultipleScope,
                         nunitVersion >= firstNUnitVersionWithEnterMultipleScope ?
-                        NUnitFrameworkConstants.NameOfEnterMultipleScope : null);
+                        NUnitV4FrameworkConstants.NameOfEnterMultipleScope : null);
                     context.ReportDiagnostic(Diagnostic.Create(descriptor, assertOperation.Syntax.GetLocation(), properties.ToImmutable()));
                 }
             }

--- a/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintAnalyzer.cs
+++ b/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintAnalyzer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.UseSpecificConstraint
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UseSpecificConstraintAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor simplifyConstraint = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.UseSpecificConstraint,
+            title: UseSpecificConstraintConstants.UseSpecificConstraintTitle,
+            messageFormat: UseSpecificConstraintConstants.UseSpecificConstraintMessage,
+            category: Categories.Style,
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: UseSpecificConstraintConstants.UseSpecificConstraintDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(simplifyConstraint);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(this.AnalyzeCompilationStart);
+        }
+
+        private static void AnalyzeInvocation(Version nunitVersion, SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax)context.Node;
+
+            if (invocationExpression.ArgumentList.Arguments.Count == 1 &&
+                invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression &&
+                memberAccessExpression.Name.Identifier.Text == NUnitFrameworkConstants.NameOfIsEqualTo)
+            {
+                ExpressionSyntax argument = invocationExpression.ArgumentList.Arguments[0].Expression;
+                string? constraint = null;
+
+                if (argument is LiteralExpressionSyntax literalExpression)
+                {
+                    constraint = literalExpression.Kind() switch
+                    {
+                        SyntaxKind.NullLiteralExpression => NUnitFrameworkConstants.NameOfIsNull,
+                        SyntaxKind.FalseLiteralExpression => NUnitFrameworkConstants.NameOfIsFalse,
+                        SyntaxKind.TrueLiteralExpression => NUnitFrameworkConstants.NameOfIsTrue,
+                        _ => null,
+                    };
+
+                    if (constraint is null && nunitVersion.Major >= 4)
+                    {
+                        constraint = literalExpression.Kind() switch
+                        {
+                            SyntaxKind.DefaultLiteralExpression => NUnitV4FrameworkConstants.NameOfIsDefault,
+                            _ => constraint,
+                        };
+                    }
+                }
+                else if (argument is DefaultExpressionSyntax defaultExpression)
+                {
+                    if (defaultExpression.Type is PredefinedTypeSyntax predefinedType)
+                    {
+                        if (predefinedType.Keyword.IsKind(SyntaxKind.ObjectKeyword) ||
+                            predefinedType.Keyword.IsKind(SyntaxKind.StringKeyword))
+                        {
+                            constraint = NUnitFrameworkConstants.NameOfIsNull;
+                        }
+                        else if (nunitVersion.Major >= 4)
+                        {
+                            constraint = NUnitV4FrameworkConstants.NameOfIsDefault;
+                        }
+                        else if (predefinedType.Keyword.IsKind(SyntaxKind.BoolKeyword))
+                        {
+                            constraint = NUnitFrameworkConstants.NameOfIsFalse;
+                        }
+                    }
+                }
+
+                if (constraint is not null)
+                {
+                    var diagnostic = Diagnostic.Create(simplifyConstraint, invocationExpression.GetLocation(),
+                        new Dictionary<string, string?>
+                        {
+                            [AnalyzerPropertyKeys.SpecificConstraint] = constraint,
+                        }.ToImmutableDictionary(),
+                        argument.ToString(), constraint);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        private void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
+        {
+            IEnumerable<AssemblyIdentity> referencedAssemblies = context.Compilation.ReferencedAssemblyNames;
+
+            AssemblyIdentity? nunit = referencedAssemblies.FirstOrDefault(a =>
+                a.Name.Equals(NUnitFrameworkConstants.NUnitFrameworkAssemblyName, StringComparison.OrdinalIgnoreCase));
+
+            if (nunit is null)
+            {
+                // Who would use NUnit.Analyzers without NUnit?
+                return;
+            }
+
+            context.RegisterSyntaxNodeAction((context) => AnalyzeInvocation(nunit.Version, context), SyntaxKind.InvocationExpression);
+        }
+    }
+}

--- a/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintConstants.cs
+++ b/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.UseSpecificConstraint
+{
+    internal static class UseSpecificConstraintConstants
+    {
+        internal const string UseSpecificConstraintTitle = "Use Specific constraint";
+        internal const string UseSpecificConstraintMessage = "Replace 'Is.EqualTo({0})' with 'Is.{1}' constraint";
+        internal const string UseSpecificConstraintDescription = "Replace 'EqualTo' with a keyword in the corresponding specific constraint.";
+    }
+}

--- a/src/nunit.analyzers/WithinUsage/WithinUsageAnalyzer.cs
+++ b/src/nunit.analyzers/WithinUsage/WithinUsageAnalyzer.cs
@@ -15,14 +15,14 @@ namespace NUnit.Analyzers.WithinUsage
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class WithinUsageAnalyzer : BaseAssertionAnalyzer
     {
-        private static readonly string[] SupportedIsMethods = new[]
-        {
+        private static readonly string[] SupportedIsMethods =
+        [
             NUnitFrameworkConstants.NameOfIsEqualTo,
             NUnitFrameworkConstants.NameOfIsLessThan,
             NUnitFrameworkConstants.NameOfIsLessThanOrEqualTo,
             NUnitFrameworkConstants.NameOfIsGreaterThan,
             NUnitFrameworkConstants.NameOfIsGreaterThanOrEqualTo,
-        };
+        ];
 
         private static readonly DiagnosticDescriptor descriptor = DiagnosticDescriptorCreator.Create(
             id: AnalyzerIdentifiers.WithinIncompatibleTypes,


### PR DESCRIPTION
Fixes #824
Fixes #826 
Fixes #828 

@mikkelbu The first commit is not directly related but was necessary to allow NUnit 4 specific names to be only tested when building against NUnit instead of making up the names in the analyzer code.

The second commit add the new analyzer and code fix.

There was a small change in the documentation tests as they were not testing for the new Style analyzers.

If you think this analyzer should be in a different category, that is fine by me.