### PR TITLE
chore: Improve NUnit2045 to mention Assert.EnterMultipleScope

### DIFF
--- a/documentation/NUnit2045.md
+++ b/documentation/NUnit2045.md
@@ -1,6 +1,6 @@
 # NUnit2045
 
-## Use Assert.Multiple
+## Use Assert.EnterMultipleScope or Assert.Multiple
 
 | Topic    | Value
 | :--      | :--
@@ -12,15 +12,17 @@
 
 ## Description
 
-Hosting Asserts inside an Assert.Multiple allows detecting more than one failure.
+Hosting Asserts inside an Assert.EnterMultipleScope or Assert.Multiple allows detecting more than one failure.
 
 ## Motivation
 
-When independent `Assert` statements are called from an `Assert.Multiple` they all will run.
-This allows detecting more than one failure in a single test run.
+When independent `Assert` statements are called from an `Assert.EnterMultipleScope` or `Assert.Multiple` they all
+will run. This allows detecting more than one failure in a single test run. Note that `Assert.EnterMultipleScope` is
+the preferred method, but this functionality was released in NUnit 4.2. On older NUnit versions one can use
+`Assert.Multiple`.
 
-Without the `Assert.Multiple` the below code will stop executing after the first failure and the second
-violation won't be detected until the next run when the first one has been finished.
+Without the `Assert.EnterMultipleScope` the below code will stop executing after the first failure and the second
+violation won't be detected until the next run when the first one has been corrected.
 
 ```csharp
 Assert.That(instance.Property1, Is.EqualTo(expectedProperty1Value));
@@ -29,7 +31,18 @@ Assert.That(instance.Property2, Is.EqualTo(expectedProperty2Value));
 
 ## How to fix violations
 
-Add an `Assert.Multiple` and call all independent `Assert` statements from the lambda parameter.
+Add an `Assert.EnterMultipleScope` using block surrounding the `Assert` statements.
+
+```csharp
+using (Assert.EnterMultipleScope())
+{
+    Assert.That(instance.Property1, Is.EqualTo(expectedProperty1Value));
+    Assert.That(instance.Property2, Is.EqualTo(expectedProperty2Value));
+};
+```
+
+Using `Assert.Multiple` then fix would look like this - where all the independent `Assert` statements are called from
+inside the lambda parameter.
 
 ```csharp
 Assert.Multiple(() =>
@@ -38,6 +51,7 @@ Assert.Multiple(() =>
     Assert.That(instance.Property2, Is.EqualTo(expectedProperty2Value));
 });
 ```
+
 <!-- start generated config severity -->
 ## Configure severity
 
@@ -49,7 +63,7 @@ Configure the severity per project, for more info see
 ### Via .editorconfig file
 
 ```ini
-# NUnit2045: Use Assert.Multiple
+# NUnit2045: Use Assert.EnterMultipleScope or Assert.Multiple
 dotnet_diagnostic.NUnit2045.severity = chosenSeverity
 ```
 
@@ -58,22 +72,22 @@ where `chosenSeverity` can be one of `none`, `silent`, `suggestion`, `warning`, 
 ### Via #pragma directive
 
 ```csharp
-#pragma warning disable NUnit2045 // Use Assert.Multiple
+#pragma warning disable NUnit2045 // Use Assert.EnterMultipleScope or Assert.Multiple
 Code violating the rule here
-#pragma warning restore NUnit2045 // Use Assert.Multiple
+#pragma warning restore NUnit2045 // Use Assert.EnterMultipleScope or Assert.Multiple
 ```
 
 Or put this at the top of the file to disable all instances.
 
 ```csharp
-#pragma warning disable NUnit2045 // Use Assert.Multiple
+#pragma warning disable NUnit2045 // Use Assert.EnterMultipleScope or Assert.Multiple
 ```
 
 ### Via attribute `[SuppressMessage]`
 
 ```csharp
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Assertion",
-    "NUnit2045:Use Assert.Multiple",
+    "NUnit2045:Use Assert.EnterMultipleScope or Assert.Multiple",
     Justification = "Reason...")]
 ```
 <!-- end generated config severity -->

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -104,7 +104,7 @@ Rules which improve assertions in the test code.
 | [NUnit2042](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2042.md) | Comparison constraint on object | :white_check_mark: | :information_source: | :x: |
 | [NUnit2043](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2043.md) | Use ComparisonConstraint for better assertion messages in case of failure | :white_check_mark: | :information_source: | :white_check_mark: |
 | [NUnit2044](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2044.md) | Non-delegate actual parameter | :white_check_mark: | :exclamation: | :white_check_mark: |
-| [NUnit2045](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2045.md) | Use Assert.Multiple | :white_check_mark: | :information_source: | :white_check_mark: |
+| [NUnit2045](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2045.md) | Use Assert.EnterMultipleScope or Assert.Multiple | :white_check_mark: | :information_source: | :white_check_mark: |
 | [NUnit2046](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2046.md) | Use CollectionConstraint for better assertion messages in case of failure | :white_check_mark: | :information_source: | :white_check_mark: |
 | [NUnit2047](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2047.md) | Incompatible types for Within constraint | :white_check_mark: | :warning: | :white_check_mark: |
 | [NUnit2048](https://github.com/nunit/nunit.analyzers/tree/master/documentation/NUnit2048.md) | Consider using Assert.That(...) instead of StringAssert(...) | :white_check_mark: | :warning: | :white_check_mark: |

--- a/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleConstants.cs
+++ b/src/nunit.analyzers/UseAssertMultiple/UseAssertMultipleConstants.cs
@@ -2,8 +2,8 @@ namespace NUnit.Analyzers.UseAssertMultiple
 {
     internal static class UseAssertMultipleConstants
     {
-        internal const string Title = "Use Assert.Multiple";
-        internal const string Message = "Call independent Assert statements from inside an Assert.Multiple";
-        internal const string Description = "Hosting Asserts inside an Assert.Multiple allows detecting more than one failure.";
+        internal const string Title = "Use Assert.EnterMultipleScope or Assert.Multiple";
+        internal const string Message = "Call independent Assert statements from inside an Assert.EnterMultipleScope or Assert.Multiple";
+        internal const string Description = "Hosting Asserts inside an Assert.EnterMultipleScope or Assert.Multiple allows detecting more than one failure.";
     }
 }


### PR DESCRIPTION
Fixes #865

For now I've decided to keep both `Assert.EnterMultipleScope` and `Assert.Multiple` as `Assert.Multiple` is still widely used.