### PR TITLE
fix: NUnit4002 shouldn't suggest `Is.Default` when expected/actual types don't match

### DIFF
--- a/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/UseSpecificConstraint/UseSpecificConstraintCodeFixTests.cs
@@ -24,7 +24,7 @@ namespace NUnit.Analyzers.Tests.UseSpecificConstraint
 #endif
             ["true", "True"],
 
-            ["null", "Null"],
+            ["(object?)null", "Null"],
             ["default(object)", "Null"],
             ["default(string)", "Null"],
 #if NUNIT4
@@ -58,11 +58,13 @@ namespace NUnit.Analyzers.Tests.UseSpecificConstraint
 
         private static void AnalyzeForEqualTo(string prefix, string suffix, string literal, string constraint, Settings? settings = null)
         {
-            var testCode = TestUtility.WrapInTestMethod(
-                $"Assert.That(false, ↓{prefix}.EqualTo({literal}){suffix});");
+            var testCode = TestUtility.WrapInTestMethod($@"
+                var actual = {literal};
+                Assert.That(actual, ↓{prefix}.EqualTo({literal}){suffix});");
 
-            var fixedCode = TestUtility.WrapInTestMethod(
-                $"Assert.That(false, {prefix}.{constraint}{suffix});");
+            var fixedCode = TestUtility.WrapInTestMethod($@"
+                var actual = {literal};
+                Assert.That(actual, {prefix}.{constraint}{suffix});");
 
             RoslynAssert.CodeFix(analyzer, fix,
                 expectedDiagnostic.WithMessage($"Replace 'Is.EqualTo({literal})' with 'Is.{constraint}' constraint"),

--- a/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintAnalyzer.cs
+++ b/src/nunit.analyzers/UseSpecificConstraint/UseSpecificConstraintAnalyzer.cs
@@ -114,6 +114,9 @@ namespace NUnit.Analyzers.UseSpecificConstraint
                             if (actualType.SpecialType == SpecialType.System_Object)
                                 continue;
 
+                            if (!SymbolEqualityComparer.Default.Equals(actualType, defaultType))
+                                continue;
+
                             constraint = NUnitV4FrameworkConstants.NameOfIsDefault;
                         }
                         else if (defaultType.SpecialType == SpecialType.System_Boolean)


### PR DESCRIPTION
Fixes #879 