### PR TITLE
chore: Improve tests by inserting missing `↓` to have more precise assertions

### DIFF
--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterClassicModelAssertUsageCodeFixTests.cs
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
             var code = TestUtility.WrapInTestMethod(@"
-            ClassicAssert.Greater(2d, 3d,
+            ↓ClassicAssert.Greater(2d, 3d,
                 ""message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/GreaterOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
             var code = TestUtility.WrapInTestMethod(@"
-            ClassicAssert.GreaterOrEqual(2d, 3d,
+            ↓ClassicAssert.GreaterOrEqual(2d, 3d,
                 ""message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessClassicModelAssertUsageCodeFixTests.cs
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
             var code = TestUtility.WrapInTestMethod(@"
-            ClassicAssert.Less(2d, 3d,
+            ↓ClassicAssert.Less(2d, 3d,
                 ""message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ClassicModelAssertUsage/LessOrEqualClassicModelAssertUsageCodeFixTests.cs
@@ -108,7 +108,7 @@ namespace NUnit.Analyzers.Tests.ClassicModelAssertUsage
         public void CodeFixPreservesLineBreakBeforeMessage()
         {
             var code = TestUtility.WrapInTestMethod(@"
-            ClassicAssert.LessOrEqual(2d, 3d,
+            ↓ClassicAssert.LessOrEqual(2d, 3d,
                 ""message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"

--- a/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstActualValueUsage/ConstActualValueUsageAnalyzerTests.cs
@@ -136,7 +136,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     string actual = ""act"";
-                    ClassicAssert.AreEqual(actual, string.Empty);
+                    ClassicAssert.AreEqual(actual, ↓string.Empty);
                 }");
 
             RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
@@ -149,7 +149,7 @@ namespace NUnit.Analyzers.Tests.ConstActualValueUsage
                 public void Test()
                 {
                     string actual = ""act"";
-                    Assert.That(string.Empty, Is.EqualTo(actual));
+                    Assert.That(↓string.Empty, Is.EqualTo(actual));
                 }");
 
             RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageAnalyzerTests.cs
@@ -342,7 +342,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             Foo expected = new Foo();
             Foo actual = new Foo();
-            Assert.That(actual.Equals(expected), Is.True);
+            Assert.That(↓actual.Equals(expected), Is.True);
         }
 
         private sealed class Foo : IEquatable<Foo>
@@ -366,7 +366,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             object expected = new Foo();
             Foo actual = new Foo();
-            Assert.That(actual.Equals(expected), Is.True);
+            Assert.That(↓actual.Equals(expected), Is.True);
         }
 
         private sealed class Foo : IEquatable<Foo>

--- a/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
+++ b/src/nunit.analyzers.tests/ConstraintsUsage/EqualConstraintUsageCodeFixTests.cs
@@ -18,7 +18,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual == ""abc"");");
+            Assert.That(↓actual == ""abc"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -32,7 +32,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual != ""abc"");");
+            Assert.That(↓actual != ""abc"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -46,7 +46,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual is ""abc"");");
+            Assert.That(↓actual is ""abc"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -60,7 +60,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual is not ""abc"");");
+            Assert.That(↓actual is not ""abc"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -74,7 +74,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual is ""abc"" or ""def"");");
+            Assert.That(↓actual is ""abc"" or ""def"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -88,7 +88,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual is not ""abc"" and not ""def"");");
+            Assert.That(↓actual is not ""abc"" and not ""def"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -102,7 +102,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             double actual = 1.234;
-            Assert.That(actual is > 1 and <= 2 or 3 or > 4);");
+            Assert.That(↓actual is > 1 and <= 2 or 3 or > 4);");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             double actual = 1.234;
@@ -116,7 +116,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual.Equals(""abc""));");
+            Assert.That(↓actual.Equals(""abc""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -130,7 +130,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(!actual.Equals(""bcd""));");
+            Assert.That(↓!actual.Equals(""bcd""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -144,7 +144,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(Equals(actual,""abc""));");
+            Assert.That(↓Equals(actual,""abc""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -158,7 +158,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(!Equals(actual,""bcd""));");
+            Assert.That(↓!Equals(actual,""bcd""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -172,7 +172,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual.Equals(""abc""), Is.True);");
+            Assert.That(↓actual.Equals(""abc""), Is.True);");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -186,7 +186,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual.Equals(""bcd""), Is.False);");
+            Assert.That(↓actual.Equals(""bcd""), Is.False);");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -200,7 +200,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            ClassicAssert.True(actual.Equals(""abc""));");
+            ClassicAssert.True(↓actual.Equals(""abc""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -214,7 +214,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            ClassicAssert.False(actual.Equals(""bcd""));");
+            ClassicAssert.False(↓actual.Equals(""bcd""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -228,7 +228,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            ClassicAssert.IsTrue(actual.Equals(""abc""));");
+            ClassicAssert.IsTrue(↓actual.Equals(""abc""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -242,7 +242,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            ClassicAssert.IsFalse(actual.Equals(""bcd""));");
+            ClassicAssert.IsFalse(↓actual.Equals(""bcd""));");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -256,7 +256,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual == ""abc"", ""Assertion message"");");
+            Assert.That(↓actual == ""abc"", ""Assertion message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -270,7 +270,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            Assert.That(actual.Equals(""abc""), Is.True, ""Assertion message"");");
+            Assert.That(↓actual.Equals(""abc""), Is.True, ""Assertion message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -284,7 +284,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            ClassicAssert.True(actual.Equals(""abc""), ""Assertion message"");");
+            ClassicAssert.True(↓actual.Equals(""abc""), ""Assertion message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -298,7 +298,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
         {
             var code = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
-            ClassicAssert.False(actual.Equals(""bcd""), ""Assertion message"");");
+            ClassicAssert.False(↓actual.Equals(""bcd""), ""Assertion message"");");
 
             var fixedCode = TestUtility.WrapInTestMethod(@"
             var actual = ""abc"";
@@ -316,7 +316,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var code = TestUtility.WrapInTestMethod($@"
             var actual = ""abc"";
             ClassicAssert.False(
-                actual.Equals(""bcd""){commaAndMessage});");
+                ↓actual.Equals(""bcd""){commaAndMessage});");
 
             var fixedCode = TestUtility.WrapInTestMethod($@"
             var actual = ""abc"";
@@ -336,7 +336,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var code = TestUtility.WrapInTestMethod($@"
             var actual = ""abc"";
             Assert.That(
-                actual.Equals(""abc""),
+                ↓actual.Equals(""abc""),
                 Is.True{commaAndMessage}
             );");
 
@@ -357,7 +357,7 @@ namespace NUnit.Analyzers.Tests.ConstraintsUsage
             var code = TestUtility.WrapInTestMethod($@"
             var actual = ""abc"";
             Assert.That(
-                actual.Equals(""abc""), Is.True{optionalNewline});");
+                ↓actual.Equals(""abc""), Is.True{optionalNewline});");
 
             var fixedCode = TestUtility.WrapInTestMethod($@"
             var actual = ""abc"";

--- a/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
+++ b/src/nunit.analyzers.tests/DiagnosticSuppressors/DereferencePossiblyNullReferenceSuppressorTests.cs
@@ -757,19 +757,19 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 testCode);
         }
 
-        [TestCase("string fatal = line2 ?? line1;")]
-        [TestCase("string fatal = line2 is not null ? line2 : line1;")]
-        [TestCase("string fatal = line2 is null ? line1 : line2;")]
-        [TestCase("string fatal = line2 != null ? line2 : line1;")]
-        [TestCase("string fatal = line2 == null ? line1 : line2;")]
-        [TestCase("string fatal; if (line2 is not null) fatal = line2; else fatal = line1;")]
-        [TestCase("string fatal; if (line2 is not null) { fatal = line2; } else { fatal = line1; }")]
-        [TestCase("string fatal; if (line2 != null) fatal = line2; else fatal = line1;")]
-        [TestCase("string fatal; if (null != line2) { fatal = line2; } else { fatal = line1; }")]
-        [TestCase("string fatal; if (line2 is null) fatal = line1; else fatal = line2;")]
-        [TestCase("string fatal; if (line2 is null) { fatal = line1; } else { fatal = line2; }")]
-        [TestCase("string fatal; if (null == line2) fatal = line1; else fatal = line2;")]
-        [TestCase("string fatal; if (line2 == null) { fatal = line1; } else { fatal = line2; }")]
+        [TestCase("string fatal = ↓line2 ?? line1;")]
+        [TestCase("string fatal = ↓line2 is not null ? line2 : line1;")]
+        [TestCase("string fatal = ↓line2 is null ? line1 : line2;")]
+        [TestCase("string fatal = ↓line2 != null ? line2 : line1;")]
+        [TestCase("string fatal = ↓line2 == null ? line1 : line2;")]
+        [TestCase("string fatal; if (line2 is not null) fatal = line2; else fatal = ↓line1;")]
+        [TestCase("string fatal; if (line2 is not null) { fatal = line2; } else { fatal = ↓line1; }")]
+        [TestCase("string fatal; if (line2 != null) fatal = line2; else fatal = ↓line1;")]
+        [TestCase("string fatal; if (null != line2) { fatal = line2; } else { fatal = ↓line1; }")]
+        [TestCase("string fatal; if (line2 is null) fatal = ↓line1; else fatal = line2;")]
+        [TestCase("string fatal; if (line2 is null) { fatal = ↓line1; } else { fatal = line2; }")]
+        [TestCase("string fatal; if (null == line2) fatal = ↓line1; else fatal = line2;")]
+        [TestCase("string fatal; if (line2 == null) { fatal = ↓line1; } else { fatal = line2; }")]
         public void TestIssue503SimpleIdentifier(string expression)
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
@@ -790,13 +790,13 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 testCode);
         }
 
-        [TestCase("string fatal = lines.Line2 ?? lines.Line1;")]
-        [TestCase("string fatal = lines.Line2 is not null ? lines.Line2 : lines.Line1;")]
-        [TestCase("string fatal = lines.Line2 is null ? lines.Line1 : lines.Line2;")]
-        [TestCase("string fatal = lines.Line2 != null ? lines.Line2 : lines.Line1;")]
-        [TestCase("string fatal = lines.Line2 == null ? lines.Line1 : lines.Line2;")]
-        [TestCase("string fatal = null != lines.Line2 ? lines.Line2 : lines.Line1;")]
-        [TestCase("string fatal = null == lines.Line2 ? lines.Line1 : lines.Line2;")]
+        [TestCase("string fatal = ↓lines.Line2 ?? lines.Line1;")]
+        [TestCase("string fatal = ↓lines.Line2 is not null ? lines.Line2 : lines.Line1;")]
+        [TestCase("string fatal = ↓lines.Line2 is null ? lines.Line1 : lines.Line2;")]
+        [TestCase("string fatal = ↓lines.Line2 != null ? lines.Line2 : lines.Line1;")]
+        [TestCase("string fatal = ↓lines.Line2 == null ? lines.Line1 : lines.Line2;")]
+        [TestCase("string fatal = ↓null != lines.Line2 ? lines.Line2 : lines.Line1;")]
+        [TestCase("string fatal = ↓null == lines.Line2 ? lines.Line1 : lines.Line2;")]
         public void TestIssue503Properties(string expression)
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
@@ -1046,7 +1046,7 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 private static string GetStringSuppress(HasString? str) // argument is nullable
                 {
                     Assert.That(str!.Inner, Is.Not.Null);
-                    return str.Inner; // warning: possible null reference return
+                    return ↓str.Inner; // warning: possible null reference return
                 }
 
                 private sealed class HasString
@@ -1074,7 +1074,7 @@ namespace NUnit.Analyzers.Tests.DiagnosticSuppressors
                 {
                     object? x = null;
                     NUnit.Framework.Assert.That(x, Is.Not.Null);
-                    M(x);
+                    M(↓x);
                 }
 
                 void M(object o)

--- a/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/SomeItemsIncompatibleTypes/SomeItemsIncompatibleTypesAnalyzerTests.cs
@@ -144,7 +144,7 @@ namespace NUnit.Analyzers.Tests.SomeItemsIncompatibleTypes
         {
             var testCode = TestUtility.WrapInTestMethod($@"
                 var actual = new[] {{ ""1"", ""2"", ""3"" }};
-                Assert.That(actual, {this.constraint}(1).Using((IEqualityComparer<string>)StringComparer.Ordinal));",
+                Assert.That(actual, ↓{this.constraint}(1).Using((IEqualityComparer<string>)StringComparer.Ordinal));",
                 "using System.Collections.Generic;");
 
             RoslynAssert.Diagnostics(analyzer,

--- a/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceSourceTypeTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceSourceTypeTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public class AnalyzeWhenTypeOfSourceNotImplementingIEnumerable
     {
-        [TestCaseSource(typeof(MyTests))]
+        [TestCaseSource(↓typeof(MyTests))]
         public void Test()
         {
         }
@@ -91,7 +91,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
         public class AnalyzeWhenTypeOfSourceNoDefaultConstructor
         {
-            [TestCaseSource(typeof(MyTests))]
+            [TestCaseSource(↓typeof(MyTests))]
             public void Test()
             {
             }

--- a/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseSourceUsage/TestCaseSourceUsesStringAnalyzerTests.cs
@@ -314,7 +314,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
         {testCaseMember}
 #pragma warning restore CS0414
 
-        [TestCaseSource(nameof(TestCases))]
+        [TestCaseSource(↓nameof(TestCases))]
         public void Test()
         {{
         }}
@@ -335,7 +335,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
     {{
         {testCaseMember}
 
-        [TestCaseSource(nameof(TestCases), new object[] {{ 1, 2, 3 }})]
+        [TestCaseSource(↓nameof(TestCases), new object[] {{ 1, 2, 3 }})]
         public void Test()
         {{
         }}
@@ -458,7 +458,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
     public class FixWhenStringLiteralTargetsSourceInAnInnerClass
     {{
-        [TestCaseSource(typeof(InnerClass), ""TestCases"")]
+        [TestCaseSource(typeof(InnerClass), ↓""TestCases"")]
         public void TestData(string input) {{ }}
 
         public class InnerClass
@@ -489,7 +489,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
     public class FixWhenStringLiteralTargetsSourceInAnotherClass
     {{
-        [TestCaseSource(typeof(AnotherClass), ""TestCases"")]
+        [TestCaseSource(typeof(AnotherClass), ↓""TestCases"")]
         public void TestData(string input) {{ }}
     }}
 
@@ -520,7 +520,7 @@ namespace NUnit.Analyzers.Tests.TestCaseSourceUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing($@"
     public class FixWhenStringLiteralTargetsSourceInAnInnerClassInAnotherClass
     {{
-        [TestCaseSource(typeof(AnotherClass.InnerClass), ""TestCases"")]
+        [TestCaseSource(typeof(AnotherClass.InnerClass), ↓""TestCases"")]
         public void TestData(string input) {{ }}
     }}
 

--- a/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestCaseUsage/TestCaseUsageAnalyzerTests.cs
@@ -492,7 +492,7 @@ namespace NUnit.Analyzers.Tests.TestCaseUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenArgumentPassesSuppressedNullToNonNullableType
     {
-        [TestCase(""Hello"", null)]
+        [TestCase(""Hello"", ↓null)]
         public void Test(params string[] a) { }
     }");
             RoslynAssert.Diagnostics(this.analyzer,

--- a/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/TestMethodUsage/TestMethodUsageAnalyzerTests.cs
@@ -344,7 +344,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
             var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
     public sealed class AnalyzeWhenTestMethodHasCustomAwaitableReturnTypeAndExpectedResultIsIncorrect
     {
-        [TestCase(ExpectedResult = '1')]
+        [TestCase(↓ExpectedResult = '1')]
         public CustomAwaitable GenericTaskTestCaseWithExpectedResult()
         {
             return new CustomAwaitable();
@@ -386,7 +386,7 @@ namespace NUnit.Analyzers.Tests.TestMethodUsage
                     TestMethodUsageAnalyzerConstants.ExpectedResultTypeMismatchMessage, typeof(int).Name));
 
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings(@"
-                [TestCase(ExpectedResult = '1')]
+                [TestCase(↓ExpectedResult = '1')]
                 public async ValueTask<int> GenericTaskTestCaseWithExpectedResult()
                 {
                     await Task.CompletedTask;

--- a/src/nunit.analyzers.tests/ValueSourceUsage/ValueSourceUsageAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/ValueSourceUsage/ValueSourceUsageAnalyzerTests.cs
@@ -243,7 +243,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
 #pragma warning restore CS0414
 
         [Test]
-        public void Test([ValueSource(nameof(TestCases))] int number)
+        public void Test([ValueSource(↓nameof(TestCases))] int number)
         {{
         }}
     }}");
@@ -325,7 +325,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     public class FixWhenStringLiteralTargetsSourceInAnInnerClass
     {{
         [Test]
-        public void TestData([ValueSource(typeof(InnerClass), ""TestCases"")] string input) {{ }}
+        public void TestData([ValueSource(typeof(InnerClass), ↓""TestCases"")] string input) {{ }}
 
         public class InnerClass
         {{
@@ -356,7 +356,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     public class FixWhenStringLiteralTargetsSourceInAnotherClass
     {{
         [Test]
-        public void TestData([ValueSource(typeof(AnotherClass), ""TestCases"")] string input) {{ }}
+        public void TestData([ValueSource(typeof(AnotherClass), ↓""TestCases"")] string input) {{ }}
     }}
 
     public class AnotherClass
@@ -387,7 +387,7 @@ namespace NUnit.Analyzers.Tests.ValueSourceUsage
     public class FixWhenStringLiteralTargetsSourceInAnInnerClassInAnotherClass
     {{
         [Test]
-        public void TestData([ValueSource(typeof(AnotherClass.InnerClass), ""TestCases"")] string input) {{ }}
+        public void TestData([ValueSource(typeof(AnotherClass.InnerClass), ↓""TestCases"")] string input) {{ }}
     }}
 
     public class AnotherClass


### PR DESCRIPTION
Fixes #894