### PR TITLE
chore: Bump NUnit dependencies

### DIFF
--- a/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
+++ b/src/nunit.analyzers.tests/nunit.analyzers.tests.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Gu.Roslyn.Asserts" Version="4.3.0" />
     <PackageReference Include="Gu.Roslyn.Asserts.Analyzers" Version="4.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NUnitVersion)' == '4'">
-    <PackageReference Include="NUnit" Version="4.4.0-beta.2.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NUnitVersion)' == '3'">


### PR DESCRIPTION
Fixes #885

`NUnit` to version 4.4.0 and `NUnit3TestAdapter` to version 5.1.0.