### PR TITLE
Rewrite UseSpecificConstraintAnalyzer as an IOperation analyzer

### DIFF
--- a/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintCodeFixTests.cs
@@ -30,15 +30,22 @@ namespace NUnit.Analyzers.Tests.UseSpecificConstraint
 #if NUNIT4
             ["default(int)", "Default"],
 #endif
+            ["0", "Zero"],
+            ["0.0", "Zero"],
         ];
 
         [TestCaseSource(nameof(EqualToSpecificConstraint))]
         public void AnalyzeForSpecificConstraint(string literal, string constraint) => AnalyzeForEqualTo(literal, constraint);
 
 #if NUNIT4
-        [Test]
-        public void AnalyzeForIsDefault() => AnalyzeForEqualTo("default", "Default",
-            Settings.Default.WithAllowedCompilerDiagnostics(AllowedCompilerDiagnostics.WarningsAndErrors));
+        /*
+         *  Is.EqualTo(default) no longer compiles with NUnit 4.3
+         *  As 'default' is untyped, the call is ambigous between the specificy typed overloads.
+         *
+            [Test]
+            public void AnalyzeForIsDefault() => AnalyzeForEqualTo("default", "Default",
+                Settings.Default.WithAllowedCompilerDiagnostics(AllowedCompilerDiagnostics.WarningsAndErrors));
+          */
 #endif
 
         private static void AnalyzeForEqualTo(string literal, string constraint, Settings? settings = null)
@@ -46,7 +53,7 @@ namespace NUnit.Analyzers.Tests.UseSpecificConstraint
             AnalyzeForEqualTo("Is", string.Empty, literal, constraint, settings);
             AnalyzeForEqualTo("Is", ".And.Not.Empty", literal, constraint, settings);
             AnalyzeForEqualTo("Is.Not", string.Empty, literal, constraint, settings);
-            AnalyzeForEqualTo("Is.EqualTo(0).Or", string.Empty, literal, constraint, settings);
+            AnalyzeForEqualTo("Is.EqualTo(4).Or", string.Empty, literal, constraint, settings);
         }
 
         private static void AnalyzeForEqualTo(string prefix, string suffix, string literal, string constraint, Settings? settings = null)

--- a/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
+++ b/src/nunit.analyzers/ComparableTypes/ComparableTypesAnalyzer.cs
@@ -58,7 +58,7 @@ namespace NUnit.Analyzers.ComparableTypes
             foreach (var constraintPartExpression in constraintExpression.ConstraintParts)
             {
                 if (constraintPartExpression.HasIncompatiblePrefixes()
-                    || HasCustomComparer(constraintPartExpression)
+                    || constraintPartExpression.HasCustomComparer()
                     || constraintPartExpression.HasUnknownExpressions())
                 {
                     continue;
@@ -168,11 +168,6 @@ namespace NUnit.Analyzers.ComparableTypes
 
             return (typeSymbol.TypeKind == TypeKind.Interface && typeSymbol.GetFullMetadataName() == iComparable) ||
                 typeSymbol.AllInterfaces.Any(i => i.TypeArguments.Length == 0 && i.GetFullMetadataName() == iComparable);
-        }
-
-        private static bool HasCustomComparer(ConstraintExpressionPart constraintPartExpression)
-        {
-            return constraintPartExpression.GetSuffixesNames().Any(s => s == NUnitFrameworkConstants.NameOfEqualConstraintUsing);
         }
     }
 }

--- a/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
+++ b/src/nunit.analyzers/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -50,7 +49,7 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
                 foreach (var constraintPartExpression in constraintExpression.ConstraintParts)
                 {
                     if (constraintPartExpression.HasIncompatiblePrefixes()
-                        || HasCustomEqualityComparer(constraintPartExpression)
+                        || constraintPartExpression.HasCustomComparer()
                         || constraintPartExpression.HasUnknownExpressions())
                     {
                         return;
@@ -140,11 +139,6 @@ namespace NUnit.Analyzers.EqualToIncompatibleTypes
                     descriptor,
                     expectedOperation.Syntax.GetLocation()));
             }
-        }
-
-        private static bool HasCustomEqualityComparer(ConstraintExpressionPart constraintPartExpression)
-        {
-            return constraintPartExpression.GetSuffixesNames().Any(s => s == NUnitFrameworkConstants.NameOfEqualConstraintUsing);
         }
     }
 }

--- a/src/nunit.analyzers/Operations/ConstraintExpressionPartExtensions.cs
+++ b/src/nunit.analyzers/Operations/ConstraintExpressionPartExtensions.cs
@@ -1,0 +1,13 @@
+using System.Linq;
+using NUnit.Analyzers.Constants;
+
+namespace NUnit.Analyzers.Operations
+{
+    internal static class ConstraintExpressionPartExtensions
+    {
+        public static bool HasCustomComparer(this ConstraintExpressionPart constraintPartExpression)
+        {
+            return constraintPartExpression.GetSuffixesNames().Any(s => s == NUnitFrameworkConstants.NameOfEqualConstraintUsing);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #856

This allows us to check the type of TActual and not suggest Is.Default if the type is object.

@mikkelbu I also incorporated the Is.Zero changes you started in #845 
