### PR TITLE
New rule to ensure that base class TestFixtures are abstract.

### DIFF
--- a/documentation/NUnit1034.md
+++ b/documentation/NUnit1034.md
@@ -1,0 +1,107 @@
+# NUnit1034
+
+## Base TestFixtures should be abstract
+
+| Topic    | Value
+| :--      | :--
+| Id       | NUnit1034
+| Severity | Warning
+| Enabled  | True
+| Category | Structure
+| Code     | [TestFixtureShouldBeAbstractAnalyzer](https://github.com/nunit/nunit.analyzers/blob/master/src/nunit.analyzers/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractAnalyzer.cs)
+
+## Description
+
+Base TestFixtures should be abstract to prevent base class tests executing separately.
+
+## Motivation
+
+When a base class is not `abstract` it will also be run as a standalone test which is most times not the intention.
+
+```csharp
+namespace Tests
+{
+    internal class ParentFixture
+    {
+        [Test]
+        public void ParentTest()
+        {
+            Assert.Pass($"Run {nameof(ParentTest)} from class {GetType().Name}");
+        }
+    }
+
+    internal class ChildFixture : ParentFixture
+    {
+        [Test]
+        public void ChildTest()
+        {
+            Assert.Pass($"Run {nameof(ChildTest)} from class {GetType().Name}");
+        }
+    }
+}
+```
+
+As the `Parent` class is valid as a standalone `TestFixture` it will be instantiated and run separately.
+
+```text
+ChildTest: Run ChildTest from class ChildFixture
+ParentTest: Run ParentTest from class ChildFixture
+ParentTest: Run ParentTest from class ParentFixture
+```
+
+This rule only fires when a class is found to be used as a base class in the current compilation.
+
+## How to fix violations
+
+Mark any base class test fixture as `abstract`:
+
+```csharp
+    internal abstract class Parent
+    {
+        [Test]
+        public void ParentRun()
+        {
+            Assert.Pass($"Run {nameof(ParentRun)} from {GetType().Name}");
+        }
+    }
+```
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file
+
+Configure the severity per project, for more info see
+[MSDN](https://learn.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2022).
+
+### Via .editorconfig file
+
+```ini
+# NUnit1034: Base TestFixtures should be abstract
+dotnet_diagnostic.NUnit1034.severity = chosenSeverity
+```
+
+where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, or `error`.
+
+### Via #pragma directive
+
+```csharp
+#pragma warning disable NUnit1034 // Base TestFixtures should be abstract
+Code violating the rule here
+#pragma warning restore NUnit1034 // Base TestFixtures should be abstract
+```
+
+Or put this at the top of the file to disable all instances.
+
+```csharp
+#pragma warning disable NUnit1034 // Base TestFixtures should be abstract
+```
+
+### Via attribute `[SuppressMessage]`
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Structure",
+    "NUnit1034:Base TestFixtures should be abstract",
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -52,6 +52,7 @@ Rules which enforce structural requirements on the test code.
 | [NUnit1031](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1031.md) | The individual arguments provided by a ValuesAttribute must match the type of the corresponding parameter of the method | :white_check_mark: | :exclamation: | :x: |
 | [NUnit1032](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1032.md) | An IDisposable field/property should be Disposed in a TearDown method | :white_check_mark: | :exclamation: | :x: |
 | [NUnit1033](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1033.md) | The Write methods on TestContext will be marked as Obsolete and eventually removed | :white_check_mark: | :warning: | :white_check_mark: |
+| [NUnit1034](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit1034.md) | Base TestFixtures should be abstract | :white_check_mark: | :warning: | :white_check_mark: |
 
 ## Assertion Rules (NUnit2001 - )
 

--- a/src/nunit.analyzers.codefixes/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractCodeFix.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.TestFixtureShouldBeAbstract
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [Shared]
+    public class TestFixtureShouldBeAbstractCodeFix : CodeFixProvider
+    {
+        internal const string MakeBaseTestFixtureAbstract = "Make base test fixture abstract";
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(AnalyzerIdentifiers.BaseTestFixtureIsNotAbstract);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            if (root is null)
+            {
+                return;
+            }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var node = root.FindNode(context.Span);
+
+            if (node is not ClassDeclarationSyntax originalExpression)
+                return;
+
+            // Add the abstract modifier
+            SyntaxTokenList updatedModifiers = AddAbstractModifier(originalExpression);
+
+            ClassDeclarationSyntax newExpression = originalExpression.WithoutLeadingTrivia()
+                                                                     .WithModifiers(updatedModifiers);
+
+            var newRoot = root.ReplaceNode(originalExpression, newExpression);
+
+            var codeAction = CodeAction.Create(
+                MakeBaseTestFixtureAbstract,
+                _ => Task.FromResult(context.Document.WithSyntaxRoot(newRoot)),
+                MakeBaseTestFixtureAbstract);
+
+            context.RegisterCodeFix(codeAction, context.Diagnostics);
+        }
+
+        private static SyntaxTokenList AddAbstractModifier(ClassDeclarationSyntax originalExpression)
+        {
+            var modifiers = originalExpression.Modifiers;
+
+            var abstractSyntax = SyntaxFactory.Token(SyntaxKind.AbstractKeyword)
+                                              .WithTrailingTrivia(SyntaxTriviaList.Create(SyntaxFactory.Whitespace(" ")));
+
+            if (!modifiers.Any())
+            {
+                // Get leading trivia from declaration
+                abstractSyntax = abstractSyntax.WithLeadingTrivia(originalExpression.GetLeadingTrivia());
+            }
+
+            return modifiers.Add(abstractSyntax);
+        }
+    }
+}

--- a/src/nunit.analyzers.sln
+++ b/src/nunit.analyzers.sln
@@ -43,6 +43,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		..\documentation\NUnit1031.md = ..\documentation\NUnit1031.md
 		..\documentation\NUnit1032.md = ..\documentation\NUnit1032.md
 		..\documentation\NUnit1033.md = ..\documentation\NUnit1033.md
+		..\documentation\NUnit1034.md = ..\documentation\NUnit1034.md
 		..\documentation\NUnit2001.md = ..\documentation\NUnit2001.md
 		..\documentation\NUnit2002.md = ..\documentation\NUnit2002.md
 		..\documentation\NUnit2003.md = ..\documentation\NUnit2003.md

--- a/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
+++ b/src/nunit.analyzers.tests/Constants/NUnitFrameworkConstantsTests.cs
@@ -128,6 +128,7 @@ namespace NUnit.Analyzers.Tests.Constants
             (nameof(NUnitFrameworkConstants.FullNameOfTypeValuesAttribute), typeof(ValuesAttribute)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeITestBuilder), typeof(ITestBuilder)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeISimpleTestBuilder), typeof(ISimpleTestBuilder)),
+            (nameof(NUnitFrameworkConstants.FullNameOfTypeIFixtureBuilder), typeof(IFixtureBuilder)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeIParameterDataSource), typeof(IParameterDataSource)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeTestCaseData), typeof(TestCaseData)),
             (nameof(NUnitFrameworkConstants.FullNameOfTypeTestCaseParameters), typeof(TestCaseParameters)),

--- a/src/nunit.analyzers.tests/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractAnalyzerTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.TestFixtureShouldBeAbstract;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.TestFixtureShouldBeAbstract
+{
+    public class TestFixtureShouldBeAbstractAnalyzerTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new TestFixtureShouldBeAbstractAnalyzer();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.BaseTestFixtureIsNotAbstract);
+
+        private static readonly IEnumerable<string> testMethodRelatedAttributes =
+        [
+            "OneTimeSetUp",
+            "OneTimeTearDown",
+            "SetUp",
+            "TearDown",
+            "Test",
+        ];
+
+        [TestCaseSource(nameof(testMethodRelatedAttributes))]
+        public void AnalyzeWhenBaseFixtureIsAbstract(string attribute)
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
+    public abstract class BaseFixture
+    {{
+        [{attribute}]
+        public void BaseFixtureMethod() {{ }}
+    }}
+
+    public class DerivedFixture : BaseFixture
+    {{
+        [Test]
+        public void DerivedFixtureMethod() {{ }}
+    }}");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [TestCaseSource(nameof(testMethodRelatedAttributes))]
+        public void AnalyzeWhenBaseFixtureIsNotAbstract(string attribute)
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
+    public class ↓BaseFixture
+    {{
+        [{attribute}]
+        public void BaseFixtureMethod() {{ }}
+    }}
+
+    public class DerivedFixture : BaseFixture
+    {{
+        [Test]
+        public void DerivedFixtureMethod() {{ }}
+    }}");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenGenericFixtureIsAbstract()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public abstract class BaseFixture<T>
+    {
+        [Test]
+        public void BaseFixtureMethod() { }
+    }
+
+    public class IntFixture : BaseFixture<int>
+    {
+    }
+    
+    public class DoubleFixture : BaseFixture<double>
+    {
+    }");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenGenericFixtureIsNotAbstract()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public class ↓BaseFixture<T>
+    {
+        [Test]
+        public void BaseFixtureMethod() { }
+    }
+
+    public class IntFixture : BaseFixture<int>
+    {
+    }
+    
+    public class DoubleFixture : BaseFixture<double>
+    {
+    }");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractCodeFixTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Gu.Roslyn.Asserts;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.TestFixtureShouldBeAbstract;
+using NUnit.Framework;
+
+namespace NUnit.Analyzers.Tests.TestFixtureShouldBeAbstract
+{
+    public class TestFixtureShouldBeAbstractCodeFixTests
+    {
+        private static readonly DiagnosticAnalyzer analyzer = new TestFixtureShouldBeAbstractAnalyzer();
+        private static readonly CodeFixProvider fix = new TestFixtureShouldBeAbstractCodeFix();
+        private static readonly ExpectedDiagnostic expectedDiagnostic =
+            ExpectedDiagnostic.Create(AnalyzerIdentifiers.BaseTestFixtureIsNotAbstract);
+
+        private static readonly IEnumerable<string> testMethodRelatedAttributes =
+        [
+            "OneTimeSetUp",
+            "OneTimeTearDown",
+            "SetUp",
+            "TearDown",
+            "Test",
+        ];
+
+        [TestCaseSource(nameof(testMethodRelatedAttributes))]
+        public void FixWhenBaseFixtureIsNotAbstract(string attribute)
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
+    // Base Fixture
+    public class ↓BaseFixture
+    {{
+        [{attribute}]
+        public void BaseFixtureMethod() {{ }}
+    }}
+
+    public class DerivedFixture : BaseFixture
+    {{
+        [Test]
+        public void DerivedFixtureMethod() {{ }}
+    }}");
+
+            var fixedCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
+    // Base Fixture
+    public abstract class BaseFixture
+    {{
+        [{attribute}]
+        public void BaseFixtureMethod() {{ }}
+    }}
+
+    public class DerivedFixture : BaseFixture
+    {{
+        [Test]
+        public void DerivedFixtureMethod() {{ }}
+    }}");
+
+            RoslynAssert.CodeFix(analyzer, fix, expectedDiagnostic, testCode, fixedCode);
+        }
+    }
+}

--- a/src/nunit.analyzers.tests/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractCodeFixTests.cs
@@ -15,27 +15,27 @@ namespace NUnit.Analyzers.Tests.TestFixtureShouldBeAbstract
         private static readonly ExpectedDiagnostic expectedDiagnostic =
             ExpectedDiagnostic.Create(AnalyzerIdentifiers.BaseTestFixtureIsNotAbstract);
 
-        private static readonly IEnumerable<string> testMethodRelatedAttributes =
+        private static readonly IEnumerable<string[]> testMethodRelatedAttributes =
         [
-            "OneTimeSetUp",
-            "OneTimeTearDown",
-            "SetUp",
-            "TearDown",
-            "Test",
+            ["", "OneTimeSetUp"],
+            ["internal ", "OneTimeTearDown"],
+            ["public ", "SetUp"],
+            ["partial ", "TearDown"],
+            ["internal partial ", "Test"],
         ];
 
         [TestCaseSource(nameof(testMethodRelatedAttributes))]
-        public void FixWhenBaseFixtureIsNotAbstract(string attribute)
+        public void FixWhenBaseFixtureIsNotAbstract(string modifiers, string attribute)
         {
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
     // Base Fixture
-    public class ↓BaseFixture
+    {modifiers}class ↓BaseFixture
     {{
         [{attribute}]
         public void BaseFixtureMethod() {{ }}
     }}
 
-    public class DerivedFixture : BaseFixture
+    {modifiers}class DerivedFixture : BaseFixture
     {{
         [Test]
         public void DerivedFixtureMethod() {{ }}
@@ -43,13 +43,13 @@ namespace NUnit.Analyzers.Tests.TestFixtureShouldBeAbstract
 
             var fixedCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
     // Base Fixture
-    public abstract class BaseFixture
+    {modifiers}abstract class BaseFixture
     {{
         [{attribute}]
         public void BaseFixtureMethod() {{ }}
     }}
 
-    public class DerivedFixture : BaseFixture
+    {modifiers}class DerivedFixture : BaseFixture
     {{
         [Test]
         public void DerivedFixtureMethod() {{ }}

--- a/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
+++ b/src/nunit.analyzers/Constants/AnalyzerIdentifiers.cs
@@ -37,6 +37,7 @@ namespace NUnit.Analyzers.Constants
         internal const string ValuesParameterTypeMismatchUsage = "NUnit1031";
         internal const string FieldIsNotDisposedInTearDown = "NUnit1032";
         internal const string TestContextWriteIsObsolete = "NUnit1033";
+        internal const string BaseTestFixtureIsNotAbstract = "NUnit1034";
 
         #endregion Structure
 

--- a/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
+++ b/src/nunit.analyzers/Constants/NUnitFrameworkConstants.cs
@@ -86,6 +86,7 @@ namespace NUnit.Analyzers.Constants
         public const string FullNameOfTypeTestAttribute = "NUnit.Framework.TestAttribute";
         public const string FullNameOfTypeParallelizableAttribute = "NUnit.Framework.ParallelizableAttribute";
         public const string FullNameOfTypeITestBuilder = "NUnit.Framework.Interfaces.ITestBuilder";
+        public const string FullNameOfTypeIFixtureBuilder = "NUnit.Framework.Interfaces.IFixtureBuilder";
         public const string FullNameOfTypeISimpleTestBuilder = "NUnit.Framework.Interfaces.ISimpleTestBuilder";
         public const string FullNameOfTypeValuesAttribute = "NUnit.Framework.ValuesAttribute";
         public const string FullNameOfTypeValueSourceAttribute = "NUnit.Framework.ValueSourceAttribute";

--- a/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
+++ b/src/nunit.analyzers/Extensions/AttributeDataExtensions.cs
@@ -19,9 +19,19 @@ namespace NUnit.Analyzers.Extensions
             return DerivesFromInterface(compilation, @this, NUnitFrameworkConstants.FullNameOfTypeITestBuilder);
         }
 
+        public static bool DerivesFromIFixtureBuilder(this AttributeData @this, Compilation compilation)
+        {
+            return DerivesFromInterface(compilation, @this, NUnitFrameworkConstants.FullNameOfTypeIFixtureBuilder);
+        }
+
         public static bool DerivesFromIParameterDataSource(this AttributeData @this, Compilation compilation)
         {
             return DerivesFromInterface(compilation, @this, NUnitFrameworkConstants.FullNameOfTypeIParameterDataSource);
+        }
+
+        public static bool IsTestFixtureAttribute(this AttributeData @this, Compilation compilation)
+        {
+            return @this.DerivesFromIFixtureBuilder(compilation);
         }
 
         public static bool IsTestMethodAttribute(this AttributeData @this, Compilation compilation)

--- a/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/src/nunit.analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -88,7 +88,8 @@ namespace NUnit.Analyzers.Extensions
 
         internal static bool IsTestFixture(this ITypeSymbol typeSymbol, Compilation compilation)
         {
-            return typeSymbol.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsTestRelatedMethod(compilation));
+            return typeSymbol.GetAllAttributes().Any(a => a.IsTestFixtureAttribute(compilation)) ||
+                   typeSymbol.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsTestRelatedMethod(compilation));
         }
 
         internal static bool IsInstancePerTestCaseFixture(this ITypeSymbol typeSymbol, Compilation compilation)

--- a/src/nunit.analyzers/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractAnalyzer.cs
+++ b/src/nunit.analyzers/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractAnalyzer.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Analyzers.Constants;
+using NUnit.Analyzers.Extensions;
+
+namespace NUnit.Analyzers.TestFixtureShouldBeAbstract
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TestFixtureShouldBeAbstractAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor testFixtureIsNotAbstract = DiagnosticDescriptorCreator.Create(
+            id: AnalyzerIdentifiers.BaseTestFixtureIsNotAbstract,
+            title: TestFixtureShouldBeAbstractConstants.Title,
+            messageFormat: TestFixtureShouldBeAbstractConstants.Message,
+            category: Categories.Structure,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            description: TestFixtureShouldBeAbstractConstants.Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(testFixtureIsNotAbstract);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationAction(DerivedFixturesShouldBeAbstract);
+        }
+
+        private static void DerivedFixturesShouldBeAbstract(CompilationAnalysisContext context)
+        {
+            IEnumerable<INamespaceSymbol> namespaces = context.Compilation.GlobalNamespace.GetNamespaceMembers();
+
+            // Determine all classes that are defined in this assembly and are used as a base class.
+            HashSet<INamedTypeSymbol> baseClasses = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            CheckNamespaces(baseClasses, context.Compilation.Assembly, namespaces);
+
+            // Now check if any of these are actually TestFixtures and defined in this assembly.
+            foreach (var baseClass in baseClasses)
+            {
+                if (!baseClass.IsAbstract &&
+                    SymbolEqualityComparer.Default.Equals(baseClass.ContainingAssembly, context.Compilation.Assembly) &&
+                    baseClass.IsTestFixture(context.Compilation))
+                {
+                    // Class is defined in this assembly, has tests, used as a base class and not abstract
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        testFixtureIsNotAbstract,
+                        baseClass.Locations[0],
+                        baseClass.Name));
+                }
+            }
+        }
+
+        private static void CheckNamespaces(HashSet<INamedTypeSymbol> baseClasses, IAssemblySymbol assembly, IEnumerable<INamespaceSymbol> namespaces)
+        {
+            foreach (var @namespace in namespaces)
+            {
+                CheckNamespace(baseClasses, assembly, @namespace);
+            }
+        }
+
+        private static void CheckNamespace(HashSet<INamedTypeSymbol> baseClasses, IAssemblySymbol assembly, INamespaceSymbol @namespace)
+        {
+            // Check child namespaces
+            CheckNamespaces(baseClasses, assembly, @namespace.GetNamespaceMembers());
+
+            if (!SymbolEqualityComparer.Default.Equals(@namespace.ContainingAssembly, assembly))
+            {
+                // Namespace is not defined in my assembly.
+                return;
+            }
+
+            ImmutableArray<INamedTypeSymbol> namedTypeSymbols = @namespace.GetTypeMembers();
+
+            if (namedTypeSymbols.Length == 0)
+            {
+                return;
+            }
+
+            IEnumerable<INamedTypeSymbol> classDefinitions = namedTypeSymbols
+                .Where(t => t.IsReferenceType);
+
+            IEnumerable<INamedTypeSymbol> baseClassDefinitions = classDefinitions
+                .Where(t => t.BaseType is not null && t.BaseType.SpecialType != SpecialType.System_Object)
+                .Select(t => t.BaseType!)
+                .Select(t => t.IsGenericType ? t.ConstructedFrom : t);
+            baseClasses.UnionWith(baseClassDefinitions);
+        }
+    }
+}

--- a/src/nunit.analyzers/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractConstants.cs
+++ b/src/nunit.analyzers/TestFixtureShouldBeAbstract/TestFixtureShouldBeAbstractConstants.cs
@@ -1,0 +1,9 @@
+namespace NUnit.Analyzers.TestFixtureShouldBeAbstract
+{
+    internal static class TestFixtureShouldBeAbstractConstants
+    {
+        internal const string Title = "Base TestFixtures should be abstract";
+        internal const string Message = "Class {0} is used as a base class and should be abstract";
+        internal const string Description = "Base TestFixtures should be abstract to prevent base class tests executing separately.";
+    }
+}


### PR DESCRIPTION
Fixes #840 

I've run this against the nunit.framework code where it raised 2 errors:

* `NUnit.Framework.Tests.Attributes.ThreadingTests` has 10 derived fixtures.
* `NUnit.Framework.Tests.Attributes.BaseRepeatableTestFixture` has 2 derived fixtures, although this might be intentional.
