### PR TITLE
fix: Correct codefix for test method signature for Assert.EnterMultipleScope

### DIFF
--- a/src/nunit.analyzers.codefixes/UseAssertEnterMultipleScope/UseAssertEnterMultipleScopeCodeFix.cs
+++ b/src/nunit.analyzers.codefixes/UseAssertEnterMultipleScope/UseAssertEnterMultipleScopeCodeFix.cs
@@ -101,7 +101,7 @@ namespace NUnit.Analyzers.UseAssertEnterMultipleScope
         {
             var methodDeclaration = newSyntaxInTree.FirstAncestorOrSelf<MethodDeclarationSyntax>();
 
-            if (!lambdaHasAsyncKeyword || methodDeclaration is null || IsAsyncTaskMethod(methodDeclaration))
+            if (!lambdaHasAsyncKeyword || methodDeclaration is null || methodDeclaration.Modifiers.Any(SyntaxKind.AsyncKeyword))
             {
                 return newRoot;
             }
@@ -123,15 +123,6 @@ namespace NUnit.Analyzers.UseAssertEnterMultipleScope
 
         private static bool IsUsingSystemThreadingTasks(UsingDirectiveSyntax u) =>
             u.Name.ToString() == SystemThreadingTasksNamespace;
-
-        private static bool IsAsyncTaskMethod(MethodDeclarationSyntax methodDeclaration)
-        {
-            var isAsync = methodDeclaration.Modifiers.Any(SyntaxKind.AsyncKeyword);
-            var returnsTask = (methodDeclaration.ReturnType is IdentifierNameSyntax id && id.Identifier.Text == TaskTypeName)
-                || (methodDeclaration.ReturnType is QualifiedNameSyntax qn && qn.ToString() == $"{SystemThreadingTasksNamespace}.{TaskTypeName}");
-
-            return isAsync && returnsTask;
-        }
 
         private static TypeSyntax GetTaskTypeSyntax(bool systemThreadingTasksUsingExists)
             => systemThreadingTasksUsingExists

--- a/src/nunit.analyzers.tests/UseAssertEnterMultipleScope/UseAssertEnterMultipleScopeAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/UseAssertEnterMultipleScope/UseAssertEnterMultipleScopeAnalyzerTests.cs
@@ -64,6 +64,48 @@ namespace NUnit.Analyzers.Tests.UseAssertEnterMultipleScope
         }
 
         [Test]
+        public void AnalyzeWhenMultipleAsyncAndValueTaskIsUsed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+        public async ValueTask Test()
+        {
+            await ↓Assert.MultipleAsync(async () =>
+            {
+                Assert.That(await Get1(), Is.Not.Null);
+                Assert.That(await Get2(), Is.Not.Null);
+            });
+
+            static Task<string?> Get1() => Task.FromResult(default(string));
+            static Task<string?> Get2() => Task.FromResult(default(string));
+        }");
+            RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenMultipleAsyncAndGenericTaskIsUsed()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+    public class TestClass
+    {
+        [Test(ExpectedResult = 4)]
+        public async Task<int> Test()
+        {
+            await ↓Assert.MultipleAsync(async () =>
+            {
+                Assert.That(await Get1(), Is.Not.Null);
+                Assert.That(await Get2(), Is.Not.Null);
+            });
+
+            return 4;
+
+            static Task<string?> Get1() => Task.FromResult(default(string));
+            static Task<string?> Get2() => Task.FromResult(default(string));
+        }
+    }");
+            RoslynAssert.Diagnostics(this.analyzer, this.diagnostic, testCode);
+        }
+
+        [Test]
         public void AnalyzeWhenMultipleIsNot()
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"


### PR DESCRIPTION


Fixes #888