### PR TITLE
Issue/892 enter multiple scope and null

### DIFF
--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -1087,6 +1087,52 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 testCode);
         }
 
+        [Test]
+        public void VariableAssertedNotNullInsideUsingBlock()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                [Test]
+                public void VariableAssertedNotNullInsideUsingBlock()
+                {
+                    MemoryStream? stream = null;
+                    using (stream = GetStream())
+                    {
+                        Assert.That(stream, Is.Not.Null);
+                    }
+
+                    Assert.That(() => ↓stream.Length, Throws.Exception);
+
+                    static MemoryStream? GetStream() => null;
+                }
+            ", "using System.IO;");
+
+            RoslynAssert.Suppressed(suppressor,
+                ExpectedDiagnostic.Create(DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"]),
+                testCode);
+        }
+
+        [Test]
+        public void VariableAssertedNotNullInsideUsingStatement()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
+                [Test]
+                public void VariableAssertedNotNullInsideUsingStatement()
+                {
+                    MemoryStream? stream = null;
+                    using (stream = GetStream())
+                        Assert.That(stream, Is.Not.Null);
+
+                    Assert.That(() => ↓stream.Length, Throws.Exception);
+
+                    static MemoryStream? GetStream() => null;
+                }
+            ", "using System.IO;");
+
+            RoslynAssert.Suppressed(suppressor,
+                ExpectedDiagnostic.Create(DereferencePossiblyNullReferenceSuppressor.SuppressionDescriptors["CS8602"]),
+                testCode);
+        }
+
         public record struct AssertMultiple(string Start, string End);
     }
 }


### PR DESCRIPTION
Fixes #892 

Doubled all Assert.Multiple tests to also test Assert.EnterMultipleScope by converting them to parameterized tests.
One test failed because a using statement was not traversed.
Updated code to check the statements of the using.
Added new tests where null suppressing asserts where done inside the using statement.
