### PR TITLE
NUnit4.4 alpha -> beta changes

### DIFF
--- a/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/EqualToIncompatibleTypes/EqualToIncompatibleTypesAnalyzerTests.cs
@@ -1063,7 +1063,7 @@ using System.Collections.Generic;");
                     var record1 = new Record("Test");
                     var record2 = new AnotherRecord("Test");
 
-                    Assert.That(record1, Is.EqualTo(record2).UsingPropertiesComparer(
+                    Assert.That(record1, Is.EqualTo(record2).UsingPropertiesComparer<AnotherRecord>(
                         {{configure}}));
                 }
 

--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NUnitVersion)' == '4'">
-    <PackageReference Include="NUnit" Version="4.4.0-alpha.0.22" />
+    <PackageReference Include="NUnit" Version="4.4.0-beta.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NUnitVersion)' == '3'">


### PR DESCRIPTION
Related to #883, #885

To ensure binary compatibility, NUnit 4.4 changed the return of `Is.EqualTo` from a generic  back to a non-generic one.
